### PR TITLE
Gather creates a subdirectory with cluster name for gather logs

### DIFF
--- a/cmd/subctl/gather.go
+++ b/cmd/subctl/gather.go
@@ -21,6 +21,7 @@ package subctl
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -39,6 +40,10 @@ var gatherCmd = &cobra.Command{
 		"can be selected by component (%v) and type (%v). Default is to capture all data.",
 		strings.Join(gather.AllModules.Elements(), ","), strings.Join(gather.AllTypes.Elements(), ",")),
 	Run: func(command *cobra.Command, args []string) {
+		if options.Directory == "" {
+			options.Directory = "submariner-" + time.Now().UTC().Format("20060102150405") // submariner-YYYYMMDDHHMMSS
+		}
+
 		execute.OnMultiCluster(restConfigProducer, func(info *cluster.Info, status reporter.Interface) bool {
 			err := checkGatherArguments()
 			exit.OnErrorWithMessage(err, "Invalid argument")

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
+	"path/filepath"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/admiral/pkg/stringset"
@@ -72,9 +72,8 @@ func Data(clusterInfo *cluster.Info, status reporter.Interface, options Options)
 		Deduplicate: true,
 	}))
 
-	if options.Directory == "" {
-		options.Directory = "submariner-" + time.Now().UTC().Format("20060102150405") // submariner-YYYYMMDDHHMMSS
-	}
+	// concatenate the name of the cluster with the root gather directory
+	options.Directory = filepath.Join(options.Directory, clusterInfo.Name)
 
 	if _, err := os.Stat(options.Directory); os.IsNotExist(err) {
 		err := os.MkdirAll(options.Directory, 0o700)

--- a/internal/gather/logs.go
+++ b/internal/gather/logs.go
@@ -102,7 +102,7 @@ func getLogFromStream(logStream io.ReadCloser) (string, error) {
 }
 
 func writeLogToFile(data, podName string, info *Info, fileExtension string) (string, error) {
-	fileName := escapeFileName(info.ClusterName+"_"+podName) + fileExtension
+	fileName := escapeFileName(podName) + fileExtension
 	filePath := filepath.Join(info.DirName, fileName)
 
 	f, err := os.Create(filePath)

--- a/internal/gather/resource.go
+++ b/internal/gather/resource.go
@@ -57,7 +57,7 @@ func ResourcesToYAMLFile(info *Info, ofType schema.GroupVersionResource, namespa
 		for i := range list.Items {
 			item := &list.Items[i]
 
-			name := escapeFileName(info.ClusterName+"_"+ofType.Resource+"_"+item.GetNamespace()+"_"+item.GetName()) + ".yaml"
+			name := escapeFileName(ofType.Resource+"_"+item.GetNamespace()+"_"+item.GetName()) + ".yaml"
 			path := filepath.Join(info.DirName, name)
 
 			file, err := os.Create(path)

--- a/scripts/test/lib_subctl_gather_test.sh
+++ b/scripts/test/lib_subctl_gather_test.sh
@@ -61,7 +61,7 @@ function validate_pod_log_files() {
   read -ra pod_names_array <<< "$pod_names"
 
   for pod_name in "${pod_names_array[@]}"; do
-    file=$gather_out_dir/${cluster}_$pod_name.log
+    file=$gather_out_dir/${cluster}/$pod_name.log
     cat $file
 
   done
@@ -96,7 +96,7 @@ function validate_resource_files() {
   for i in "${!names_array[@]}"; do
     name=${names_array[$i]}
     namespace=${namespaces_array[$i]}
-    file=$gather_out_dir/${cluster_name}_${short_res}_${namespace}_${name}.yaml
+    file=$gather_out_dir/${cluster_name}/${short_res}_${namespace}_${name}.yaml
     cat $file
 
     kind_count=$(grep "kind: $kind$" $file | wc -l)
@@ -114,8 +114,8 @@ function validate_resource_files() {
 }
 
 function validate_broker_resources() {
-  validate_resource_files $submariner_broker_ns 'endpoints.submariner.io' 'Endpoint' '' 'broker'
-  validate_resource_files $submariner_broker_ns 'clusters.submariner.io' 'Cluster' '' 'broker'
-  validate_resource_files $submariner_broker_ns 'serviceimports.multicluster.x-k8s.io' 'ServiceImport' '' 'broker'
-  validate_resource_files $submariner_broker_ns 'endpointslices.discovery.k8s.io' 'EndpointSlice' '' 'broker'
+  validate_resource_files $submariner_broker_ns endpoints.submariner.io Endpoint
+  validate_resource_files $submariner_broker_ns clusters.submariner.io Cluster
+  validate_resource_files $submariner_broker_ns serviceimports.multicluster.x-k8s.io ServiceImport
+  validate_resource_files $submariner_broker_ns endpointslices.discovery.k8s.io EndpointSlice
 }

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -42,8 +42,8 @@ function test_subctl_gather() {
         with_context "${cluster}" validate_gathered_files
     done
 
-    # Broker
-    with_context "$broker" validate_broker_resources
+    # Broker (on the first cluster)
+    with_context "${broker}" validate_broker_resources
     echo "::endgroup::"
 }
 


### PR DESCRIPTION
- this commit creates a subdirectory name derived from kubeconfig
  cluster.Name for gather logs to be stored in separate directories
  under the root timestamped directory

Resolves #54 

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
