### PR TITLE
Remove deprecated --ikeport

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -40,9 +40,6 @@ import (
 var (
 	joinFlags    join.Options
 	labelGateway bool
-
-	// Deprecated: will be removed in 0.14.
-	ignoredIkePort int
 )
 
 var joinCmd = &cobra.Command{
@@ -96,8 +93,6 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&joinFlags.Repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&joinFlags.ImageVersion, "version", "", "image version")
 	cmd.Flags().IntVar(&joinFlags.NATTPort, "nattport", 4500, "IPsec NATT port")
-	cmd.Flags().IntVar(&ignoredIkePort, "ikeport", 500, "IPsec IKE port")
-	_ = cmd.Flags().MarkDeprecated("ikeport", "the IKE port setting is ignored")
 	cmd.Flags().BoolVar(&joinFlags.NATTraversal, "natt", true, "enable NAT traversal for IPsec")
 
 	cmd.Flags().BoolVar(&joinFlags.PreferredServer, "preferred-server", false,


### PR DESCRIPTION
--ikeport was deprecated in 0.13, remove it for 0.14.

Depends on https://github.com/submariner-io/shipyard/pull/919
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
