### PR TITLE
Use ENV vars instead of flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,6 @@ PLATFORMS ?= linux/amd64,linux/arm64
 IMAGES = subctl
 PRELOAD_IMAGES := $(IMAGES) submariner-operator submariner-gateway submariner-globalnet submariner-route-agent lighthouse-agent lighthouse-coredns nettest
 MULTIARCH_IMAGES := subctl
-undefine SKIP
-undefine FOCUS
-undefine E2E_TESTDIR
 
 ifneq (,$(filter ovn,$(USING)))
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.ovn.yml
@@ -46,7 +43,6 @@ CROSS_BINARIES := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,cmd/bin/subctl-$
 CROSS_TARBALLS := $(foreach cross,$(CROSS_TARGETS),$(patsubst %,dist/subctl-$(VERSION)-%.tar.xz,$(cross)))
 
 override E2E_ARGS += cluster1 cluster2
-override SYSTEM_ARGS += --settings $(SETTINGS) cluster1 cluster2
 export DEPLOY_ARGS
 override UNIT_TEST_ARGS += test internal/env
 override VALIDATE_ARGS += --skip-dirs pkg/client
@@ -74,7 +70,7 @@ deploy: cmd/bin/subctl
 
 # [system-test] runs system level tests for the various `subctl` commands
 system-test:
-	scripts/test/system.sh $(SYSTEM_ARGS)
+	scripts/test/system.sh
 
 clean:
 	rm -f $(BINARIES) $(CROSS_BINARIES) $(CROSS_TARBALLS)

--- a/scripts/test/lib_subctl_gather_test.sh
+++ b/scripts/test/lib_subctl_gather_test.sh
@@ -37,7 +37,7 @@ function validate_gathered_files () {
   validate_pod_log_files $subm_ns '-l name=submariner-operator'
 
   # Service Discovery
-  if [[ "$lighthouse" == "true" ]]; then
+  if [[ "$LIGHTHOUSE" == "true" ]]; then
     validate_resource_files all 'serviceexports.multicluster.x-k8s.io' 'ServiceExport'
     validate_resource_files all 'serviceimports.multicluster.x-k8s.io' 'ServiceImport'
     validate_resource_files all 'endpointslices.discovery.k8s.io' 'EndpointSlice' '-l endpointslice.kubernetes.io/managed-by=lighthouse-agent.submariner.io'

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -16,7 +16,7 @@ function deploy_env_once() {
 
     # Print GHA groups to make looking at CI output easier
     printf "::group::Deploying the environment"
-    make deploy SETTINGS="$settings" using="${USING}" -o package/.image.subctl
+    make deploy SETTINGS="$SETTINGS" using="${USING}" -o package/.image.subctl
     declare_kubeconfig
     echo "::endgroup::" 
 }
@@ -49,7 +49,6 @@ function test_subctl_gather() {
 
 ### Main ###
 
-settings="${DAPPER_SOURCE}/.shipyard.system.yml"
 subm_ns=submariner-operator
 submariner_broker_ns=submariner-k8s-broker
 load_settings


### PR DESCRIPTION
Switch to using Shipyard's ENV vars instead of flags, much simpler to
understand.

Depends on https://github.com/submariner-io/shipyard/pull/890

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
