### PR TITLE
Create secrets for serviceaccounts

### DIFF
--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -206,7 +206,7 @@ func CreateNewBrokerRoleBinding(kubeClient kubernetes.Interface, serviceAccount,
 // nolint:wrapcheck // No need to wrap here
 func CreateNewBrokerSA(kubeClient kubernetes.Interface, submarinerBrokerSA, inNamespace string) (brokerSA *v1.ServiceAccount, err error) {
 	sa := NewBrokerSA(submarinerBrokerSA)
-	_, err = serviceaccount.Ensure(kubeClient, inNamespace, sa)
+	_, err = serviceaccount.Ensure(kubeClient, inNamespace, sa, true)
 
 	if err != nil {
 		return nil, err

--- a/pkg/serviceaccount/ensure.go
+++ b/pkg/serviceaccount/ensure.go
@@ -20,28 +20,158 @@ package serviceaccount
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/resource"
 	resourceutil "github.com/submariner-io/subctl/pkg/resource"
+	"github.com/submariner-io/subctl/pkg/secret"
 	"github.com/submariner-io/submariner-operator/pkg/embeddedyamls"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 )
 
-// EnsureFromYAML creates the given service account.
+const (
+	createdByAnnotation = "kubernetes.io/created-by"
+	creatorName         = "subctl"
+)
+
+// ensureFromYAML creates the given service account.
 // nolint:wrapcheck // No need to wrap errors here.
-func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
+func ensureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (*corev1.ServiceAccount, error) {
 	sa := &corev1.ServiceAccount{}
 
 	err := embeddedyamls.GetObject(yaml, sa)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
-	return Ensure(kubeClient, namespace, sa)
+	_, err = Ensure(kubeClient, namespace, sa)
+	if err != nil {
+		return nil, err
+	}
+
+	return sa, err
 }
 
 // nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, namespace string, sa *corev1.ServiceAccount) (bool, error) {
 	return resourceutil.CreateOrUpdate(context.TODO(), resource.ForServiceAccount(kubeClient, namespace), sa)
+}
+
+// EnsureFromYAML creates the given service account and secret for it.
+func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
+	sa, err := ensureFromYAML(kubeClient, namespace, yaml)
+	if err != nil {
+		return false, errors.Wrap(err, "error provisioning the ServiceAccount resource")
+	}
+
+	saSecret, err := EnsureSecretFromSA(kubeClient, sa.Name, namespace)
+	if err != nil {
+		return false, errors.Wrap(err, "error creating secret for ServiceAccount resource")
+	}
+
+	return sa != nil && saSecret != nil, nil
+}
+
+func EnsureSecretFromSA(client kubernetes.Interface, saName, namespace string) (*corev1.Secret, error) {
+	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), saName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get ServiceAccount %s/%s", namespace, saName)
+	}
+
+	saSecret := getSecretFromSA(client, sa)
+
+	if saSecret != nil {
+		return saSecret, nil
+	}
+
+	// We couldn't find right secret from this SA, search all Secrets
+	saSecret, err = getSecretForSA(client, sa)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if err != nil {
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-token-%s", sa.Name, generateRandomString(5)),
+				Namespace: namespace,
+				Annotations: map[string]string{
+					corev1.ServiceAccountNameKey: saName,
+					createdByAnnotation:          creatorName,
+				},
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+		}
+
+		saSecret, err = secret.Ensure(client, newSecret.Namespace, newSecret)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create secret for ServiceAccount %v", saName)
+		}
+	}
+
+	secretRef := corev1.ObjectReference{
+		Name: saSecret.Name,
+	}
+
+	sa.Secrets = append(sa.Secrets, secretRef)
+	_, err = Ensure(client, namespace, sa)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update ServiceAccount %v with Secret reference %v", saName, secretRef.Name)
+	}
+
+	return saSecret, nil
+}
+
+func getSecretFromSA(client kubernetes.Interface, sa *corev1.ServiceAccount) *corev1.Secret {
+	secretNamePrefix := fmt.Sprintf("%s-token-", sa.Name)
+	for _, saSecretRef := range sa.Secrets {
+		if strings.HasPrefix(saSecretRef.Name, secretNamePrefix) {
+			saSecret, _ := client.CoreV1().Secrets(sa.Namespace).Get(context.TODO(), saSecretRef.Name, metav1.GetOptions{})
+			if saSecret.Annotations[corev1.ServiceAccountNameKey] == sa.Name && saSecret.Type == corev1.SecretTypeServiceAccountToken {
+				return saSecret
+			}
+		}
+	}
+
+	return nil
+}
+
+func getSecretForSA(client kubernetes.Interface, sa *corev1.ServiceAccount) (*corev1.Secret, error) {
+	saSecrets, err := client.CoreV1().Secrets(sa.Namespace).List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("type", "kubernetes.io/service-account-token").String(),
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get secrets of type service-account-token in %v", sa.Namespace)
+	}
+
+	for i := 0; i < len(saSecrets.Items); i++ {
+		if saSecrets.Items[i].Annotations[corev1.ServiceAccountNameKey] == sa.Name {
+			return &saSecrets.Items[i], nil
+		}
+	}
+
+	return nil, apierrors.NewNotFound(schema.GroupResource{
+		Group:    corev1.SchemeGroupVersion.Group,
+		Resource: "secrets",
+	}, sa.Name)
+}
+
+// nolint:gosec // we need a pseudo random string for name.
+func generateRandomString(length int) string {
+	rand.Seed(time.Now().UnixNano())
+
+	s := make([]byte, length)
+	rand.Read(s)
+
+	return fmt.Sprintf("%x", s)[:length]
 }

--- a/pkg/serviceaccount/ensure_test.go
+++ b/pkg/serviceaccount/ensure_test.go
@@ -71,7 +71,7 @@ var _ = Describe("EnsureFromYAML", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-sa",
 				},
-			})
+			}, false)
 			Expect(err).To(Succeed())
 			assertServiceAccount()
 

--- a/pkg/serviceaccount/ensure_test.go
+++ b/pkg/serviceaccount/ensure_test.go
@@ -62,7 +62,7 @@ var _ = Describe("EnsureFromYAML", func() {
 	})
 
 	When("the ServiceAccount already exists", func() {
-		It("should not update it", func() {
+		It("should not return any error", func() {
 			_, err := serviceaccount.Ensure(client, namespace, &corev1.ServiceAccount{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ServiceAccount",
@@ -76,7 +76,7 @@ var _ = Describe("EnsureFromYAML", func() {
 			assertServiceAccount()
 
 			created, err := serviceaccount.EnsureFromYAML(client, namespace, roleYAML)
-			Expect(created).To(BeFalse())
+			Expect(created).To(BeTrue())
 			Expect(err).To(Succeed())
 		})
 	})


### PR DESCRIPTION
K8s 1.24+ doesn't autocreate secret for serviceaccount. This
breaks submariner deployments which expects secret to be created
and associated to the corresponding serviceaccount.

The fix ensures the Secret of type service-account-token exists,
is annotated with ServiceAccount.Name, and is added to Secrets list in
the ServiceAccount.

Fixes #102

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
