### PR TITLE
Cloud prepare support for OVN Clusters

### DIFF
--- a/pkg/cloud/prepare/gcp.go
+++ b/pkg/cloud/prepare/gcp.go
@@ -28,29 +28,13 @@ import (
 )
 
 func GCP(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *gcp.Config, status reporter.Interface) error {
-	gwPorts := []api.PortSpec{
-		{Port: ports.Natt, Protocol: "udp"},
-		{Port: ports.NatDiscovery, Protocol: "udp"},
-
-		// ESP & AH protocols are used for private-ip to private-ip gateway communications
-		{Port: 0, Protocol: "esp"},
-		{Port: 0, Protocol: "ah"},
-	}
-	input := api.PrepareForSubmarinerInput{
-		InternalPorts: []api.PortSpec{
-			{Port: ports.Vxlan, Protocol: "udp"},
-		},
-	}
-
-	for i := range ports.Metrics {
-		port := api.PortSpec{
-			Port: ports.Metrics[i], Protocol: "tcp",
-		}
-		input.InternalPorts = append(input.InternalPorts, port)
+	gwPorts, input, err := getPortConfig(restConfigProducer, ports, false)
+	if err != nil {
+		return status.Error(err, "Failed to prepare the cloud")
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := gcp.RunOn(restConfigProducer, config, cli.NewReporter(),
+	err = gcp.RunOn(restConfigProducer, config, cli.NewReporter(),
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {
 				gwInput := api.GatewayDeployInput{

--- a/pkg/cloud/prepare/prepare.go
+++ b/pkg/cloud/prepare/prepare.go
@@ -1,0 +1,100 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prepare
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/cloud-prepare/pkg/api"
+	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/restconfig"
+	"github.com/submariner-io/subctl/pkg/cloud"
+	"github.com/submariner-io/submariner-operator/pkg/client"
+	"github.com/submariner-io/submariner-operator/pkg/discovery/network"
+	"github.com/submariner-io/submariner/pkg/cni"
+)
+
+func getNetworkDetails(restCfgProducer *restconfig.Producer) (*network.ClusterNetwork, error) {
+	k8sConfig, err := restCfgProducer.ForCluster()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating the restConfig")
+	}
+
+	clientProducer, err := client.NewProducerFromRestConfig(k8sConfig.Config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating the client producer")
+	}
+
+	networkDetails, err := network.Discover(clientProducer.ForDynamic(), clientProducer.ForKubernetes(), clientProducer.ForOperator(),
+		constants.OperatorNamespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to discover network details")
+	} else if networkDetails == nil {
+		return nil, fmt.Errorf("no network details discovered")
+	}
+
+	return networkDetails, nil
+}
+
+func getPortConfig(restcfg *restconfig.Producer, ports *cloud.Ports, useNumericESP bool,
+) ([]api.PortSpec, api.PrepareForSubmarinerInput, error) {
+	gwPorts := []api.PortSpec{
+		{Port: ports.Natt, Protocol: "udp"},
+		{Port: ports.NatDiscovery, Protocol: "udp"},
+
+		// ESP & AH protocols are used for private-ip to private-ip gateway communications.
+		{Port: 0, Protocol: "esp"},
+		{Port: 0, Protocol: "ah"},
+	}
+
+	if useNumericESP {
+		for i, port := range gwPorts {
+			switch port.Protocol {
+			case "esp":
+				gwPorts[i].Protocol = "50"
+			case "ah":
+				gwPorts[i].Protocol = "51"
+			}
+		}
+	}
+
+	input := api.PrepareForSubmarinerInput{}
+
+	for i := range ports.Metrics {
+		port := api.PortSpec{
+			Port: ports.Metrics[i], Protocol: "tcp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
+	}
+
+	nwDetails, err := getNetworkDetails(restcfg)
+	if err != nil {
+		return gwPorts, input, errors.Wrapf(err, "failed to discover the network details in the cluster")
+	}
+
+	if nwDetails.NetworkPlugin != cni.OVNKubernetes {
+		port := api.PortSpec{
+			Port: ports.Vxlan, Protocol: "udp",
+		}
+		input.InternalPorts = append(input.InternalPorts, port)
+	}
+
+	return gwPorts, input, nil
+}

--- a/pkg/cloud/prepare/rhos.go
+++ b/pkg/cloud/prepare/rhos.go
@@ -28,29 +28,13 @@ import (
 )
 
 func RHOS(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *rhos.Config, status reporter.Interface) error {
-	gwPorts := []api.PortSpec{
-		{Port: ports.Natt, Protocol: "udp"},
-		{Port: ports.NatDiscovery, Protocol: "udp"},
-
-		// ESP & AH protocols are used for private-ip to private-ip gateway communications
-		{Port: 0, Protocol: "esp"},
-		{Port: 0, Protocol: "ah"},
-	}
-	input := api.PrepareForSubmarinerInput{
-		InternalPorts: []api.PortSpec{
-			{Port: ports.Vxlan, Protocol: "udp"},
-		},
-	}
-
-	for i := range ports.Metrics {
-		port := api.PortSpec{
-			Port: ports.Metrics[i], Protocol: "tcp",
-		}
-		input.InternalPorts = append(input.InternalPorts, port)
+	gwPorts, input, err := getPortConfig(restConfigProducer, ports, false)
+	if err != nil {
+		return status.Error(err, "Failed to prepare the cloud")
 	}
 
 	// nolint:wrapcheck // No need to wrap errors here.
-	err := rhos.RunOn(restConfigProducer, config, status,
+	err = rhos.RunOn(restConfigProducer, config, status,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {
 				gwInput := api.GatewayDeployInput{


### PR DESCRIPTION
When deploying Submariner on an OCP Cluster with OVNK as
the CNI, Submariner does not use the internal VxLAN tunnels
to forward the traffic from the worker nodes to the local
Gateway node. So as part of cloud prepare, we can avoid
opening of this port. This PR handles this for AWS, GCP,
OSP and Azure clusters.

Fixes: https://github.com/submariner-io/subctl/issues/90
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
