### PR TITLE
Support nat-discovery port validation in subctl diagnose

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -16,7 +16,6 @@ package subctl
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -126,27 +125,25 @@ var (
 		Use:   "inter-cluster <localkubeconfig> <remotekubeconfig>",
 		Short: "Check firewall access to setup tunnels between the Gateway node",
 		Long:  "This command checks if the firewall configuration allows tunnels to be configured on the Gateway nodes.",
-		Args: func(command *cobra.Command, args []string) error {
-			if len(args) != 2 {
-				return fmt.Errorf("two kubeconfigs must be specified")
-			}
-
-			same, err := compareFiles(args[0], args[1])
-			if err != nil {
-				return err
-			}
-
-			if same {
-				return fmt.Errorf("the specified kubeconfig files are the same")
-			}
-
-			return nil
-		},
+		Args:  checkKubeconfigArgs,
 		Run: func(command *cobra.Command, args []string) {
-			if !diagnose.TunnelConfigAcrossClusters(clusterInfoFromKubeConfig(args[0]), clusterInfoFromKubeConfig(args[1]),
-				diagnoseFirewallOptions, cli.NewReporter()) {
-				os.Exit(1)
-			}
+			err := diagnose.TunnelConfigAcrossClusters(
+				clusterInfoFromKubeConfig(args[0]), clusterInfoFromKubeConfig(args[1]),
+				diagnoseFirewallOptions, cli.NewReporter())
+			exit.OnError(err)
+		},
+	}
+
+	diagnoseFirewallNatDiscovery = &cobra.Command{
+		Use:   "nat-discovery <localkubeconfig> <remotekubeconfig>",
+		Short: "Check firewall access for nat-discovery to function properly",
+		Long:  "This command checks if the firewall configuration allows nat-discovery between the configured Gateway nodes.",
+		Args:  checkKubeconfigArgs,
+		Run: func(command *cobra.Command, args []string) {
+			err := diagnose.NatDiscoveryConfigAcrossClusters(
+				clusterInfoFromKubeConfig(args[0]), clusterInfoFromKubeConfig(args[1]),
+				diagnoseFirewallOptions, cli.NewReporter())
+			exit.OnError(err)
 		},
 	}
 
