### PR TITLE
Introduce new client.Producer interface

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -26,7 +26,6 @@ import (
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/subctl/pkg/diagnose"
-	"github.com/submariner-io/submariner-operator/pkg/client"
 )
 
 var (
@@ -75,7 +74,7 @@ var (
 		Long:  "This command checks if Submariner can be deployed on the Kubernetes version.",
 		Run: func(command *cobra.Command, args []string) {
 			execute.OnMultiCluster(restConfigProducer, func(info *cluster.Info, status reporter.Interface) bool {
-				return diagnose.K8sVersion(info.ClientProducer.ForKubernetes(), status)
+				return diagnose.K8sVersion(info.LegacyClientProducer.ForKubernetes(), status)
 			})
 		},
 	}
@@ -87,7 +86,7 @@ var (
 		Run: func(command *cobra.Command, args []string) {
 			execute.OnMultiCluster(restConfigProducer, execute.IfSubmarinerInstalled(
 				func(info *cluster.Info, status reporter.Interface) bool {
-					return diagnose.KubeProxyMode(info.ClientProducer, diagnoseKubeProxyOptions.podNamespace,
+					return diagnose.KubeProxyMode(info.LegacyClientProducer, diagnoseKubeProxyOptions.podNamespace,
 						info.GetImageRepositoryInfo(), status)
 				}))
 		},
@@ -227,10 +226,7 @@ func clusterInfoFromKubeConfig(kubeConfig string) *cluster.Info {
 	config, err := producer.ForCluster()
 	exit.OnErrorWithMessage(err, fmt.Sprintf("The provided kubeconfig %q is invalid", kubeConfig))
 
-	clientProducer, err := client.NewProducerFromRestConfig(config.Config)
-	exit.OnErrorWithMessage(err, fmt.Sprintf("Error creating client producer for kubeconfig %q", kubeConfig))
-
-	clusterInfo, err := cluster.NewInfo("", clientProducer, config.Config)
+	clusterInfo, err := cluster.NewInfo("", config.Config)
 	exit.OnErrorWithMessage(err, fmt.Sprintf("Error initializing cluster information for kubeconfig %q", kubeConfig))
 
 	if clusterInfo.Submariner == nil {
@@ -243,7 +239,7 @@ func clusterInfoFromKubeConfig(kubeConfig string) *cluster.Info {
 }
 
 func diagnoseAll(clusterInfo *cluster.Info, status reporter.Interface) bool {
-	success := diagnose.K8sVersion(clusterInfo.ClientProducer.ForKubernetes(), status)
+	success := diagnose.K8sVersion(clusterInfo.LegacyClientProducer.ForKubernetes(), status)
 
 	fmt.Println()
 
@@ -265,7 +261,7 @@ func diagnoseAll(clusterInfo *cluster.Info, status reporter.Interface) bool {
 
 	fmt.Println()
 
-	success = diagnose.KubeProxyMode(clusterInfo.ClientProducer, diagnoseKubeProxyOptions.podNamespace,
+	success = diagnose.KubeProxyMode(clusterInfo.LegacyClientProducer, diagnoseKubeProxyOptions.podNamespace,
 		clusterInfo.GetImageRepositoryInfo(), status) && success
 
 	fmt.Println()

--- a/cmd/subctl/execute/execute.go
+++ b/cmd/subctl/execute/execute.go
@@ -27,7 +27,6 @@ import (
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
-	"github.com/submariner-io/submariner-operator/pkg/client"
 )
 
 type OnClusterFn func(*cluster.Info, reporter.Interface) bool
@@ -45,15 +44,7 @@ func OnMultiCluster(restConfigProducer restconfig.Producer, run OnClusterFn) {
 	for _, config := range restConfigs {
 		fmt.Printf("Cluster %q\n", config.ClusterName)
 
-		clientProducer, err := client.NewProducerFromRestConfig(config.Config)
-		if err != nil {
-			status.Failure("Error creating the client producer: %v", err)
-			fmt.Println()
-
-			continue
-		}
-
-		clusterInfo, err := cluster.NewInfo(config.ClusterName, clientProducer, config.Config)
+		clusterInfo, err := cluster.NewInfo(config.ClusterName, config.Config)
 		if err != nil {
 			success = false
 

--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -29,7 +29,6 @@ import (
 	"github.com/submariner-io/subctl/internal/exit"
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
-	"github.com/submariner-io/submariner-operator/pkg/client"
 )
 
 var restConfigProducer = restconfig.NewProducer()
@@ -50,10 +49,7 @@ func Execute() {
 }
 
 func setupTestFrameworkBeforeSuite() {
-	clientProducer, err := client.NewProducerFromRestConfig(framework.RestConfigs[framework.ClusterA])
-	exit.OnErrorWithMessage(err, "Error creating client producer")
-
-	clusterInfo, err := cluster.NewInfo(framework.TestContext.ClusterIDs[framework.ClusterA], clientProducer,
+	clusterInfo, err := cluster.NewInfo(framework.TestContext.ClusterIDs[framework.ClusterA],
 		framework.RestConfigs[framework.ClusterA])
 	exit.OnErrorWithMessage(err, "Error initializing the cluster information")
 

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -108,7 +108,7 @@ func gatherDataByCluster(clusterInfo *cluster.Info, status reporter.Interface, o
 		DirName:              options.Directory,
 		IncludeSensitiveData: options.IncludeSensitiveData,
 		Summary:              &Summary{},
-		ClientProducer:       clusterInfo.ClientProducer,
+		ClientProducer:       clusterInfo.LegacyClientProducer,
 		Client:               clusterInfo.Client,
 		Submariner:           clusterInfo.Submariner,
 		ServiceDiscovery:     &v1alpha1.ServiceDiscovery{},

--- a/internal/show/network.go
+++ b/internal/show/network.go
@@ -45,8 +45,8 @@ func Network(clusterInfo *cluster.Info, status reporter.Interface) bool {
 	} else {
 		msg = "    Discovered network details"
 
-		clusterNetwork, err = network.Discover(clusterInfo.ClientProducer.ForDynamic(), clusterInfo.ClientProducer.ForKubernetes(),
-			clusterInfo.ClientProducer.ForOperator(), constants.OperatorNamespace)
+		clusterNetwork, err = network.Discover(clusterInfo.LegacyClientProducer.ForDynamic(), clusterInfo.LegacyClientProducer.ForKubernetes(),
+			clusterInfo.LegacyClientProducer.ForOperator(), constants.OperatorNamespace)
 		if err != nil {
 			status.Failure("There was an error discovering network details for this cluster", err)
 			status.End()

--- a/internal/show/versions.go
+++ b/internal/show/versions.go
@@ -35,7 +35,7 @@ import (
 )
 
 func getOperatorVersion(clusterInfo *cluster.Info) ([]interface{}, error) {
-	deployments := clusterInfo.ClientProducer.ForKubernetes().AppsV1().Deployments(constants.OperatorNamespace)
+	deployments := clusterInfo.LegacyClientProducer.ForKubernetes().AppsV1().Deployments(constants.OperatorNamespace)
 
 	operatorDeployment, err := deployments.Get(context.TODO(), names.OperatorComponent, v1.GetOptions{})
 	if err != nil {

--- a/pkg/client/default_producer.go
+++ b/pkg/client/default_producer.go
@@ -1,0 +1,43 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DefaultProducer struct {
+	KubeClient    kubernetes.Interface
+	DynamicClient dynamic.Interface
+	GeneralClient client.Client
+}
+
+func (p *DefaultProducer) ForKubernetes() kubernetes.Interface {
+	return p.KubeClient
+}
+
+func (p *DefaultProducer) ForDynamic() dynamic.Interface {
+	return p.DynamicClient
+}
+
+func (p *DefaultProducer) ForGeneral() client.Client {
+	return p.GeneralClient
+}

--- a/pkg/client/producer.go
+++ b/pkg/client/producer.go
@@ -1,0 +1,37 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Producer interface {
+	// This is a general client that can be used for any resource type and for most operations.
+	ForGeneral() client.Client
+
+	// This is needed for operations that aren't supported by the general client (eg, accessing subresources like pod logs).
+	ForKubernetes() kubernetes.Interface
+
+	// While the general client supports Unstructured, this client provides a direct API via GVR which may be easier or
+	// preferable in some cases.
+	ForDynamic() dynamic.Interface
+}

--- a/pkg/client/restconfig_producer.go
+++ b/pkg/client/restconfig_producer.go
@@ -1,0 +1,49 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewProducerFromRestConfig(config *rest.Config) (Producer, error) {
+	var err error
+	p := &DefaultProducer{}
+
+	p.KubeClient, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating kube client")
+	}
+
+	p.DynamicClient, err = dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating dynamic client")
+	}
+
+	p.GeneralClient, err = client.New(config, client.Options{})
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating controller client")
+	}
+
+	return p, nil
+}

--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/image"
 	"github.com/submariner-io/submariner-operator/api/submariner/v1alpha1"
-	"github.com/submariner-io/submariner-operator/pkg/client"
+	operatorClient "github.com/submariner-io/submariner-operator/pkg/client"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,18 +37,20 @@ import (
 )
 
 type Info struct {
-	Name           string
-	RestConfig     *rest.Config
-	ClientProducer client.Producer
-	Client         controllerClient.Client
-	Submariner     *v1alpha1.Submariner
+	Name       string
+	RestConfig *rest.Config
+	// TODO - will be replaced by ClientProducer.
+	LegacyClientProducer operatorClient.Producer
+	ClientProducer       client.Producer
+	// TODO - will be replaced by ClientProducer.
+	Client     controllerClient.Client
+	Submariner *v1alpha1.Submariner
 }
 
-func NewInfo(clusterName string, clientProducer client.Producer, config *rest.Config) (*Info, error) {
+func NewInfo(clusterName string, config *rest.Config) (*Info, error) {
 	info := &Info{
-		Name:           clusterName,
-		RestConfig:     config,
-		ClientProducer: clientProducer,
+		Name:       clusterName,
+		RestConfig: config,
 	}
 
 	var err error
@@ -57,8 +60,18 @@ func NewInfo(clusterName string, clientProducer client.Producer, config *rest.Co
 		return nil, errors.Wrap(err, "error creating client")
 	}
 
+	info.LegacyClientProducer, err = operatorClient.NewProducerFromRestConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating client producer")
+	}
+
+	info.ClientProducer, err = client.NewProducerFromRestConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating client producer")
+	}
+
 	submariner := &v1alpha1.Submariner{}
-	err = info.Client.Get(context.TODO(), controllerClient.ObjectKey{
+	err = info.ClientProducer.ForGeneral().Get(context.TODO(), controllerClient.ObjectKey{
 		Namespace: constants.SubmarinerNamespace,
 		Name:      names.SubmarinerCrName,
 	}, submariner)
@@ -73,7 +86,7 @@ func NewInfo(clusterName string, clientProducer client.Producer, config *rest.Co
 }
 
 func (c *Info) GetGateways() ([]submarinerv1.Gateway, error) {
-	gateways, err := c.ClientProducer.ForSubmariner().SubmarinerV1().
+	gateways, err := c.LegacyClientProducer.ForSubmariner().SubmarinerV1().
 		Gateways(constants.OperatorNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -87,7 +100,7 @@ func (c *Info) GetGateways() ([]submarinerv1.Gateway, error) {
 }
 
 func (c *Info) HasSingleNode() (bool, error) {
-	nodes, err := c.ClientProducer.ForKubernetes().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodes, err := c.LegacyClientProducer.ForKubernetes().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return false, errors.Wrap(err, "error listing Nodes")
 	}
@@ -96,7 +109,7 @@ func (c *Info) HasSingleNode() (bool, error) {
 }
 
 func (c *Info) GetLocalEndpoint() (*submarinerv1.Endpoint, error) {
-	endpoints, err := c.ClientProducer.ForSubmariner().SubmarinerV1().Endpoints(constants.OperatorNamespace).List(
+	endpoints, err := c.LegacyClientProducer.ForSubmariner().SubmarinerV1().Endpoints(constants.OperatorNamespace).List(
 		context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing Endpoints")
@@ -115,7 +128,7 @@ func (c *Info) GetLocalEndpoint() (*submarinerv1.Endpoint, error) {
 }
 
 func (c *Info) GetAnyRemoteEndpoint() (*submarinerv1.Endpoint, error) {
-	endpoints, err := c.ClientProducer.ForSubmariner().SubmarinerV1().Endpoints(constants.OperatorNamespace).List(
+	endpoints, err := c.LegacyClientProducer.ForSubmariner().SubmarinerV1().Endpoints(constants.OperatorNamespace).List(
 		context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing Endpoints")

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -110,7 +110,7 @@ func checkCalicoIPPoolsIfCalicoCNI(info *cluster.Info, status reporter.Interface
 	status.Start("Trying to detect the Calico ConfigMap")
 	defer status.End()
 
-	found, err := detectCalicoConfigMap(info.ClientProducer.ForKubernetes())
+	found, err := detectCalicoConfigMap(info.LegacyClientProducer.ForKubernetes())
 	if err != nil {
 		status.Failure("Error trying to detect the Calico ConfigMap: %s", err)
 		return false
@@ -133,7 +133,7 @@ func checkCalicoIPPoolsIfCalicoCNI(info *cluster.Info, status reporter.Interface
 		return false
 	}
 
-	client := info.ClientProducer.ForDynamic().Resource(calicoGVR)
+	client := info.LegacyClientProducer.ForDynamic().Resource(calicoGVR)
 
 	ippoolList, err := client.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -227,7 +227,7 @@ func checkOVNVersion(info *cluster.Info, status reporter.Interface) bool {
 	status.Start("Checking OVN version")
 	defer status.End()
 
-	clientSet := info.ClientProducer.ForKubernetes()
+	clientSet := info.LegacyClientProducer.ForKubernetes()
 
 	ovnPod, err := mustFindPod(clientSet, ovnKubeDBPodLabel)
 	if err != nil {

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -45,7 +45,7 @@ func checkOverlappingCIDRs(clusterInfo *cluster.Info, status reporter.Interface)
 
 	defer status.End()
 
-	endpointList, err := clusterInfo.ClientProducer.ForSubmariner().SubmarinerV1().Endpoints(clusterInfo.Submariner.Namespace).List(
+	endpointList, err := clusterInfo.LegacyClientProducer.ForSubmariner().SubmarinerV1().Endpoints(clusterInfo.Submariner.Namespace).List(
 		context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		status.Failure("Error listing the Submariner endpoints: %v", err)
@@ -104,26 +104,26 @@ func checkPods(clusterInfo *cluster.Info, status reporter.Interface) bool {
 
 	tracker := reporter.NewTracker(status)
 
-	checkDaemonset(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-gateway", tracker)
-	checkDaemonset(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-routeagent", tracker)
+	checkDaemonset(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-gateway", tracker)
+	checkDaemonset(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-routeagent", tracker)
 
 	// Check if service-discovery components are deployed and running if enabled
 	if clusterInfo.Submariner.Spec.ServiceDiscoveryEnabled {
-		checkDeployment(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-lighthouse-agent", tracker)
-		checkDeployment(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-lighthouse-coredns", tracker)
+		checkDeployment(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-lighthouse-agent", tracker)
+		checkDeployment(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-lighthouse-coredns", tracker)
 	}
 
 	// Check if globalnet components are deployed and running if enabled
 	if clusterInfo.Submariner.Spec.GlobalCIDR != "" {
-		checkDaemonset(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-globalnet", tracker)
+		checkDaemonset(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-globalnet", tracker)
 	}
 
 	// check if networkplugin syncer components are deployed and running if enabled
 	if clusterInfo.Submariner.Status.NetworkPlugin == cni.OVNKubernetes {
-		checkDeployment(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-networkplugin-syncer", tracker)
+		checkDeployment(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-networkplugin-syncer", tracker)
 	}
 
-	checkPodsStatus(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, tracker)
+	checkPodsStatus(clusterInfo.LegacyClientProducer.ForKubernetes(), constants.OperatorNamespace, tracker)
 
 	if tracker.HasFailures() {
 		return false

--- a/pkg/diagnose/firewall_metrics.go
+++ b/pkg/diagnose/firewall_metrics.go
@@ -49,7 +49,7 @@ func FirewallMetricsConfig(clusterInfo *cluster.Info, options FirewallOptions, s
 
 	podCommand := fmt.Sprintf("timeout %d %s", options.ValidationTimeout, tcpSniffMetricsCommand)
 
-	sPod, err := spawnSnifferPodOnGatewayNode(clusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
+	sPod, err := spawnSnifferPodOnGatewayNode(clusterInfo.LegacyClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
 		clusterInfo.GetImageRepositoryInfo())
 	if err != nil {
 		status.Failure("Error spawning the sniffer pod on the Gateway node: %v", err)
@@ -61,7 +61,7 @@ func FirewallMetricsConfig(clusterInfo *cluster.Info, options FirewallOptions, s
 	gatewayPodIP := sPod.Pod.Status.HostIP
 	podCommand = fmt.Sprintf("for i in $(seq 10); do timeout 2 nc -p 9898 %s 8080; done", gatewayPodIP)
 
-	cPod, err := spawnClientPodOnNonGatewayNodeWithHostNet(clusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
+	cPod, err := spawnClientPodOnNonGatewayNodeWithHostNet(clusterInfo.LegacyClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
 		clusterInfo.GetImageRepositoryInfo())
 	if err != nil {
 		status.Failure("Error spawning the client pod on non-Gateway node: %v", err)

--- a/pkg/diagnose/firewall_vxlan.go
+++ b/pkg/diagnose/firewall_vxlan.go
@@ -86,7 +86,7 @@ func checkFWConfig(clusterInfo *cluster.Info, options FirewallOptions, status re
 
 	podCommand := fmt.Sprintf("timeout %d %s", options.ValidationTimeout, tcpSniffVxLANCommand)
 
-	sPod, err := spawnSnifferPodOnNode(clusterInfo.ClientProducer.ForKubernetes(), gwNodeName, options.PodNamespace, podCommand,
+	sPod, err := spawnSnifferPodOnNode(clusterInfo.LegacyClientProducer.ForKubernetes(), gwNodeName, options.PodNamespace, podCommand,
 		clusterInfo.GetImageRepositoryInfo())
 	if err != nil {
 		status.Failure("Error spawning the sniffer pod on the Gateway node: %v", err)
@@ -98,7 +98,7 @@ func checkFWConfig(clusterInfo *cluster.Info, options FirewallOptions, status re
 	remoteClusterIP := strings.Split(remoteEndpoint.Spec.Subnets[0], "/")[0]
 	podCommand = fmt.Sprintf("nc -w %d %s 8080", options.ValidationTimeout/2, remoteClusterIP)
 
-	cPod, err := spawnClientPodOnNonGatewayNode(clusterInfo.ClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
+	cPod, err := spawnClientPodOnNonGatewayNode(clusterInfo.LegacyClientProducer.ForKubernetes(), options.PodNamespace, podCommand,
 		clusterInfo.GetImageRepositoryInfo())
 	if err != nil {
 		status.Failure("Error spawning the client pod on non-Gateway node: %v", err)

--- a/pkg/diagnose/globalnet.go
+++ b/pkg/diagnose/globalnet.go
@@ -61,7 +61,7 @@ func GlobalnetConfig(clusterInfo *cluster.Info, status reporter.Interface) bool 
 }
 
 func checkClusterGlobalEgressIPs(clusterInfo *cluster.Info, status reporter.Interface) {
-	clusterGlobalEgress, err := clusterInfo.ClientProducer.ForSubmariner().SubmarinerV1().ClusterGlobalEgressIPs(
+	clusterGlobalEgress, err := clusterInfo.LegacyClientProducer.ForSubmariner().SubmarinerV1().ClusterGlobalEgressIPs(
 		corev1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		status.Failure("Error listing the ClusterGlobalEgressIP resources: %v", err)
@@ -113,7 +113,7 @@ func checkClusterGlobalEgressIPs(clusterInfo *cluster.Info, status reporter.Inte
 }
 
 func checkGlobalEgressIPs(clusterInfo *cluster.Info, status reporter.Interface) {
-	globalEgressIps, err := clusterInfo.ClientProducer.ForSubmariner().SubmarinerV1().GlobalEgressIPs(
+	globalEgressIps, err := clusterInfo.LegacyClientProducer.ForSubmariner().SubmarinerV1().GlobalEgressIPs(
 		corev1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		status.Failure("Error obtaining GlobalEgressIPs resources: %v", err)
@@ -152,7 +152,7 @@ func checkGlobalIngressIPs(clusterInfo *cluster.Info, status reporter.Interface)
 		Resource: "serviceexports",
 	}
 
-	serviceExports, err := clusterInfo.ClientProducer.ForDynamic().Resource(*serviceExportGVR).Namespace(corev1.NamespaceAll).
+	serviceExports, err := clusterInfo.LegacyClientProducer.ForDynamic().Resource(*serviceExportGVR).Namespace(corev1.NamespaceAll).
 		List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		status.Failure("Error listing ServiceExport resources: %v", err)
@@ -163,7 +163,7 @@ func checkGlobalIngressIPs(clusterInfo *cluster.Info, status reporter.Interface)
 		ns := serviceExports.Items[i].GetNamespace()
 		name := serviceExports.Items[i].GetName()
 
-		svc, err := clusterInfo.ClientProducer.ForKubernetes().CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		svc, err := clusterInfo.LegacyClientProducer.ForKubernetes().CoreV1().Services(ns).Get(context.TODO(), name, metav1.GetOptions{})
 
 		if apierrors.IsNotFound(err) {
 			status.Warning("No matching Service resource found for exported service \"%s/%s\"", ns, name)
@@ -179,7 +179,7 @@ func checkGlobalIngressIPs(clusterInfo *cluster.Info, status reporter.Interface)
 			continue
 		}
 
-		globalIngress, err := clusterInfo.ClientProducer.ForSubmariner().SubmarinerV1().GlobalIngressIPs(ns).Get(context.TODO(),
+		globalIngress, err := clusterInfo.LegacyClientProducer.ForSubmariner().SubmarinerV1().GlobalIngressIPs(ns).Get(context.TODO(),
 			name, metav1.GetOptions{})
 
 		if apierrors.IsNotFound(err) {
@@ -216,7 +216,7 @@ func checkGlobalIngressIPs(clusterInfo *cluster.Info, status reporter.Interface)
 func verifyInternalService(clusterInfo *cluster.Info, status reporter.Interface, ns, name string,
 	globalIngress *submarinerv1.GlobalIngressIP,
 ) {
-	svcs, err := clusterInfo.ClientProducer.ForKubernetes().CoreV1().Services(ns).List(
+	svcs, err := clusterInfo.LegacyClientProducer.ForKubernetes().CoreV1().Services(ns).List(
 		context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("submariner.io/exportedServiceRef=%s", name)})
 	if err != nil {
 		status.Failure("Error listing internal Services \"%s/%s\": %v", ns, name, err)


### PR DESCRIPTION
This replaces the `client.Producer` interface in the **submariner-operator** repo which isn't used in **submariner-operator**. The new interface provides 3 clients (see the comments in the code).

Also redefine the `ClientProducer` field as the new `client.Producer` in `cluster.Info` and rename the previous field to `LegacyClientProducer`. Users will be migrated in subsequent PRs.