### PR TITLE
Fix default image repo/version in compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ cmd/bin/subctl-%: $(shell find . -name "*.go") $(VENDOR_MODULES)
 	GOARCH=$${components[-1]}; \
 	export GOARCH GOOS; \
 	LDFLAGS="-X 'github.com/submariner-io/subctl/pkg/version.Version=$(VERSION)' \
-		-X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}' \
-		-X 'github.com/submariner-io/submariner-operator/api/submariner/v1alpha1.DefaultRepo=$(DEFAULT_REPO)'" \
+		-X 'github.com/submariner-io/submariner-operator/api/v1alpha1.DefaultSubmarinerOperatorVersion=$${DEFAULT_IMAGE_VERSION#v}' \
+		-X 'github.com/submariner-io/submariner-operator/api/v1alpha1.DefaultRepo=$(DEFAULT_REPO)'" \
 	$(SCRIPTS_DIR)/compile.sh $@ ./cmd
 
 ci: golangci-lint markdownlint unit build images


### PR DESCRIPTION
This has been broken by a change in operator repo, fix to use the
updated package.

Resolves #222 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
