### PR TITLE
Add missing status.End() to show brokers cmd

### DIFF
--- a/internal/show/brokers.go
+++ b/internal/show/brokers.go
@@ -70,6 +70,7 @@ func Brokers(clusterInfo *cluster.Info, status reporter.Interface) bool {
 		)
 	}
 
+	status.End()
 	printer.Print()
 
 	return true


### PR DESCRIPTION
Fixes issue: #161

Signed-off-by: Maayan Friedman <maafried@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
