### PR TITLE
Remove K8s E2E param, use default

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        # Run tests against the latest K8s version
-        k8s_version: ['1.23']
         lighthouse: ['', 'lighthouse']
     steps:
       - name: Check out the repository
@@ -25,7 +23,6 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
-          k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.globalnet }} ${{ matrix.lighthouse }}
 
       - name: Post mortem


### PR DESCRIPTION
Instead of explicitly setting the K8s version for E2E-Full CI, just use
the default from Shipyard. We typically want to use the same latest-K8s
version in all repos once we test it and make it available in Shipyard.
This will require less maintenance.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
