### PR TITLE
diagnose firewall inter-cluster: add support for LB mode

### DIFF
--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -45,6 +45,9 @@ const (
 
 const (
 	clientSourcePort = "9898"
+	loadBalancerName = "submariner-gateway"
+	encapsPortName   = "cable-encaps"
+	nattPortName     = "natt-discovery"
 )
 
 const (
@@ -68,6 +71,7 @@ func spawnClientPodOnNonGatewayNode(client kubernetes.Interface, namespace, podC
 	imageRepInfo *image.RepositoryInfo,
 ) (*pods.Scheduled, error) {
 	scheduling := pods.Scheduling{ScheduleOn: pods.NonGatewayNode, Networking: pods.PodNetworking}
+
 	return spawnPod(client, scheduling, "validate-client", namespace, podCommand, imageRepInfo)
 }
 
@@ -220,9 +224,21 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, optio
 		return status.Error(err, "Could not determine the target port")
 	}
 
+	portFilter := fmt.Sprintf("dst port %d", destPort)
+
+	lbNodePort, err := getLbNodePort(localClusterInfo, localEndpoint, targetPort)
+	if err != nil {
+		return status.Error(err, "Could not determine LB node port")
+	}
+
+	// When SM deployed using LB the encapsulated and nat discovery traffic received in some platforms on LB nodeport
+	if lbNodePort != 0 {
+		portFilter += fmt.Sprintf(" or dst port %d ", lbNodePort)
+	}
+
 	clientMessage := string(uuid.NewUUID())[0:8]
-	podCommand := fmt.Sprintf("timeout %d tcpdump -ln -Q in -A -s 100 -i any udp and dst port %d | grep '%s'",
-		options.ValidationTimeout, destPort, clientMessage)
+	podCommand := fmt.Sprintf("timeout %d tcpdump -ln -Q in -A -s 100 -i any udp and %s | grep '%s'",
+		options.ValidationTimeout, portFilter, clientMessage)
 
 	sPod, err := spawnSnifferPodOnNode(localClusterInfo.ClientProducer.ForKubernetes(), gwNodeName, options.PodNamespace, podCommand,
 		localClusterInfo.GetImageRepositoryInfo())
@@ -294,4 +310,30 @@ func getTargetPort(submariner *v1alpha1.Submariner, endpoint *subv1.Endpoint, tg
 	default:
 		return 0, fmt.Errorf("could not determine the target port for cable driver %q", endpoint.Spec.Backend)
 	}
+}
+
+func getLbNodePort(clusterInfo *cluster.Info, endpoint *subv1.Endpoint, tgtport TargetPort) (int32, error) {
+	usingLoadBalancer, _ := endpoint.Spec.GetBackendBool(subv1.UsingLoadBalancer, nil)
+	if usingLoadBalancer == nil || !*usingLoadBalancer {
+		return 0, nil
+	}
+
+	portName := encapsPortName
+	if tgtport == NatDiscoveryPort {
+		portName = nattPortName
+	}
+
+	svc, err := clusterInfo.ClientProducer.ForKubernetes().CoreV1().Services(endpoint.GetNamespace()).Get(
+		context.TODO(), loadBalancerName, metav1.GetOptions{})
+	if err == nil {
+		for _, port := range svc.Spec.Ports {
+			if port.Name == portName {
+				return port.NodePort, nil
+			}
+		}
+	} else {
+		return 0, fmt.Errorf("error reading the details of LB service %s: %w", loadBalancerName, err)
+	}
+
+	return 0, fmt.Errorf("could not determine nodePort for port name %q of LB service %s", portName, loadBalancerName)
 }


### PR DESCRIPTION
When I checked the firewall inter-cluster with LB mode I noticed that
both encapsulated and nat discovery traffic received in some platforms
on LB nodeport.

This PR updates the server tcpdump pod to listen also on nodeport in case
SM is deployed in LB mode.

Fixes: https://github.com/submariner-io/submariner/issues/1849

Signed-off-by: yboaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
