### PR TITLE
Mention default cable driver in join help msg

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -108,7 +108,7 @@ func addJoinFlags(cmd *cobra.Command) {
 		"enable Submariner pod debugging (verbose logging in the deployed pods)")
 	cmd.Flags().BoolVar(&joinFlags.OperatorDebug, "operator-debug", false, "enable operator debugging (verbose logging)")
 	cmd.Flags().BoolVar(&labelGateway, "label-gateway", true, "label gateways if necessary")
-	cmd.Flags().StringVar(&joinFlags.CableDriver, "cable-driver", "", "cable driver implementation")
+	cmd.Flags().StringVar(&joinFlags.CableDriver, "cable-driver", "libreswan", "cable driver implementation")
 	cmd.Flags().UintVar(&joinFlags.GlobalnetClusterSize, "globalnet-cluster-size", 0,
 		"cluster size for GlobalCIDR allocated to this cluster (amount of global IPs)")
 	cmd.Flags().StringVar(&joinFlags.GlobalnetCIDR, "globalnet-cidr", "",


### PR DESCRIPTION
While joining a cluster, if the cable driver is not mentioned, the
default is `libreswan`. This information should be displayed while
running `subctl join --help` like this:

```
$ cmd/bin/subctl-devel-c9c8c8c-linux-amd64 join --help
Connect a cluster to an existing broker

Usage:
  subctl join [flags]

Flags:
      --cable-driver string                       cable driver
implementation (default "libreswan")
```

Closes: #166
Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
