### PR TITLE
Fix intermittent failure with diagnose metrics cmd

### DIFF
--- a/pkg/diagnose/firewall_metrics.go
+++ b/pkg/diagnose/firewall_metrics.go
@@ -61,7 +61,7 @@ func FirewallMetricsConfig(clusterInfo *cluster.Info, options FirewallOptions, s
 	gatewayPodIP := sPod.Pod.Status.HostIP
 	podCommand = fmt.Sprintf("for i in $(seq 10); do timeout 2 nc -p 9898 %s 8080; done", gatewayPodIP)
 
-	cPod, err := spawnClientPodOnNonGatewayNode(clusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
+	cPod, err := spawnClientPodOnNonGatewayNodeWithHostNet(clusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
 		clusterInfo.GetImageRepositoryInfo())
 	if err != nil {
 		status.Failure("Error spawning the client pod on non-Gateway node: %v", err)


### PR DESCRIPTION
In the latest OCP deployments, it is seen that when the
validate-client pod is scheduled it gets terminated pretty
quickly even before its able to send the required data. We
have addressed similar issue earlier by modifying the client
pod to use HostNetworking enabled. This PR implements a similar
change even for diagnose firewall metrics command.

Fixes: https://github.com/submariner-io/subctl/issues/149
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