@@ -185,10 +182,12 @@ func addDiagnoseFirewallSubCommands() {
 	addDiagnoseFWConfigFlags(diagnoseFirewallMetricsCmd)
 	addDiagnoseFWConfigFlags(diagnoseFirewallVxLANCmd)
 	addDiagnoseFWConfigFlags(diagnoseFirewallTunnelCmd)
+	addDiagnoseFWConfigFlags(diagnoseFirewallNatDiscovery)
 
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallMetricsCmd)
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallVxLANCmd)
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallTunnelCmd)
+	diagnoseFirewallCmd.AddCommand(diagnoseFirewallNatDiscovery)
 }
 
 func addDiagnosePodNamespaceFlag(command *cobra.Command, value *string) {
@@ -200,6 +199,23 @@ func addDiagnoseFWConfigFlags(command *cobra.Command) {
 		"timeout in seconds while validating the connection attempt")
 	command.Flags().BoolVar(&diagnoseFirewallOptions.VerboseOutput, "verbose", false, "produce verbose output")
 	addDiagnosePodNamespaceFlag(command, &diagnoseFirewallOptions.PodNamespace)
+}
+
+func checkKubeconfigArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("two kubeconfigs must be specified")
+	}
+
+	same, err := compareFiles(args[0], args[1])
+	if err != nil {
+		return err
+	}
+
+	if same {
+		return fmt.Errorf("the specified kubeconfig files are the same")
+	}
+
+	return nil
 }
 
 func clusterInfoFromKubeConfig(kubeConfig string) *cluster.Info {

--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -20,13 +20,30 @@ package diagnose
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/pods"
 	"github.com/submariner-io/subctl/pkg/cluster"
+	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
+	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
+)
+
+type TargetPort int
+
+const (
+	TunnelPort TargetPort = iota
+	NatDiscoveryPort
+)
+
+const (
+	clientSourcePort = "9898"
 )
 
 const (
@@ -75,19 +92,18 @@ func spawnSnifferPodOnNode(client kubernetes.Interface, nodeName, namespace, pod
 	return spawnPod(client, scheduling, "validate-sniffer", namespace, podCommand)
 }
 
-func getActiveGatewayNodeName(clusterInfo *cluster.Info, hostname string, status reporter.Interface) string {
+func getActiveGatewayNodeName(clusterInfo *cluster.Info, hostname string, status reporter.Interface) (string, error) {
 	nodes, err := clusterInfo.ClientProducer.ForKubernetes().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "submariner.io/gateway=true",
 	})
 	if err != nil {
-		status.Failure("Error obtaining the Gateway Nodes in cluster %q: %v", clusterInfo.Name, err)
-		return ""
+		return "", status.Error(err, "Error obtaining the Gateway Nodes in cluster %q", clusterInfo.Name)
 	}
 
 	for i := range nodes.Items {
 		node := &nodes.Items[i]
 		if node.Name == hostname {
-			return hostname
+			return hostname, nil
 		}
 
 		// On some platforms, the nodeName does not match with the hostname.
@@ -95,8 +111,7 @@ func getActiveGatewayNodeName(clusterInfo *cluster.Info, hostname string, status
 		// tiny pod to read the hostname and return the corresponding node.
 		sPod, err := spawnSnifferPodOnNode(clusterInfo.ClientProducer.ForKubernetes(), node.Name, "default", "hostname")
 		if err != nil {
-			status.Failure("Error spawning the sniffer pod on the node %q: %v", node.Name, err)
-			return ""
+			return "", status.Error(err, "Error spawning the sniffer pod on the node %q: %v", node.Name)
 		}
 
 		err = sPod.AwaitCompletion()
@@ -104,17 +119,159 @@ func getActiveGatewayNodeName(clusterInfo *cluster.Info, hostname string, status
 		sPod.Delete()
 
 		if err != nil {
-			status.Failure("Error waiting for the sniffer pod to finish its execution on node %q: %v", node.Name, err)
-			return ""
+			return "", status.Error(err, "Error waiting for the sniffer pod to finish its execution on node %q: %v", node.Name)
 		}
 
 		if sPod.PodOutput[:len(sPod.PodOutput)-1] == hostname {
-			return node.Name
+			return node.Name, nil
 		}
 	}
 
-	status.Failure("Could not find the active Gateway node %q in local cluster in cluster %q",
-		hostname, clusterInfo.Name)
+	return "", status.Error(fmt.Errorf("could not find the active Gateway node %q in local cluster %q",
+		hostname, clusterInfo.Name), "Error")
+}
 
-	return ""
+func getGatewayIP(clusterInfo *cluster.Info, localClusterID string, status reporter.Interface) (string, error) {
+	gateways, err := clusterInfo.GetGateways()
+	if err != nil {
+		return "", status.Error(err, "Error retrieving gateways from cluster %q", clusterInfo.Name)
+	}
+
+	if len(gateways) == 0 {
+		return "", status.Error(fmt.Errorf("there are no gateways detected on cluster %q", clusterInfo.Name), "Error")
+	}
+
+	for i := range gateways {
+		gw := &gateways[i]
+		if gw.Status.HAStatus != subv1.HAStatusActive {
+			continue
+		}
+
+		for j := range gw.Status.Connections {
+			conn := &gw.Status.Connections[j]
+			if conn.Endpoint.ClusterID == localClusterID {
+				if conn.UsingIP != "" {
+					return conn.UsingIP, nil
+				}
+
+				if conn.Endpoint.NATEnabled {
+					return conn.Endpoint.PublicIP, nil
+				}
+
+				return conn.Endpoint.PrivateIP, nil
+			}
+		}
+	}
+
+	return "", status.Error(fmt.Errorf("the gateway on cluster %q does not have an active connection to cluster %q",
+		clusterInfo.Name, localClusterID), "Error")
+}
+
+func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, options FirewallOptions,
+	status reporter.Interface, targetPort TargetPort, message string,
+) error {
+	mustHaveSubmariner(localClusterInfo)
+	mustHaveSubmariner(remoteClusterInfo)
+
+	status.Start(message)
+	defer status.End()
+
+	singleNode, err := remoteClusterInfo.HasSingleNode()
+	if err != nil {
+		return status.Error(err, "")
+	}
+
+	if singleNode {
+		status.Success(singleNodeMessage)
+		return nil
+	}
+
+	localEndpoint, err := localClusterInfo.GetLocalEndpoint()
+	if err != nil {
+		return status.Error(err, "Unable to obtain the local endpoint")
+	}
+
+	gwNodeName, err := getActiveGatewayNodeName(localClusterInfo, localEndpoint.Spec.Hostname, status)
+	if err != nil {
+		return err
+	}
+
+	destPort, err := getTargetPort(localClusterInfo.Submariner, localEndpoint, targetPort)
+	if err != nil {
+		return status.Error(err, "Could not determine the target port")
+	}
+
+	clientMessage := string(uuid.NewUUID())[0:8]
+	podCommand := fmt.Sprintf("timeout %d tcpdump -ln -Q in -A -s 100 -i any udp and dst port %d | grep '%s'",
+		options.ValidationTimeout, destPort, clientMessage)
+
+	sPod, err := spawnSnifferPodOnNode(localClusterInfo.ClientProducer.ForKubernetes(), gwNodeName, options.PodNamespace, podCommand)
+	if err != nil {
+		return status.Error(err, "Error spawning the sniffer pod on the Gateway node %q", gwNodeName)
+	}
+
+	defer sPod.Delete()
+
+	gatewayPodIP, err := getGatewayIP(remoteClusterInfo, localClusterInfo.Name, status)
+	if err != nil {
+		return status.Error(err, "Error retrieving the gateway IP of cluster %q", localClusterInfo.Name)
+	}
+
+	podCommand = fmt.Sprintf("for x in $(seq 1000); do echo %s; done | for i in $(seq 5);"+
+		" do timeout 2 nc -n -p %s -u %s %d; done", clientMessage, clientSourcePort, gatewayPodIP, destPort)
+
+	// Spawn the pod on the nonGateway node. If we spawn the pod on Gateway node, the tunnel process can
+	// sometimes drop the udp traffic from client pod until the tunnels are properly setup.
+	cPod, err := spawnClientPodOnNonGatewayNode(remoteClusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand)
+	if err != nil {
+		return status.Error(err, "Error spawning the client pod on non-Gateway node of cluster %q", remoteClusterInfo.Name)
+	}
+
+	defer cPod.Delete()
+
+	if err = cPod.AwaitCompletion(); err != nil {
+		return status.Error(err, "Error waiting for the client pod to finish its execution")
+	}
+
+	if err = sPod.AwaitCompletion(); err != nil {
+		return status.Error(err, "Error waiting for the sniffer pod to finish its execution")
+	}
+
+	if options.VerboseOutput {
+		status.Success("tcpdump output from sniffer pod on Gateway node")
+		status.Success(sPod.PodOutput)
+	}
+
+	if !strings.Contains(sPod.PodOutput, clientMessage) {
+		return status.Error(fmt.Errorf("the tcpdump output from the sniffer pod does not include the message"+
+			" sent from client pod. Please check that your firewall configuration allows UDP/%d traffic"+
+			" on the %q node", destPort, localEndpoint.Spec.Hostname), "Error")
+	}
+
+	return nil
+}
+
+func getTargetPort(submariner *v1alpha1.Submariner, endpoint *subv1.Endpoint, port TargetPort) (int32, error) {
+	var targetPort int32
+	var err error
+
+	switch endpoint.Spec.Backend {
+	case "libreswan", "wireguard", "vxlan":
+		if port == TunnelPort {
+			targetPort, err = endpoint.Spec.GetBackendPort(subv1.UDPPortConfig, int32(submariner.Spec.CeIPSecNATTPort))
+			if err != nil {
+				return 0, fmt.Errorf("error reading tunnel port: %w", err)
+			}
+		} else if port == NatDiscoveryPort {
+			intValue, _ := strconv.ParseInt(subv1.DefaultNATTDiscoveryPort, 0, 32)
+			targetPort, err = endpoint.Spec.GetBackendPort(subv1.NATTDiscoveryPortConfig, int32(intValue))
+			if err != nil {
+				return 0, fmt.Errorf("error reading nat-discovery port: %w", err)
+			}
+		}
+
+		return targetPort, nil
+	default:
+		return 0, fmt.Errorf("could not determine the target port for cable driver %q", endpoint.Spec.Backend)
+	}
 }

--- a/pkg/diagnose/firewall_natdiscovery.go
+++ b/pkg/diagnose/firewall_natdiscovery.go
@@ -25,16 +25,16 @@ import (
 	"github.com/submariner-io/subctl/pkg/cluster"
 )
 
-func TunnelConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, options FirewallOptions,
+func NatDiscoveryConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, options FirewallOptions,
 	status reporter.Interface,
 ) error {
-	message := fmt.Sprintf("Checking if tunnels can be setup on the gateway node of cluster %q", localClusterInfo.Name)
+	message := fmt.Sprintf("Checking if nat-discovery port is opened on the gateway node of cluster %q", localClusterInfo.Name)
 
-	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, options, status, TunnelPort, message)
+	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, options, status, NatDiscoveryPort, message)
 	if err != nil {
-		status.Failure("Could not determine if Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Name)
+		status.Failure("Could not determine if nat-discovery port is allowed in the cluster %q", localClusterInfo.Name)
 	} else {
-		status.Success("Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Name)
+		status.Success("nat-discovery port is allowed in the cluster %q", localClusterInfo.Name)
 	}
 
 	return err

--- a/pkg/diagnose/firewall_vxlan.go
+++ b/pkg/diagnose/firewall_vxlan.go
@@ -78,8 +78,9 @@ func checkFWConfig(clusterInfo *cluster.Info, options FirewallOptions, status re
 		return
 	}
 
-	gwNodeName := getActiveGatewayNodeName(clusterInfo, localEndpoint.Spec.Hostname, status)
-	if gwNodeName == "" {
+	gwNodeName, err := getActiveGatewayNodeName(clusterInfo, localEndpoint.Spec.Hostname, status)
+	if err != nil {
+		status.Failure("Unable to obtain a gateway node: %v", err)
 		return
 	}
 


### PR DESCRIPTION
Currently subctl diagnose ... command validates if metrics port
and tunnel port are allowed on the gateway port. Similar validation
should be done for Nat-discovery port as well. This PR handles that
and users can now use "subctl diagnose firewall nat-discovery ..."
for validating the nat-discovery port.

Fixes issue: https://github.com/submariner-io/subctl/issues/80
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
