### PR TITLE
Automated backport of #126: Change default namespace for diagnose

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -193,7 +193,7 @@ func addDiagnoseFirewallSubCommands() {
 }
 
 func addDiagnosePodNamespaceFlag(command *cobra.Command, value *string) {
-	command.Flags().StringVar(value, "namespace", "default", "namespace in which validation pods should be deployed")
+	command.Flags().StringVar(value, "namespace", constants.OperatorNamespace, "namespace in which validation pods should be deployed")
 }
 
 func addDiagnoseFWConfigFlags(command *cobra.Command) {

--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/image"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,7 +75,7 @@ func ScheduleAndAwaitCompletion(config *Config) (string, error) {
 	}
 
 	if config.Namespace == "" {
-		config.Namespace = "default"
+		config.Namespace = constants.OperatorNamespace
 	}
 
 	np := &Scheduled{Config: config}
@@ -97,7 +98,7 @@ func Schedule(config *Config) (*Scheduled, error) {
 	}
 
 	if config.Namespace == "" {
-		config.Namespace = "default"
+		config.Namespace = constants.OperatorNamespace
 	}
 
 	np := &Scheduled{Config: config}

--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/pods"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/subctl/pkg/image"
@@ -126,7 +127,7 @@ func getActiveGatewayNodeName(clusterInfo *cluster.Info, hostname string, imageR
 		// On some platforms, the nodeName does not match with the hostname.
 		// Submariner Endpoint stores the hostname info in the endpoint and not the nodeName. So, we spawn a
 		// tiny pod to read the hostname and return the corresponding node.
-		sPod, err := spawnSnifferPodOnNode(clusterInfo.ClientProducer.ForKubernetes(), node.Name, "default", "hostname",
+		sPod, err := spawnSnifferPodOnNode(clusterInfo.ClientProducer.ForKubernetes(), node.Name, constants.OperatorNamespace, "hostname",
 			imageRepInfo)
 		if err != nil {
 			return "", status.Error(err, "Error spawning the sniffer pod on the node %q: %v", node.Name)


### PR DESCRIPTION
Backport of #126 on release-0.13.

#126: Change default namespace for diagnose

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.