### PR TITLE
Display proper output message on `subctl show brokers`

### DIFF
--- a/internal/show/brokers.go
+++ b/internal/show/brokers.go
@@ -45,6 +45,7 @@ func Brokers(clusterInfo *cluster.Info, status reporter.Interface) bool {
 
 	brokers := brokerList.Items
 	if len(brokers) == 0 {
+		status.Success("No brokers found")
 		return true
 	}
 


### PR DESCRIPTION
when broker is not installed on the cluster.

Currently a blank line is displayed. Instead display that "No brokers
found" when a broker is not installed on the cluster.

The output will look like

$ cmd/bin/subctl-devel-59cc4f5-linux-amd64 show brokers
Cluster "cluster2"
 ✓ Detecting broker(s)
 ✓ No brokers found

Closes: #167
Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
