### PR TITLE
Re-ignore nilerr false issues for go 1.18 linting

### DIFF
--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -370,8 +370,7 @@ func ConfigureTestFramework(args []string) error {
 
 		clusterName, err := rcp.ClusterNameFromContext()
 		if err != nil {
-			// nilerr is currently disabled because of go1.18. Remove the TODO below when nilerr is re-enabled.
-			// TODO nolint:nilerr // This is intentional.
+			// nolint:nilerr // This is intentional.
 			return nil
 		}
 

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -172,8 +172,7 @@ func WaitForClientToken(kubeClient kubernetes.Interface, submarinerBrokerSA, inN
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		secret, lastErr = rbac.GetClientTokenSecret(kubeClient, inNamespace, submarinerBrokerSA)
 		if lastErr != nil {
-			// nilerr is currently disabled because of go1.18. Remove the TODO below when nilerr is re-enabled.
-			// TODO nolint:nilerr // Intentional - the error is propagated via the outer-scoped var 'lastErr'
+			// nolint:nilerr // Intentional - the error is propagated via the outer-scoped var 'lastErr'
 			return false, nil
 		}
 


### PR DESCRIPTION
When we bump Shipyard to golangci-lint 1.47.3, golang 1.18 limitations
for nilerr will be fixed and these isses are flagged again.

Depends on https://github.com/submariner-io/shipyard/pull/899
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
