### PR TITLE
Fix KIND deployments using ovn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ undefine SKIP
 undefine FOCUS
 undefine E2E_TESTDIR
 
-ifneq (,$(filter ovn,$(_using)))
+ifneq (,$(filter ovn,$(USING)))
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.ovn.yml
 else
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml


### PR DESCRIPTION
As the `using` flag is needed before it's processed (in Shipyard's
`Makefile.inc`), use the one processed in Shipyard's `Makefile.dapper`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
