### PR TITLE
Rebuild subctl for any .go file change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ dist/subctl-%.tar.xz: cmd/bin/subctl-%
 	tar -cJf $@ --transform "s/^cmd.bin/subctl-$(VERSION)/" $<
 
 # Versions may include hyphens so it's easier to use $(VERSION) than to extract them from the target
-cmd/bin/subctl-%: $(shell find cmd/ -name "*.go") $(VENDOR_MODULES)
+cmd/bin/subctl-%: $(shell find . -name "*.go") $(VENDOR_MODULES)
 	mkdir -p cmd/bin
 	target=$@; \
 	target=$${target%.exe}; \


### PR DESCRIPTION
subctl needs to be rebuilt any time any .go file changes anywhere in
the repo. There's no need for any further subtlety now that subctl is
in its own repository.

Suggested-by: Sridhar Gaddam <sgaddam@redhat.com>
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
