### PR TITLE
Label operator namespace as privileged, add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
-	github.com/submariner-io/admiral v0.13.0-m2
+	github.com/submariner-io/admiral v0.13.0-m2.0.20220616204116-c054a15f1c60
 	github.com/submariner-io/cloud-prepare v0.13.0-m2
 	github.com/submariner-io/lighthouse v0.13.0-m2
 	github.com/submariner-io/shipyard v0.13.0-m2.0.20220613150042-b90492334262

--- a/go.sum
+++ b/go.sum
@@ -315,6 +315,7 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -1261,8 +1262,9 @@ github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.5.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
+github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
+github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3/go.mod h1:rtQlpHw+eR6UrqaS3kX1VYeaCxzCVdimDS7g5Ln4pPc=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -1356,8 +1358,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/submariner-io/admiral v0.13.0-m2 h1:cdwtgkyvUpPt8LNk7KJsaHcelzpksWWldtPvJ5MIdwo=
 github.com/submariner-io/admiral v0.13.0-m2/go.mod h1:9OWhRE9xZGBGCDFYRVJwOTSUXnTAP9fUWw1KnOrzGVE=
+github.com/submariner-io/admiral v0.13.0-m2.0.20220616204116-c054a15f1c60 h1:mrlCOedkDreAylxztOIiK7CxQNTYkafEm5zk3kX+WCw=
+github.com/submariner-io/admiral v0.13.0-m2.0.20220616204116-c054a15f1c60/go.mod h1:f3eyy4WCqB2sOFHXhht5dm4epkBj7Apm+UYt70gpMhM=
 github.com/submariner-io/cloud-prepare v0.13.0-m2 h1:URMRJ73Jq9jfSMVlgvkbKIS9/2ELYp4fRvIQSHA6b3A=
 github.com/submariner-io/cloud-prepare v0.13.0-m2/go.mod h1:A2Q5aYtIkKIVLZ4Tkood8lpvNm9E6YbI3NXYTayWs3E=
 github.com/submariner-io/lighthouse v0.13.0-m2 h1:EBuj8+GlpfNvQu1AgOvZgILhcgEp9+7Lyx0LWDU7d0g=

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -65,8 +65,10 @@ func Ensure(crdUpdater crd.Updater, kubeClient kubernetes.Interface, componentAr
 		}
 	}
 
+	brokerNamespaceLabels := map[string]string{}
+
 	// Create the namespace
-	_, err := namespace.Ensure(kubeClient, brokerNS)
+	_, err := namespace.Ensure(kubeClient, brokerNS, brokerNamespaceLabels)
 	if err != nil {
 		return err // nolint:wrapcheck // No need to wrap here
 	}

--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -39,7 +39,12 @@ func Ensure(status reporter.Interface, clientProducer client.Producer, operatorN
 		status.Success("Created operator CRDs")
 	}
 
-	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace); err != nil {
+	operatorNamespaceLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/audit": "privileged",
+		"pod-security.kubernetes.io/warn": "privileged",
+	}
+
+	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace, operatorNamespaceLabels); err != nil {
 		return err
 	} else if created {
 		status.Success("Created operator namespace: %s", operatorNamespace)

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -44,6 +44,11 @@ function verify_subm_operator() {
   # Verify SubM namespace (ignore SubM Broker ns)
   kubectl get ns $subm_ns
 
+  # Verify SubM operator namespace has required pod security labels
+  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/enforce\":\"privileged\"'
+  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/audit\":\"privileged\"'
+  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/warn\":\"privileged\"'
+
   # Verify SubM Operator CRD
   kubectl get crds submariners.submariner.io
   kubectl api-resources | grep submariners


### PR DESCRIPTION
This is required for OpenShift 4.11.
    
Also add the privileged label during upgrades.
    
It would be better if these were Go unit tests, but we don't have those
for subctl yet.

Relates-to: submariner-io/subctl#27
Signed-off-by: Daniel Farrell <dfarrell@redhat.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
