### PR TITLE
Use `table` printer in `show` commands

### DIFF
--- a/internal/show/brokers.go
+++ b/internal/show/brokers.go
@@ -20,10 +20,9 @@ package show
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/subctl/internal/show/table"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,22 +48,29 @@ func Brokers(clusterInfo *cluster.Info, status reporter.Interface) bool {
 		return true
 	}
 
-	template := "%-25.24s%-25.24s%-34.33s%-20v%-21s%-26v%-40s\n"
-	fmt.Printf(template, "NAMESPACE", "NAME", "COMPONENTS", "GLOBALNET ENABLED", "GLOBALNET CIDR", "DEFAULT GLOBALNET SIZE",
-		"DEFAULT DOMAINS")
+	printer := table.Printer{Columns: []table.Column{
+		{Name: "NAMESPACE", MaxLength: 24},
+		{Name: "NAME", MaxLength: 24},
+		{Name: "COMPONENTS"},
+		{Name: "GLOBALNET"},
+		{Name: "GLOBALNET CIDR"},
+		{Name: "DEFAULT GLOBALNET SIZE"},
+		{Name: "DEFAULT DOMAINS", MaxLength: 40},
+	}}
 
 	for i := range brokers {
-		fmt.Printf(
-			template,
+		printer.Add(
 			brokers[i].Namespace,
 			brokers[i].Name,
-			strings.Join(brokers[i].Spec.Components, ", "),
+			brokers[i].Spec.Components,
 			brokers[i].Spec.GlobalnetEnabled,
 			brokers[i].Spec.GlobalnetCIDRRange,
 			brokers[i].Spec.DefaultGlobalnetClusterSize,
-			strings.Join(brokers[i].Spec.DefaultCustomDomains, ", "),
+			brokers[i].Spec.DefaultCustomDomains,
 		)
 	}
+
+	printer.Print()
 
 	return true
 }

--- a/internal/show/versions.go
+++ b/internal/show/versions.go
@@ -20,85 +20,65 @@ package show
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/show/table"
 	"github.com/submariner-io/subctl/pkg/cluster"
-	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
-	submarinerclientset "github.com/submariner-io/submariner-operator/pkg/client/clientset/versioned"
 	"github.com/submariner-io/submariner-operator/pkg/images"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
-type versionImageInfo struct {
-	component  string
-	repository string
-	version    string
-}
+func getOperatorVersion(clusterInfo *cluster.Info) ([]interface{}, error) {
+	deployments := clusterInfo.ClientProducer.ForKubernetes().AppsV1().Deployments(constants.OperatorNamespace)
 
-func newVersionInfoFrom(repository, component, version string) versionImageInfo {
-	return versionImageInfo{
-		component:  component,
-		repository: repository,
-		version:    version,
-	}
-}
-
-func getSubmarinerVersion(submariner *v1alpha1.Submariner, versions []versionImageInfo) []versionImageInfo {
-	versions = append(versions, newVersionInfoFrom(submariner.Spec.Repository, names.SubmarinerCrName, submariner.Spec.Version))
-	return versions
-}
-
-func getOperatorVersion(clientSet kubernetes.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
-	operatorConfig, err := clientSet.AppsV1().Deployments(constants.OperatorNamespace).Get(context.TODO(), names.OperatorComponent,
-		v1.GetOptions{})
+	operatorDeployment, err := deployments.Get(context.TODO(), names.OperatorComponent, v1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return versions, nil
+			return nil, nil
 		}
 
 		return nil, errors.Wrap(err, "error retrieving Deployment")
 	}
 
-	operatorFullImageStr := operatorConfig.Spec.Template.Spec.Containers[0].Image
-	version, repository := images.ParseOperatorImage(operatorFullImageStr)
-	versions = append(versions, newVersionInfoFrom(repository, names.OperatorComponent, version))
+	version, repository := images.ParseOperatorImage(operatorDeployment.Spec.Template.Spec.Containers[0].Image)
 
-	return versions, nil
+	return []interface{}{names.OperatorComponent, repository, version}, nil
 }
 
