### PR TITLE
Remove use of client.Producer in internal/gather

### DIFF
--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -29,8 +29,15 @@ import (
 	"github.com/submariner-io/subctl/internal/exit"
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
+	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/client"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
+
+func init() {
+	runtime.Must(operatorv1alpha1.AddToScheme(scheme.Scheme))
+}
 
 var restConfigProducer = restconfig.NewProducer()
 

--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -144,9 +144,9 @@ func gatherOVNResources(info *Info, networkPlugin string) {
 
 	// we check two different labels because OpenShift deploys with a different
 	// label compared to ovn-kubernetes upstream
-	ovnMasterpods, err := findPods(info.ClientProducer.ForKubernetes(), ovnMasterPodLabelOCP)
+	ovnMasterpods, err := findPods(info.KubeClient, ovnMasterPodLabelOCP)
 	if err != nil || ovnMasterpods == nil || len(ovnMasterpods.Items) == 0 {
-		ovnMasterpods, err = findPods(info.ClientProducer.ForKubernetes(), ovnMasterPodLabelGeneric)
+		ovnMasterpods, err = findPods(info.KubeClient, ovnMasterPodLabelGeneric)
 		if err != nil {
 			info.Status.Failure("Failed to gather any OVN master ovnMasterpods: " + err.Error())
 		} else if ovnMasterpods == nil || len(ovnMasterpods.Items) == 0 {
@@ -204,7 +204,7 @@ func execCmdInBash(info *Info, pod *v1.Pod, cmd string) (string, string, error) 
 	execOptions := pods.ExecOptionsFromPod(pod)
 	execConfig := pods.ExecConfig{
 		RestConfig: info.RestConfig,
-		ClientSet:  info.ClientProducer.ForKubernetes(),
+		ClientSet:  info.KubeClient,
 	}
 
 	execOptions.Command = []string{"/bin/bash", "-c", cmd}

--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -22,7 +22,6 @@ import (
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -56,49 +55,25 @@ func gatherAddonPodLogs(info *Info) {
 }
 
 func gatherEndpoints(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "endpoints",
-	}, namespace, v1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerv1.SchemeGroupVersion.WithKind("EndpointList"), namespace, v1.ListOptions{})
 }
 
 func gatherClusters(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "clusters",
-	}, namespace, v1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerv1.SchemeGroupVersion.WithKind("ClusterList"), namespace, v1.ListOptions{})
 }
 
 func gatherGateways(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "gateways",
-	}, namespace, v1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerv1.SchemeGroupVersion.WithKind("GatewayList"), namespace, v1.ListOptions{})
 }
 
 func gatherClusterGlobalEgressIPs(info *Info) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "clusterglobalegressips",
-	}, corev1.NamespaceAll, v1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerv1.SchemeGroupVersion.WithKind("ClusterGlobalEgressIPList"), corev1.NamespaceAll, v1.ListOptions{})
 }
 
 func gatherGlobalEgressIPs(info *Info) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "globalegressips",
-	}, corev1.NamespaceAll, v1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerv1.SchemeGroupVersion.WithKind("GlobalEgressIPList"), corev1.NamespaceAll, v1.ListOptions{})
 }
 
 func gatherGlobalIngressIPs(info *Info) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerv1.SchemeGroupVersion.Group,
-		Version:  submarinerv1.SchemeGroupVersion.Version,
-		Resource: "globalingressips",
-	}, corev1.NamespaceAll, v1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerv1.SchemeGroupVersion.WithKind("GlobalIngressIPList"), corev1.NamespaceAll, v1.ListOptions{})
 }

