### PR TITLE
Automated backport of #127: Add warning about missing labels

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/image"
 	v1 "k8s.io/api/core/v1"
@@ -78,6 +79,10 @@ func ScheduleAndAwaitCompletion(config *Config) (string, error) {
 		config.Namespace = constants.OperatorNamespace
 	}
 
+	if err := checkNSLabels(config); err != nil {
+		return "", err
+	}
+
 	np := &Scheduled{Config: config}
 	if err := np.schedule(); err != nil {
 		return "", err
@@ -99,6 +104,10 @@ func Schedule(config *Config) (*Scheduled, error) {
 
 	if config.Namespace == "" {
 		config.Namespace = constants.OperatorNamespace
+	}
+
+	if err := checkNSLabels(config); err != nil {
+		return nil, err
 	}
 
 	np := &Scheduled{Config: config}
@@ -270,4 +279,43 @@ func addNodeSelectorTerm(nodeSelTerms []v1.NodeSelectorTerm, label string,
 			Values:   values,
 		},
 	}})
+}
+
+func checkNSLabels(config *Config) error {
+	ns, err := config.ClientSet.CoreV1().Namespaces().Get(context.TODO(), config.Namespace, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error fetching %s namespace", config.Namespace))
+	}
+
+	expectedLabels := map[string]string{
+		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/audit":   "privileged",
+		"pod-security.kubernetes.io/warn":    "privileged",
+	}
+
+	missingLabels := map[string]string{}
+
+	for key, expectedLabel := range expectedLabels {
+		actualLabel, found := ns.Labels[key]
+		if !found || actualLabel != expectedLabel {
+			missingLabels[key] = expectedLabel
+		}
+	}
+
+	if len(missingLabels) != 0 {
+		warnAbout(missingLabels, ns.Name)
+	}
+
+	return nil
+}
+
+func warnAbout(missingLabels map[string]string, namespace string) {
+	status := cli.NewReporter()
+	status.Warning("Starting with Kubernetes 1.23, the Pod Security admission controller expects namespaces to have security labels."+
+		" Without these, you will see warnings in subctl's output. subctl should work fine, but you can avoid the warnings and ensure "+
+		"correct behavior by adding these labels to the namespace %s:", namespace)
+
+	for key, val := range missingLabels {
+		status.Warning(fmt.Sprintf("%s %s", key, val))
+	}
 }


### PR DESCRIPTION
Backport of #127 on release-0.13.

#127: Add warning about missing labels

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.