### PR TITLE
Remove deprecated --metrics-port

### DIFF
--- a/cmd/subctl/cloud.go
+++ b/cmd/subctl/cloud.go
@@ -19,9 +19,6 @@ limitations under the License.
 package subctl
 
 import (
-	"strconv"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/subctl/pkg/cloud"
 	"github.com/submariner-io/submariner/pkg/port"
@@ -71,31 +68,7 @@ func init() {
 
 	cloudPrepareCmd.PersistentFlags().Var(&uint16Slice{value: &cloudPorts.Metrics}, "metrics-ports", "Metrics ports")
 
-	cloudPrepareCmd.PersistentFlags().Var(&metricsAliasType{}, "metrics-port", "Metrics port")
-	_ = cloudPrepareCmd.PersistentFlags().MarkDeprecated("metrics-port", "Use metrics-ports instead")
-
 	cloudCmd.AddCommand(cloudPrepareCmd)
 
 	cloudCmd.AddCommand(cloudCleanupCmd)
-}
-
-type metricsAliasType struct{}
-
-func (m metricsAliasType) String() string {
-	return strconv.FormatUint(uint64(cloudPorts.Metrics[0]), 10)
-}
-
-func (m metricsAliasType) Set(s string) error {
-	v, err := strconv.ParseUint(s, 0, 16)
-	if err != nil {
-		return errors.Wrap(err, "conversion to uint16 failed")
-	}
-
-	cloudPorts.Metrics = []uint16{uint16(v)}
-
-	return nil
-}
-
-func (m metricsAliasType) Type() string {
-	return "uint16"
 }


### PR DESCRIPTION
--metrics-port was deprecated in 0.13, remove it for 0.14.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
