### PR TITLE
Warn users about ns label warnings

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/image"
 	v1 "k8s.io/api/core/v1"
@@ -78,6 +79,10 @@ func ScheduleAndAwaitCompletion(config *Config) (string, error) {
 		config.Namespace = constants.OperatorNamespace
 	}
 
+	if err := checkNSLabels(config); err != nil {
+		return "", err
+	}
+
 	np := &Scheduled{Config: config}
 	if err := np.schedule(); err != nil {
 		return "", err
@@ -99,6 +104,10 @@ func Schedule(config *Config) (*Scheduled, error) {
 
 	if config.Namespace == "" {
 		config.Namespace = constants.OperatorNamespace
+	}
+
+	if err := checkNSLabels(config); err != nil {
+		return nil, err
 	}
 
 	np := &Scheduled{Config: config}
@@ -270,4 +279,43 @@ func addNodeSelectorTerm(nodeSelTerms []v1.NodeSelectorTerm, label string,
 			Values:   values,
 		},
 	}})
+}
+
+func checkNSLabels(config *Config) error {
+	ns, err := config.ClientSet.CoreV1().Namespaces().Get(context.TODO(), config.Namespace, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error fetching %s namespace", config.Namespace))
+	}
+
+	expectedLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/audit":   "privileged",
+		"pod-security.kubernetes.io/warn":    "privileged",
+	}
+
+	missingLabels := map[string]string{}
+
+	for key, expectedLabel := range expectedLabels {
+		actualLabel, found := ns.Labels[key]
+		if !found || actualLabel != expectedLabel {
+			missingLabels[key] = expectedLabel
+		}
+	}
+
+	if len(missingLabels) != 0 {
+		warnAbout(missingLabels, ns.Name)
+	}
+
+	return nil
+}
+
+func warnAbout(missingLabels map[string]string, namespace string) {
+	status := cli.NewReporter()
+	status.Warning("Starting with Kubernetes 1.23, the Pod Security admission controller expects namespaces to have security labels."+
+		" Without these, you will see warnings in subctl's output. subctl should work fine, but you can avoid the warnings and ensure "+
+		"correct behavior by adding these labels to the namespace %s:", namespace)
+
+	for key, val := range missingLabels {
+		status.Warning(fmt.Sprintf("%s %s", key, val))
+	}
 }


### PR DESCRIPTION
K8S1.23/OCP 4.11 and above throws warnings if the ns is not
`PodSecurity` labelled. This affects `diagnose kube-proxy-mode`
and `diagnose firewall` subcommands.

This PR adds a warning about these warnings so that the user
is not surprised when they pop up in the logs while running
these commands.

Partially Closes: #119

Depends on https://github.com/submariner-io/subctl/pull/126

Sample output when the `namespace` has not been specified by the user:
```
./cmd/bin/subctl diagnose firewall nat-discovery output/kubeconfigs/kind-config-cluster1 output/kubeconfigs/kind-config-cluster2
 ✓ Checking if nat-discovery port is opened on the gateway node of cluster "cluster1" 
 ✓ nat-discovery port is allowed in the cluster "cluster1"
```

Output when the namespace has been specified by the user:
```
./cmd/bin/subctl diagnose firewall nat-discovery output/kubeconfigs/kind-config-cluster1 output/kubeconfigs/kind-config-cluster2 --namespace user_ns
 ⚠ Kubernetes 1.23/OpenShift Container Platform 4.11 and above expects namespaces to have security labels as required by `PodSecurity Admission controller`. Otherwise, the related warnings would be logged. To avoid such warnings, make sure the namespace specified has below labels:
 ⚠ pod-security.kubernetes.io/enforce: privileged
 ⚠ pod-security.kubernetes.io/audit: privileged
 ⚠ pod-security.kubernetes.io/warn: privileged
```


Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
