### PR TITLE
Open metrics port for globalnet by default

### DIFF
--- a/cmd/subctl/cloud.go
+++ b/cmd/subctl/cloud.go
@@ -58,12 +58,14 @@ func init() {
 	restConfigProducer.AddKubeContextFlag(cloudCmd)
 	rootCmd.AddCommand(cloudCmd)
 
+	cloudPorts.Metrics = append(cloudPorts.Metrics, 8080, 8081)
+
 	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Natt, "natt-port", port.ExternalTunnel,
 		"IPSec NAT traversal port")
 	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.NatDiscovery, "nat-discovery-port",
 		port.NATTDiscovery, "NAT discovery port")
 	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Vxlan, "vxlan-port", port.IntraClusterVxLAN, "Internal VXLAN port")
-	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Metrics, "metrics-port", 8080, "Metrics port")
+	cloudPrepareCmd.PersistentFlags().Var(&cloudPorts.Metrics, "metrics-port", "Metrics port")
 
 	cloudCmd.AddCommand(cloudPrepareCmd)
 

--- a/cmd/subctl/uint16slice.go
+++ b/cmd/subctl/uint16slice.go
@@ -16,11 +16,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cloud
+package subctl
 
-type Ports struct {
-	Natt         uint16
-	NatDiscovery uint16
-	Vxlan        uint16
-	Metrics      []uint16
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type uint16Slice struct {
+	value *[]uint16
+}
+
+func (s *uint16Slice) Type() string {
+	return "uint16Slice"
+}
+
+func (s *uint16Slice) String() string {
+	return fmt.Sprintf("%v", *s.value)
+}
+
+func (s *uint16Slice) Set(value string) error {
+	values := strings.Split(value, ",")
+
+	*s.value = make([]uint16, len(values))
+
+	for i, d := range values {
+		u, err := strconv.ParseUint(d, 10, 16)
+		if err != nil {
+			return errors.Wrap(err, "conversion to uint16 failed")
+		}
+
+		(*s.value)[i] = uint16(u)
+	}
+
+	return nil
 }

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -18,9 +18,54 @@ limitations under the License.
 
 package cloud
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type uintslice []uint16
+
+func (i *uintslice) Type() string {
+	return "uintslice"
+}
+
+func (i *uintslice) String() string {
+	return fmt.Sprintf("%d", *i)
+}
+
+func (i *uintslice) Set(value string) error {
+	values := strings.Split(value, ",")
+
+	for _, val := range values {
+		tmp, err := strconv.ParseUint(val, 0, 16)
+		if err != nil {
+			return errors.Wrap(err, "Conversion to uint failed")
+		}
+
+		if !i.Contains(uint16(tmp)) {
+			*i = append(*i, uint16(tmp))
+		}
+	}
+
+	return nil
+}
+
+func (i *uintslice) Contains(value uint16) bool {
+	for _, port := range *i {
+		if value == port {
+			return true
+		}
+	}
+
+	return false
+}
+
 type Ports struct {
 	Natt         uint16
 	NatDiscovery uint16
 	Vxlan        uint16
-	Metrics      uint16
+	Metrics      uintslice
 }

--- a/pkg/cloud/prepare/aws.go
+++ b/pkg/cloud/prepare/aws.go
@@ -40,8 +40,14 @@ func AWS(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *aw
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: ports.Vxlan, Protocol: "udp"},
-			{Port: ports.Metrics, Protocol: "tcp"},
 		},
+	}
+
+	for i := range ports.Metrics {
+		port := api.PortSpec{
+			Port: ports.Metrics[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// For load-balanced gateways we want these ports open internally to facilitate private-ip to pivate-ip gateways communications.

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -42,8 +42,14 @@ func Azure(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: ports.Vxlan, Protocol: "udp"},
-			{Port: ports.Metrics, Protocol: "tcp"},
 		},
+	}
+
+	for i := range ports.Metrics {
+		port := api.PortSpec{
+			Port: ports.Metrics[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.

--- a/pkg/cloud/prepare/gcp.go
+++ b/pkg/cloud/prepare/gcp.go
@@ -39,8 +39,14 @@ func GCP(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *gc
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: ports.Vxlan, Protocol: "udp"},
-			{Port: ports.Metrics, Protocol: "tcp"},
 		},
+	}
+
+	for i := range ports.Metrics {
+		port := api.PortSpec{
+			Port: ports.Metrics[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.

--- a/pkg/cloud/prepare/rhos.go
+++ b/pkg/cloud/prepare/rhos.go
@@ -39,8 +39,14 @@ func RHOS(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *r
 	input := api.PrepareForSubmarinerInput{
 		InternalPorts: []api.PortSpec{
 			{Port: ports.Vxlan, Protocol: "udp"},
-			{Port: ports.Metrics, Protocol: "tcp"},
 		},
+	}
+
+	for i := range ports.Metrics {
+		port := api.PortSpec{
+			Port: ports.Metrics[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.


### PR DESCRIPTION
1) allow metrics-port flag for cloud prepare cmd to accept
multiple values
2) make globalnet metrics port to be default as well

Fixes: #73

Signed-off-by: Maayan Friedman <maafried@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
