### PR TITLE
Automated backport of #99: Add OVNKubernetes diagnosis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/gophercloud/utils v0.0.0-20210909165623-d7085207ff6d
 	github.com/mattn/go-isatty v0.0.14
+	github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -996,6 +996,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2 h1:YocNLcTBdEdvY3iDK6jfWXvEaM5OCKkjxPKoJRdB3Gg=
+github.com/mcuadros/go-version v0.0.0-20190830083331-035f6764e8d2/go.mod h1:76rfSfYPWj01Z85hUf/ituArm797mNKcvINh1OlsZKo=
 github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43/go.mod h1:+t7E0lkKfbBsebllff1xdTmyJt8lH37niI6kwFk9OTo=
 github.com/mdlayher/ethtool v0.0.0-20211028163843-288d040e9d60/go.mod h1:aYbhishWc4Ai3I2U4Gaa2n3kHWSwzme6EsG/46HRQbE=
 github.com/mdlayher/genetlink v1.0.0/go.mod h1:0rJ0h4itni50A86M2kHcgS85ttZazNt7a8H2a2cw0Gc=

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -237,16 +237,16 @@ func checkOVNVersion(info *cluster.Info, status reporter.Interface) bool {
 
 	ovnNBVersion, err := getOVNNBVersion(clientSet, info.RestConfig, ovnPod)
 	if err != nil {
-		status.Failure("Failed to get OVN NB version %v", err)
+		status.Failure("Failed to get ovn-nb database version %v", err)
 		return false
 	}
 
 	if version.Compare(ovnNBVersion, minOVNNBVersion, "<") {
-		status.Failure("The OVN NB DB version %v is less than the minimum supported version %v", ovnNBVersion, minOVNNBVersion)
+		status.Failure("The ovn-nb database version %v is less than the minimum supported version %v", ovnNBVersion, minOVNNBVersion)
 		return false
 	}
 
-	status.Success("The OVN NB DB version %v is supported", ovnNBVersion)
+	status.Success("The ovn-nb database version %v is supported", ovnNBVersion)
 
 	return true
 }
@@ -275,6 +275,7 @@ func getOVNNBVersion(clientSet kubernetes.Interface, config *rest.Config, pod *c
 		// NBDB container name is nb-ovsdb [vanilla OVNK] or nbdb [OCP].
 		if strings.HasPrefix(container.Name, "nb") {
 			containerName = container.Name
+			break
 		}
 	}
 

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -19,18 +19,30 @@ limitations under the License.
 package diagnose
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/mcuadros/go-version"
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cni"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	ovnKubeDBPodLabel = "ovn-db-pod=true"
+	minOVNNBVersion   = "6.1.0"
 )
 
 var supportedNetworkPlugins = []string{
@@ -70,6 +82,10 @@ func CNIConfig(clusterInfo *cluster.Info, status reporter.Interface) bool {
 			" It may or may not work.", clusterInfo.Submariner.Status.NetworkPlugin)
 	} else {
 		status.Success("The detected CNI network plugin (%q) is supported", clusterInfo.Submariner.Status.NetworkPlugin)
+	}
+
+	if clusterInfo.Submariner.Status.NetworkPlugin == cni.OVNKubernetes {
+		return checkOVNVersion(clusterInfo, status)
 	}
 
 	return checkCalicoIPPoolsIfCalicoCNI(clusterInfo, status)
@@ -205,4 +221,98 @@ func mustHaveSubmariner(clusterInfo *cluster.Info) {
 	if clusterInfo.Submariner == nil {
 		panic("cluster.Info.Submariner field cannot be nil")
 	}
+}
+
+func checkOVNVersion(info *cluster.Info, status reporter.Interface) bool {
+	status.Start("Checking OVN version")
+	defer status.End()
+
+	clientSet := info.ClientProducer.ForKubernetes()
+
+	ovnPod, err := findPod(clientSet, ovnKubeDBPodLabel)
+	if err != nil || ovnPod == nil {
+		status.Failure("Failed to get OVNKubeDB Pod %v", err)
+		return false
+	}
+
+	ovnNBVersion, err := getOVNNBVersion(clientSet, info.RestConfig, ovnPod)
+	if err != nil {
+		status.Failure("Failed to get OVN NB version %v", err)
+		return false
+	}
+
+	if version.Compare(ovnNBVersion, minOVNNBVersion, "<") {
+		status.Failure("OVN NBDB version %v is lesser than minimum supported %v", ovnNBVersion, minOVNNBVersion)
+		return false
+	}
+
+	status.Success("OVN NBDB Version %v is supported", ovnNBVersion)
+
+	return true
+}
+
+func findPod(clientSet kubernetes.Interface, labelSelector string) (*corev1.Pod, error) {
+	pods, err := clientSet.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+		Limit:         1,
+	})
+	if err != nil {
+		return nil, errors.WithMessagef(err, "error listing Pods by label selector %q", labelSelector)
+	}
+
+	if len(pods.Items) == 0 {
+		return nil, errors.WithMessagef(err, "found 0 pods with label %v", labelSelector)
+	}
+
+	return &pods.Items[0], nil
+}
+
+func getOVNNBVersion(clientSet kubernetes.Interface, config *rest.Config, pod *corev1.Pod) (string, error) {
+	containerName := ""
+
+	for i := 0; i < len(pod.Spec.Containers); i++ {
+		container := pod.Spec.Containers[i]
+		// NBDB container name is nb-ovsdb [vanilla OVNK] or nbdb [OCP].
+		if strings.HasPrefix(container.Name, "nb") {
+			containerName = container.Name
+		}
+	}
+
+	cmd := []string{"ovn-nbctl", "-V"}
+	req := clientSet.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		Param("container", containerName)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: containerName,
+		Command:   cmd,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	var stdout, stderr bytes.Buffer
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", errors.WithMessagef(err, "Failed to get OVN NBDB version")
+	}
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+
+	if err != nil {
+		return "", errors.WithMessagef(err, "Failed to get OVN NBDB version")
+	}
+
+	result := strings.Split(stdout.String(), "DB Schema")[1]
+
+	return strings.TrimSpace(result), nil
 }

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -25,6 +25,7 @@ import (
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/cni"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -115,6 +116,11 @@ func checkPods(clusterInfo *cluster.Info, status reporter.Interface) bool {
 	// Check if globalnet components are deployed and running if enabled
 	if clusterInfo.Submariner.Spec.GlobalCIDR != "" {
 		checkDaemonset(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-globalnet", tracker)
+	}
+
+	// check if networkplugin syncer components are deployed and running if enabled
+	if clusterInfo.Submariner.Status.NetworkPlugin == cni.OVNKubernetes {
+		checkDeployment(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-networkplugin-syncer", tracker)
 	}
 
 	checkPodsStatus(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, tracker)


### PR DESCRIPTION
# PLEASE SQUASH WHEN MERGING

Backport of #99 on release-0.13.

#99: Add OVNKubernetes diagnosis

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.