### PR TITLE
Remove use of deprecated MCS SchemeGroupVersion

### DIFF
--- a/pkg/diagnose/globalnet.go
+++ b/pkg/diagnose/globalnet.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/globalnet/constants"
@@ -149,7 +150,7 @@ func checkGlobalEgressIPs(clusterInfo *cluster.Info, status reporter.Interface) 
 }
 
 func checkGlobalIngressIPs(clusterInfo *cluster.Info, status reporter.Interface) {
-	serviceExportGVR := mcsv1a1.SchemeGroupVersion.WithResource("serviceexports")
+	serviceExportGVR := gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceexports")
 
 	serviceExports, err := clusterInfo.ClientProducer.ForDynamic().Resource(serviceExportGVR).Namespace(corev1.NamespaceAll).
 		List(context.TODO(), metav1.ListOptions{})

--- a/pkg/service/export.go
+++ b/pkg/service/export.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/client"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,9 +48,9 @@ func Export(clientProducer client.Producer, serviceNamespace, svcName string, st
 		return status.Error(err, "Failed to convert to Unstructured")
 	}
 
-	gvr := mcsv1a1.SchemeGroupVersion.WithResource("serviceexports")
+	serviceExportGVR := gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceexports")
 
-	_, err = clientProducer.ForDynamic().Resource(gvr).Namespace(serviceNamespace).
+	_, err = clientProducer.ForDynamic().Resource(serviceExportGVR).Namespace(serviceNamespace).
 		Create(context.TODO(), resourceServiceExport, metav1.CreateOptions{})
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {


### PR DESCRIPTION
Use the `GroupVersion` instead.
