### PR TITLE
Rework join kubecontext handling using clientcmd

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -23,6 +23,7 @@ import (
 	cpaws "github.com/submariner-io/cloud-prepare/pkg/aws"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	cloudaws "github.com/submariner-io/subctl/pkg/cloud/aws"
 	"github.com/submariner-io/subctl/pkg/cloud/cleanup"
 	"github.com/submariner-io/subctl/pkg/cloud/prepare"
@@ -31,13 +32,15 @@ import (
 var (
 	awsConfig cloudaws.Config
 
+	awsRestConfigProducer = restconfig.NewProducer()
+
 	awsPrepareCmd = &cobra.Command{
 		Use:     "aws",
 		Short:   "Prepare an OpenShift AWS cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on AWS cloud for Submariner installation.",
 		PreRunE: checkAWSFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := prepare.AWS(&restConfigProducer, &cloudPorts, &awsConfig, cli.NewReporter())
+			err := prepare.AWS(&awsRestConfigProducer, &cloudPorts, &awsConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}
@@ -49,7 +52,7 @@ var (
 			" cloud after Submariner uninstallation.",
 		PreRunE: checkAWSFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := cleanup.AWS(&restConfigProducer, &awsConfig, cli.NewReporter())
+			err := cleanup.AWS(&awsRestConfigProducer, &awsConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}

--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cloud/azure"
 	"github.com/submariner-io/subctl/pkg/cloud/cleanup"
 	"github.com/submariner-io/subctl/pkg/cloud/prepare"
@@ -30,13 +31,15 @@ import (
 var (
 	azureConfig azure.Config
 
+	azureRestConfigProducer = restconfig.NewProducer()
+
 	azurePrepareCmd = &cobra.Command{
 		Use:     "azure",
 		Short:   "Prepare an OpenShift Azure cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on Azure cloud for Submariner installation.",
 		PreRunE: checkAzureFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := prepare.Azure(&restConfigProducer, &cloudPorts, &azureConfig, cli.NewReporter())
+			err := prepare.Azure(&azureRestConfigProducer, &cloudPorts, &azureConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}
@@ -48,7 +51,7 @@ var (
 			" cloud after Submariner uninstallation.",
 		PreRunE: checkAzureFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := cleanup.Azure(&restConfigProducer, &azureConfig, cli.NewReporter())
+			err := cleanup.Azure(&azureRestConfigProducer, &azureConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}

--- a/cmd/subctl/benchmark.go
+++ b/cmd/subctl/benchmark.go
@@ -34,6 +34,8 @@ var (
 	intraCluster bool
 	verbose      bool
 
+	benchmarkRestConfigProducer = restconfig.NewProducer()
+
 	benchmarkCmd = &cobra.Command{
 		Use:   "benchmark",
 		Short: "Benchmark tests",
@@ -47,7 +49,7 @@ var (
 			return checkBenchmarkArguments(args, intraCluster)
 		},
 		Run: func(command *cobra.Command, args []string) {
-			err := setUpTestFramework(args, restConfigProducer)
+			err := setUpTestFramework(args, benchmarkRestConfigProducer)
 			exit.OnErrorWithMessage(err, "error setting up test framework")
 			benchmark.StartThroughputTests(intraCluster, verbose)
 		},
@@ -60,7 +62,7 @@ var (
 			return checkBenchmarkArguments(args, intraCluster)
 		},
 		Run: func(command *cobra.Command, args []string) {
-			err := setUpTestFramework(args, restConfigProducer)
+			err := setUpTestFramework(args, benchmarkRestConfigProducer)
 			exit.OnErrorWithMessage(err, "error setting up test framework")
 			benchmark.StartLatencyTests(intraCluster, verbose)
 		},
@@ -79,15 +81,15 @@ func init() {
 }
 
 func addBenchmarkFlags(cmd *cobra.Command) {
-	restConfigProducer.AddKubeContextMultiFlag(cmd, "comma-separated list of one or two kubeconfig contexts to use.")
+	benchmarkRestConfigProducer.AddKubeContextMultiFlag(cmd, "comma-separated list of one or two kubeconfig contexts to use.")
 	cmd.PersistentFlags().BoolVar(&intraCluster, "intra-cluster", false, "run the test within a single cluster")
 	cmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "produce verbose logs during benchmark tests")
 }
 
 func checkBenchmarkArguments(args []string, intraCluster bool) error {
-	if !intraCluster && len(args) != 2 && restConfigProducer.CountRequestedClusters() != 2 {
+	if !intraCluster && len(args) != 2 && benchmarkRestConfigProducer.CountRequestedClusters() != 2 {
 		return fmt.Errorf("two kubecontexts must be specified")
-	} else if intraCluster && len(args) != 1 && restConfigProducer.CountRequestedClusters() != 1 {
+	} else if intraCluster && len(args) != 1 && benchmarkRestConfigProducer.CountRequestedClusters() != 1 {
 		return fmt.Errorf("only one kubecontext should be specified")
 	}
 

--- a/cmd/subctl/cloud.go
+++ b/cmd/subctl/cloud.go
@@ -20,6 +20,7 @@ package subctl
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cloud"
 	"github.com/submariner-io/submariner/pkg/port"
 )
@@ -34,6 +35,8 @@ const (
 
 var (
 	cloudPorts cloud.Ports
+
+	cloudRestConfigProducer = restconfig.NewProducer()
 
 	cloudCmd = &cobra.Command{
 		Use:   "cloud",
@@ -55,7 +58,7 @@ var (
 )
 
 func init() {
-	restConfigProducer.AddKubeContextFlag(cloudCmd)
+	cloudRestConfigProducer.AddKubeContextFlag(cloudCmd)
 	rootCmd.AddCommand(cloudCmd)
 
 	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Natt, "natt-port", port.ExternalTunnel,

--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/subctl/internal/component"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/broker"
 	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/deploy"
@@ -40,6 +41,8 @@ var (
 	defaultComponents = []string{component.ServiceDiscovery, component.Connectivity}
 )
 
+var deployRestConfigProducer = restconfig.NewProducer()
+
 // deployBroker represents the deployBroker command.
 var deployBroker = &cobra.Command{
 	Use:   "deploy-broker",
@@ -47,7 +50,7 @@ var deployBroker = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		status := cli.NewReporter()
 
-		config, err := restConfigProducer.ForCluster()
+		config, err := deployRestConfigProducer.ForCluster()
 		exit.OnError(status.Error(err, "Error creating REST config"))
 
 		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
@@ -64,7 +67,7 @@ var deployBroker = &cobra.Command{
 
 func init() {
 	addDeployBrokerFlags()
-	restConfigProducer.AddKubeContextFlag(deployBroker)
+	deployRestConfigProducer.AddKubeContextFlag(deployBroker)
 	rootCmd.AddCommand(deployBroker)
 }
 

--- a/cmd/subctl/export.go
+++ b/cmd/subctl/export.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/service"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,7 +34,8 @@ var (
 	exportOptions struct {
 		namespace string
 	}
-	exportCmd = &cobra.Command{
+	exportRestConfigProducer = restconfig.NewProducer()
+	exportCmd                = &cobra.Command{
 		Use:   "export",
 		Short: "Exports a resource to other clusters",
 		Long:  "This command exports a resource so it is accessible to other clusters",
@@ -43,17 +45,17 @@ var (
 		Short: "Exports a Service to other clusters",
 		Long: "This command creates a ServiceExport resource with the given name which causes the Service of the same name to be accessible" +
 			" to other clusters",
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: exportRestConfigProducer.CheckVersionMismatch,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := validateArguments(args)
 			exit.OnErrorWithMessage(err, "Insufficient arguments")
 
 			status := cli.NewReporter()
 
-			config, err := restConfigProducer.ForCluster()
+			config, err := exportRestConfigProducer.ForCluster()
 			exit.OnError(status.Error(err, "Error creating REST config"))
 
-			clientConfig := restConfigProducer.ClientConfig()
+			clientConfig := exportRestConfigProducer.ClientConfig()
 			if exportOptions.namespace == "" {
 				if exportOptions.namespace, _, err = clientConfig.Namespace(); err != nil {
 					exportOptions.namespace = "default"
@@ -74,7 +76,7 @@ func init() {
 	err := mcsv1a1.Install(scheme.Scheme)
 	exit.OnErrorWithMessage(err, "Failed to add to scheme")
 
-	restConfigProducer.AddKubeConfigFlag(exportCmd)
+	exportRestConfigProducer.AddKubeConfigFlag(exportCmd)
 	exportServiceCmd.Flags().StringVarP(&exportOptions.namespace, "namespace", "n", "", "namespace of the service to be exported")
 	exportCmd.AddCommand(exportServiceCmd)
 	rootCmd.AddCommand(exportCmd)

--- a/cmd/subctl/gather.go
+++ b/cmd/subctl/gather.go
@@ -28,10 +28,13 @@ import (
 	"github.com/submariner-io/subctl/cmd/subctl/execute"
 	"github.com/submariner-io/subctl/internal/exit"
 	"github.com/submariner-io/subctl/internal/gather"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
 )
 
 var options gather.Options
+
+var gatherRestConfigProducer = restconfig.NewProducer()
 
 var gatherCmd = &cobra.Command{
 	Use:   "gather",
@@ -44,7 +47,7 @@ var gatherCmd = &cobra.Command{
 			options.Directory = "submariner-" + time.Now().UTC().Format("20060102150405") // submariner-YYYYMMDDHHMMSS
 		}
 
-		execute.OnMultiCluster(restConfigProducer, func(info *cluster.Info, status reporter.Interface) bool {
+		execute.OnMultiCluster(gatherRestConfigProducer, func(info *cluster.Info, status reporter.Interface) bool {
 			err := checkGatherArguments()
 			exit.OnErrorWithMessage(err, "Invalid argument")
 
@@ -54,7 +57,7 @@ var gatherCmd = &cobra.Command{
 }
 
 func init() {
-	restConfigProducer.AddKubeContextMultiFlag(gatherCmd, "")
+	gatherRestConfigProducer.AddKubeContextMultiFlag(gatherCmd, "")
 	addGatherFlags(gatherCmd)
 	rootCmd.AddCommand(gatherCmd)
 }

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cloud/cleanup"
 	"github.com/submariner-io/subctl/pkg/cloud/gcp"
 	"github.com/submariner-io/subctl/pkg/cloud/prepare"
@@ -34,13 +35,15 @@ import (
 var (
 	gcpConfig gcp.Config
 
+	gcpRestConfigProducer = restconfig.NewProducer()
+
 	gcpPrepareCmd = &cobra.Command{
 		Use:     "gcp",
 		Short:   "Prepare an OpenShift GCP cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on GCP cloud for Submariner installation.",
 		PreRunE: checkGCPFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := prepare.GCP(&restConfigProducer, &cloudPorts, &gcpConfig, cli.NewReporter())
+			err := prepare.GCP(&gcpRestConfigProducer, &cloudPorts, &gcpConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}
@@ -51,7 +54,7 @@ var (
 		Long:    "This command cleans up an installer-provisioned infrastructure (IPI) on GCP-based cloud after Submariner uninstallation.",
 		PreRunE: checkGCPFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := cleanup.GCP(&restConfigProducer, &gcpConfig, cli.NewReporter())
+			err := cleanup.GCP(&gcpRestConfigProducer, &gcpConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}

--- a/cmd/subctl/generic_cloud.go
+++ b/cmd/subctl/generic_cloud.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cloud/cleanup"
 	"github.com/submariner-io/subctl/pkg/cloud/prepare"
 )
@@ -31,12 +32,14 @@ var (
 		gateways int
 	}
 
+	genericRestConfigProducer = restconfig.NewProducer()
+
 	genericPrepareCmd = &cobra.Command{
 		Use:   "generic",
 		Short: "Prepares a generic cluster for Submariner",
 		Long:  "This command labels the required number of gateway nodes for Submariner installation.",
 		Run: func(cmd *cobra.Command, args []string) {
-			exit.OnError(prepare.GenericCluster(&restConfigProducer, genericCloudConfig.gateways, cli.NewReporter()))
+			exit.OnError(prepare.GenericCluster(&genericRestConfigProducer, genericCloudConfig.gateways, cli.NewReporter()))
 		},
 	}
 
@@ -45,7 +48,7 @@ var (
 		Short: "Cleans up a cluster after Submariner uninstallation",
 		Long:  "This command removes the labels from gateway nodes after Submariner uninstallation.",
 		Run: func(cmd *cobra.Command, args []string) {
-			exit.OnError(cleanup.GenericCluster(&restConfigProducer, cli.NewReporter()))
+			exit.OnError(cleanup.GenericCluster(&genericRestConfigProducer, cli.NewReporter()))
 		},
 	}
 )

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cloud/cleanup"
 	"github.com/submariner-io/subctl/pkg/cloud/prepare"
 	"github.com/submariner-io/subctl/pkg/cloud/rhos"
@@ -30,13 +31,15 @@ import (
 var (
 	rhosConfig rhos.Config
 
+	rhosRestConfigProducer = restconfig.NewProducer()
+
 	rhosPrepareCmd = &cobra.Command{
 		Use:     "rhos",
 		Short:   "Prepare an OpenShift RHOS cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on RHOS cloud for Submariner installation.",
 		PreRunE: checkRHOSFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := prepare.RHOS(&restConfigProducer, &cloudPorts, &rhosConfig, cli.NewReporter())
+			err := prepare.RHOS(&rhosRestConfigProducer, &cloudPorts, &rhosConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}
@@ -48,7 +51,7 @@ var (
 			" cloud after Submariner uninstallation.",
 		PreRunE: checkRHOSFlags,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := cleanup.RHOS(&restConfigProducer, &rhosConfig, cli.NewReporter())
+			err := cleanup.RHOS(&rhosRestConfigProducer, &rhosConfig, cli.NewReporter())
 			exit.OnError(err)
 		},
 	}

--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/subctl/internal/exit"
-	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -39,8 +38,6 @@ func init() {
 	runtime.Must(apiextensionsv1.AddToScheme(scheme.Scheme))
 	runtime.Must(submarinerv1.AddToScheme(scheme.Scheme))
 }
-
-var restConfigProducer = restconfig.NewProducer()
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{

--- a/cmd/subctl/show.go
+++ b/cmd/subctl/show.go
@@ -21,10 +21,13 @@ package subctl
 import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/cmd/subctl/execute"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/internal/show"
 )
 
 var (
+	showRestConfigProducer = restconfig.NewProducer()
+
 	// showCmd represents the show command.
 	showCmd = &cobra.Command{
 		Use:   "show",
@@ -35,54 +38,54 @@ var (
 		Use:     "connections",
 		Short:   "Show cluster connectivity information",
 		Long:    `This command shows information about Submariner endpoint connections with other clusters.`,
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, execute.IfSubmarinerInstalled(show.Connections))
+			execute.OnMultiCluster(showRestConfigProducer, execute.IfSubmarinerInstalled(show.Connections))
 		},
 	}
 	endpointsCmd = &cobra.Command{
 		Use:     "endpoints",
 		Short:   "Show Submariner endpoint information",
 		Long:    `This command shows information about Submariner endpoints in a cluster.`,
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, execute.IfSubmarinerInstalled(show.Endpoints))
+			execute.OnMultiCluster(showRestConfigProducer, execute.IfSubmarinerInstalled(show.Endpoints))
 		},
 	}
 	gatewaysCmd = &cobra.Command{
 		Use:     "gateways",
 		Short:   "Show Submariner gateway summary information",
 		Long:    `This command shows summary information about the Submariner gateways in a cluster.`,
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, execute.IfSubmarinerInstalled(show.Gateways))
+			execute.OnMultiCluster(showRestConfigProducer, execute.IfSubmarinerInstalled(show.Gateways))
 		},
 	}
 	networksCmd = &cobra.Command{
 		Use:     "networks",
 		Short:   "Get information on your cluster related to Submariner",
 		Long:    `This command shows the status of Submariner in your cluster, and the relevant network details from your cluster.`,
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, show.Network)
+			execute.OnMultiCluster(showRestConfigProducer, show.Network)
 		},
 	}
 	versionCmd = &cobra.Command{
 		Use:     "versions",
 		Short:   "Shows Submariner component versions",
 		Long:    `This command shows the versions of the Submariner components in the cluster.`,
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, show.Versions)
+			execute.OnMultiCluster(showRestConfigProducer, show.Versions)
 		},
 	}
 	brokersCmd = &cobra.Command{
 		Use:     "brokers",
 		Short:   "Shows Broker information",
 		Long:    "This command shows information about the Broker in the cluster",
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, show.Brokers)
+			execute.OnMultiCluster(showRestConfigProducer, show.Brokers)
 		},
 	}
 	allCmd = &cobra.Command{
@@ -90,15 +93,15 @@ var (
 		Short: "Show information related to a Submariner cluster",
 		Long: `This command shows information related to a Submariner cluster:
 		      networks, endpoints, gateways, connections, broker and component versions.`,
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
-			execute.OnMultiCluster(restConfigProducer, show.All)
+			execute.OnMultiCluster(showRestConfigProducer, show.All)
 		},
 	}
 )
 
 func init() {
-	restConfigProducer.AddKubeConfigFlag(showCmd)
+	showRestConfigProducer.AddKubeConfigFlag(showCmd)
 	rootCmd.AddCommand(showCmd)
 	showCmd.AddCommand(connectionsCmd)
 	showCmd.AddCommand(endpointsCmd)

--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/service"
 	mcsclient "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/typed/apis/v1alpha1"
 )
@@ -31,7 +32,8 @@ var (
 	unexportOptions struct {
 		namespace string
 	}
-	unexportCmd = &cobra.Command{
+	unexportRestConfigProducer = restconfig.NewProducer()
+	unexportCmd                = &cobra.Command{
 		Use:   "unexport",
 		Short: "Stop a resource from being exported to other clusters",
 		Long:  "This command stops exporting a resource so that it's no longer accessible to other clusters",
@@ -41,17 +43,17 @@ var (
 		Short: "Stop a Service from being exported to other clusters",
 		Long: "This command removes the ServiceExport resource with the given name which in turn stops the Service " +
 			"of the same name from being exported to other clusters",
-		PreRunE: restConfigProducer.CheckVersionMismatch,
+		PreRunE: unexportRestConfigProducer.CheckVersionMismatch,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := validateUnexportArguments(args)
 			exit.OnErrorWithMessage(err, "Insufficient arguments")
 
 			status := cli.NewReporter()
 
-			config, err := restConfigProducer.ForCluster()
+			config, err := unexportRestConfigProducer.ForCluster()
 			exit.OnError(status.Error(err, "Error creating REST config"))
 
-			clientConfig := restConfigProducer.ClientConfig()
+			clientConfig := unexportRestConfigProducer.ClientConfig()
 			if unexportOptions.namespace == "" {
 				if unexportOptions.namespace, _, err = clientConfig.Namespace(); err != nil {
 					unexportOptions.namespace = "default"
@@ -68,7 +70,7 @@ var (
 )
 
 func init() {
-	restConfigProducer.AddKubeContextFlag(unexportCmd)
+	unexportRestConfigProducer.AddKubeContextFlag(unexportCmd)
 	unexportServiceCmd.Flags().StringVarP(&unexportOptions.namespace, "namespace", "n", "", "namespace of the service to be unexported")
 	unexportCmd.AddCommand(unexportServiceCmd)
 	rootCmd.AddCommand(unexportCmd)

--- a/cmd/subctl/uninstall.go
+++ b/cmd/subctl/uninstall.go
@@ -26,6 +26,7 @@ import (
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/uninstall"
 )
@@ -35,15 +36,17 @@ var uninstallOptions struct {
 	namespace string
 }
 
+var uninstallRestConfigProducer = restconfig.NewProducer()
+
 var uninstallCmd = &cobra.Command{
 	Use:     "uninstall",
 	Short:   "Uninstall Submariner and its components",
 	Long:    "This command uninstalls Submariner and its components",
-	PreRunE: restConfigProducer.CheckVersionMismatch,
+	PreRunE: uninstallRestConfigProducer.CheckVersionMismatch,
 	Run: func(cmd *cobra.Command, args []string) {
 		status := cli.NewReporter()
 
-		config, err := restConfigProducer.ForCluster()
+		config, err := uninstallRestConfigProducer.ForCluster()
 		exit.OnError(status.Error(err, "Error creating REST config"))
 
 		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
@@ -72,6 +75,6 @@ func init() {
 		"namespace in which Submariner is installed")
 	uninstallCmd.Flags().BoolVarP(&uninstallOptions.noPrompt, "yes", "y", false, "automatically answer yes to confirmation prompt")
 
-	restConfigProducer.AddKubeConfigFlag(uninstallCmd)
+	uninstallRestConfigProducer.AddKubeConfigFlag(uninstallCmd)
 	rootCmd.AddCommand(uninstallCmd)
 }

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -38,6 +38,7 @@ import (
 	"github.com/submariner-io/subctl/internal/component"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/exit"
+	"github.com/submariner-io/subctl/internal/restconfig"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
 )
@@ -52,6 +53,8 @@ var (
 	verifyOnly                      string
 	disruptiveTests                 bool
 )
+
+var verifyRestConfigProducer = restconfig.NewProducer()
 
 var verifyCmd = &cobra.Command{
 	Use:   "verify --kubecontexts <kubeContext1>,<kubeContext2>",
@@ -78,7 +81,7 @@ The following verifications are deemed disruptive:
 		if len(args) > 0 {
 			fmt.Println("subctl verify with kubeconfig arguments is deprecated, please use --kubecontexts instead")
 		}
-		err := setUpTestFramework(args, restConfigProducer)
+		err := setUpTestFramework(args, verifyRestConfigProducer)
 		exit.OnErrorWithMessage(err, "error setting up test framework")
 
 		disruptive := extractDisruptiveVerifications(verifyOnly)
@@ -115,7 +118,7 @@ prompt for confirmation therefore you must specify --enable-disruptive to run th
 }
 
 func init() {
-	restConfigProducer.AddKubeContextMultiFlag(verifyCmd, "comma-separated list of exactly two kubeconfig contexts to use.")
+	verifyRestConfigProducer.AddKubeContextMultiFlag(verifyCmd, "comma-separated list of exactly two kubeconfig contexts to use.")
 	addVerifyFlags(verifyCmd)
 	rootCmd.AddCommand(verifyCmd)
 
@@ -153,7 +156,7 @@ func isNonInteractive(err error) bool {
 }
 
 func checkValidateArguments(args []string) error {
-	if len(args) != 2 && restConfigProducer.CountRequestedClusters() != 2 {
+	if len(args) != 2 && verifyRestConfigProducer.CountRequestedClusters() != 2 {
 		return fmt.Errorf("two kubecontexts must be specified")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.5.0
+	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/admiral v0.14.0-m0
 	github.com/submariner-io/cloud-prepare v0.14.0-m0
 	github.com/submariner-io/lighthouse v0.14.0-m0
@@ -103,7 +104,6 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/urfave/cli/v2 v2.4.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88 // indirect


### PR DESCRIPTION
This enables all available connection options. We can also use
clientcmd's built-in support for disabling TLS certificate checks,
instead of our own --check-broker-certificate.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