-func getServiceDiscoveryVersions(submarinerClient submarinerclientset.Interface, versions []versionImageInfo) ([]versionImageInfo, error) {
-	lighthouseAgentConfig, err := submarinerClient.SubmarinerV1alpha1().ServiceDiscoveries(constants.OperatorNamespace).Get(
-		context.TODO(), names.ServiceDiscoveryCrName, v1.GetOptions{})
+func getServiceDiscoveryVersion(clusterInfo *cluster.Info) ([]interface{}, error) {
+	serviceDiscoveries := clusterInfo.ClientProducer.ForOperator().SubmarinerV1alpha1().ServiceDiscoveries(constants.OperatorNamespace)
+
+	serviceDiscovery, err := serviceDiscoveries.Get(context.TODO(), names.ServiceDiscoveryCrName, v1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return versions, nil
+			return nil, nil
 		}
 
 		return nil, errors.Wrap(err, "error retrieving Submariner resource")
 	}
 
-	versions = append(versions, newVersionInfoFrom(lighthouseAgentConfig.Spec.Repository, names.ServiceDiscoveryCrName,
-		lighthouseAgentConfig.Spec.Version))
-
-	return versions, nil
+	return []interface{}{names.ServiceDiscoveryCrName, serviceDiscovery.Spec.Repository, serviceDiscovery.Spec.Version}, nil
 }
 
 func Versions(clusterInfo *cluster.Info, status reporter.Interface) bool {
 	status.Start("Showing versions")
 
-	var versions []versionImageInfo
+	printer := table.Printer{Columns: []table.Column{
+		{Name: "COMPONENT"},
+		{Name: "REPOSITORY"},
+		{Name: "VERSION"},
+	}}
 
-	if clusterInfo.Submariner != nil {
-		versions = getSubmarinerVersion(clusterInfo.Submariner, versions)
+	submariner := clusterInfo.Submariner
+	if submariner != nil {
+		printer.Add(names.SubmarinerCrName, submariner.Spec.Repository, submariner.Spec.Version)
 	}
 
-	versions, err := getOperatorVersion(clusterInfo.ClientProducer.ForKubernetes(), versions)
+	operatorVersion, err := getOperatorVersion(clusterInfo)
 	if err != nil {
 		status.Failure("Unable to get the Operator version", err)
 		status.End()
@@ -106,7 +86,11 @@ func Versions(clusterInfo *cluster.Info, status reporter.Interface) bool {
 		return false
 	}
 
-	versions, err = getServiceDiscoveryVersions(clusterInfo.ClientProducer.ForOperator(), versions)
+	if operatorVersion != nil {
+		printer.Add(operatorVersion...)
+	}
+
+	lighthouseVersion, err := getServiceDiscoveryVersion(clusterInfo)
 	if err != nil {
 		status.Failure("Unable to get the Service-Discovery version", err)
 		status.End()
@@ -114,24 +98,13 @@ func Versions(clusterInfo *cluster.Info, status reporter.Interface) bool {
 		return false
 	}
 
+	if lighthouseVersion != nil {
+		printer.Add(lighthouseVersion...)
+	}
+
 	status.End()
 
-	if len(versions) > 0 {
-		printVersions(versions)
-	}
+	printer.Print()
 
 	return true
-}
-
-func printVersions(versions []versionImageInfo) {
-	template := "%-32.31s%-54.53s%-16.15s\n"
-	fmt.Printf(template, "COMPONENT", "REPOSITORY", "VERSION")
-
-	for _, item := range versions {
-		fmt.Printf(
-			template,
-			item.component,
-			item.repository,
-			item.version)
-	}
 }


### PR DESCRIPTION
The code was needlessly complicated, this way it's simpler and has the same effect.

As part of the work:
    * Support for no max length was added.
    * Code now auto formats values (instead of having caller do it).
    * Spacing between columns is 3 (same as kubectl output)
    * Empty tables aren't printed (same as kubectl output)

The commands were greatly simplified by this change, and the print out
is much more aligned with `kubectl` behavior and with each other.

The PR encompasses 2 commits:
1. Overhaul `table.Printer` to be simple & useful
2. Use `table` printer in `show` commands

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
4. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
5. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
6. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
7. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
8. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