--- a/internal/gather/logs.go
+++ b/internal/gather/logs.go
@@ -37,7 +37,7 @@ func gatherPodLogs(podLabelSelector string, info *Info) {
 
 func gatherPodLogsByContainer(podLabelSelector, container string, info *Info) {
 	err := func() error {
-		pods, err := findPods(info.ClientProducer.ForKubernetes(), podLabelSelector)
+		pods, err := findPods(info.KubeClient, podLabelSelector)
 		if err != nil {
 			return err
 		}
@@ -131,7 +131,7 @@ func findPods(clientSet kubernetes.Interface, byLabelSelector string) (*corev1.P
 // nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
 func outputPreviousPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, info *Info, podLogInfo *LogInfo) error {
 	podLogOptions.Previous = true
-	logRequest := info.ClientProducer.ForKubernetes().CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOptions)
+	logRequest := info.KubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOptions)
 	logStream, _ := logRequest.Stream(context.TODO())
 
 	// TODO: Check for error other than "no previous pods found"
@@ -161,7 +161,7 @@ func outputPreviousPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, i
 func outputCurrentPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, info *Info, podLogInfo *LogInfo) error {
 	// Running with Previous = false on the same pod
 	podLogOptions.Previous = false
-	logRequest := info.ClientProducer.ForKubernetes().CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOptions)
+	logRequest := info.KubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOptions)
 
 	logStream, err := logRequest.Stream(context.TODO())
 	if err != nil {
@@ -178,7 +178,7 @@ func outputCurrentPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, in
 
 func logPodInfo(info *Info, what, podLabelSelector string, process func(info *Info, pod *corev1.Pod)) {
 	err := func() error {
-		pods, err := findPods(info.ClientProducer.ForKubernetes(), podLabelSelector)
+		pods, err := findPods(info.KubeClient, podLabelSelector)
 		if err != nil {
 			return err
 		}

--- a/internal/gather/operator.go
+++ b/internal/gather/operator.go
@@ -23,23 +23,14 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func gatherSubmariners(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerOp.SchemeGroupVersion.Group,
-		Version:  submarinerOp.SchemeGroupVersion.Version,
-		Resource: "submariners",
-	}, namespace, metav1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerOp.SchemeGroupVersion.WithKind("SubmarinerList"), namespace, metav1.ListOptions{})
 }
 
 func gatherServiceDiscoveries(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    submarinerOp.SchemeGroupVersion.Group,
-		Version:  submarinerOp.SchemeGroupVersion.Version,
-		Resource: "servicediscoveries",
-	}, namespace, metav1.ListOptions{})
+	ResourcesToYAMLFile(info, submarinerOp.SchemeGroupVersion.WithKind("ServiceDiscoveryList"), namespace, metav1.ListOptions{})
 }
 
 func gatherSubmarinerOperatorDeployment(info *Info, namespace string) {

--- a/internal/gather/servicediscovery.go
+++ b/internal/gather/servicediscovery.go
@@ -49,18 +49,18 @@ func gatherCoreDNSPodLogs(info *Info) {
 }
 
 func gatherServiceExports(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    mcsv1a1.GroupName,
-		Version:  mcsv1a1.GroupVersion.Version,
-		Resource: "serviceexports",
+	ResourcesToYAMLFile(info, schema.GroupVersionKind{
+		Group:   mcsv1a1.GroupName,
+		Version: mcsv1a1.GroupVersion.Version,
+		Kind:    "ServiceExport",
 	}, namespace, metav1.ListOptions{})
 }
 
 func gatherServiceImports(info *Info, namespace string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    mcsv1a1.GroupName,
-		Version:  mcsv1a1.GroupVersion.Version,
-		Resource: "serviceimports",
+	ResourcesToYAMLFile(info, schema.GroupVersionKind{
+		Group:   mcsv1a1.GroupName,
+		Version: mcsv1a1.GroupVersion.Version,
+		Kind:    "ServiceImport",
 	}, namespace, metav1.ListOptions{})
 }
 
@@ -70,11 +70,8 @@ func gatherEndpointSlices(info *Info, namespace string) {
 	}
 	labelSelector := labels.Set(labelMap).String()
 
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    discoveryv1.SchemeGroupVersion.Group,
-		Version:  discoveryv1.SchemeGroupVersion.Version,
-		Resource: "endpointslices",
-	}, namespace, metav1.ListOptions{LabelSelector: labelSelector})
+	ResourcesToYAMLFile(info, discoveryv1.SchemeGroupVersion.WithKind("EndpointSliceList"), namespace,
+		metav1.ListOptions{LabelSelector: labelSelector})
 }
 
 func gatherConfigMapCoreDNS(info *Info) {
@@ -114,11 +111,8 @@ func gatherConfigMapCoreDNS(info *Info) {
 
 // gatherLabeledServices gathers a service based on the label provided.
 func gatherLabeledServices(info *Info, label string) {
-	ResourcesToYAMLFile(info, schema.GroupVersionResource{
-		Group:    corev1.SchemeGroupVersion.Group,
-		Version:  corev1.SchemeGroupVersion.Version,
-		Resource: "services",
-	}, corev1.NamespaceAll, metav1.ListOptions{LabelSelector: label})
+	ResourcesToYAMLFile(info, corev1.SchemeGroupVersion.WithKind("ServiceList"), corev1.NamespaceAll,
+		metav1.ListOptions{LabelSelector: label})
 }
 
 func gatherConfigMapLighthouseDNS(info *Info, namespace string) {
@@ -126,6 +120,6 @@ func gatherConfigMapLighthouseDNS(info *Info, namespace string) {
 }
 
 func isCoreDNSTypeOcp(info *Info) bool {
-	pods, err := findPods(info.ClientProducer.ForKubernetes(), ocpCoreDNSPodLabel)
+	pods, err := findPods(info.KubeClient, ocpCoreDNSPodLabel)
 	return err == nil && len(pods.Items) > 0
 }

--- a/internal/gather/summary.go
+++ b/internal/gather/summary.go
@@ -105,7 +105,7 @@ func getVersions(info *Info) version {
 		Subctl: subctlversion.Version,
 	}
 
-	k8sServerVersion, err := info.ClientProducer.ForKubernetes().Discovery().ServerVersion()
+	k8sServerVersion, err := info.KubeClient.Discovery().ServerVersion()
 	if err != nil {
 		fmt.Println("error in getting k8s server version", err)
 		Versions.K8sServer = err.Error()
@@ -208,7 +208,7 @@ func getFormattedIP(ipAddrList, ipaddr string) string {
 
 // nolint:gocritic // hugeParam: listOptions - match K8s API.
 func listNodes(info *Info, listOptions metav1.ListOptions) (*v1.NodeList, error) {
-	nodes, err := info.ClientProducer.ForKubernetes().CoreV1().Nodes().List(context.TODO(), listOptions)
+	nodes, err := info.KubeClient.CoreV1().Nodes().List(context.TODO(), listOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing Nodes")
 	}

--- a/internal/gather/types.go
+++ b/internal/gather/types.go
@@ -21,9 +21,9 @@ package gather
 import (
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
-	"github.com/submariner-io/submariner-operator/pkg/client"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,8 +37,9 @@ type Info struct {
 	DirName              string
 	IncludeSensitiveData bool
 	Summary              *Summary
-	ClientProducer       client.Producer
 	Client               controllerClient.Client
+	// This is needed for operations that aren't (yet) supported by the controller Client (eg, accessing subresources like pod logs).
+	KubeClient kubernetes.Interface
 }
 
 type Summary struct {


### PR DESCRIPTION
...in lieu of controller Client. However we still need the kube client set for subresource operations like get pod logs which aren't supported by the controller Client.
