### PR TITLE
Remove use of Shipyard `compile.sh` flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export BASE_BRANCH
 export DEFAULT_IMAGE_VERSION
 
 DEFAULT_REPO ?= "quay.io/submariner"
+BUILD_UPX=false
 
 # Define LOCAL_BUILD to build directly on the host and not inside a Dapper container
 ifdef LOCAL_BUILD
@@ -79,7 +80,6 @@ build: $(BINARIES)
 
 build-cross: $(CROSS_TARBALLS)
 
-licensecheck: BUILD_ARGS=--noupx
 licensecheck: build | bin/lichen
 	bin/lichen -c .lichen.yaml $(BINARIES)
 
@@ -113,11 +113,10 @@ cmd/bin/subctl-%: $(shell find . -name "*.go") $(VENDOR_MODULES)
 	GOOS=$${components[-2]}; \
 	GOARCH=$${components[-1]}; \
 	export GOARCH GOOS; \
-	$(SCRIPTS_DIR)/compile.sh \
-		--ldflags "-X 'github.com/submariner-io/subctl/pkg/version.Version=$(VERSION)' \
-		       -X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}' \
-		       -X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultRepo=$(DEFAULT_REPO)'" \
-        --noupx $@ ./cmd $(BUILD_ARGS)
+	LDFLAGS="-X 'github.com/submariner-io/subctl/pkg/version.Version=$(VERSION)' \
+		-X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}' \
+		-X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultRepo=$(DEFAULT_REPO)'" \
+	$(SCRIPTS_DIR)/compile.sh $@ ./cmd
 
 ci: golangci-lint markdownlint unit build images
 


### PR DESCRIPTION
Shipyard's switching to ENV vars, adjust accordingly.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
