### PR TITLE
Set client pod of firewall inter-cluster to run in hostnet

### DIFF
--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -71,6 +71,13 @@ func spawnClientPodOnNonGatewayNode(client kubernetes.Interface, namespace, podC
 	return spawnPod(client, scheduling, "validate-client", namespace, podCommand, imageRepInfo)
 }
 
+func spawnClientPodOnNonGatewayNodeWithHostNet(client kubernetes.Interface, namespace, podCommand string,
+	imageRepInfo *image.RepositoryInfo,
+) (*pods.Scheduled, error) {
+	scheduling := pods.Scheduling{ScheduleOn: pods.NonGatewayNode, Networking: pods.HostNetworking}
+	return spawnPod(client, scheduling, "validate-client", namespace, podCommand, imageRepInfo)
+}
+
 func spawnPod(client kubernetes.Interface, scheduling pods.Scheduling, podName, namespace,
 	podCommand string, imageRepInfo *image.RepositoryInfo,
 ) (*pods.Scheduled, error) {
@@ -235,7 +242,7 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, optio
 
 	// Spawn the pod on the nonGateway node. If we spawn the pod on Gateway node, the tunnel process can
 	// sometimes drop the udp traffic from client pod until the tunnels are properly setup.
-	cPod, err := spawnClientPodOnNonGatewayNode(remoteClusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
+	cPod, err := spawnClientPodOnNonGatewayNodeWithHostNet(remoteClusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
 		localClusterInfo.GetImageRepositoryInfo())
 	if err != nil {
 		return status.Error(err, "Error spawning the client pod on non-Gateway node of cluster %q", remoteClusterInfo.Name)


### PR DESCRIPTION
We have noticed that with the latest OCP deployments the
diagnose inter-cluster client pod is sometimes getting terminated
due to which the validation fails, using HostNetworking
for the clientPod works consistently.

This PR updates client pod used in firewal inter-cluster command to
run in HostNetworking instead of PodNetworking.

Signed-off-by: yboaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
