### PR TITLE
cloud-prepare: Don't open metrics port

### DIFF
--- a/cmd/subctl/cloud.go
+++ b/cmd/subctl/cloud.go
@@ -64,9 +64,10 @@ func init() {
 		port.NATTDiscovery, "NAT discovery port")
 	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Vxlan, "vxlan-port", port.IntraClusterVxLAN, "Internal VXLAN port")
 
-	cloudPorts.Metrics = append(cloudPorts.Metrics, 8080, 8081)
+	ports := []uint16{}
 
-	cloudPrepareCmd.PersistentFlags().Var(&uint16Slice{value: &cloudPorts.Metrics}, "metrics-ports", "Metrics ports")
+	cloudPrepareCmd.PersistentFlags().Var(&uint16Slice{value: &ports}, "metrics-ports", "Metrics ports")
+	_ = cloudPrepareCmd.PersistentFlags().MarkDeprecated("metrics-ports", "Metrics ports are no longer used, this flag is ignored")
 
 	cloudCmd.AddCommand(cloudPrepareCmd)
 

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -22,5 +22,4 @@ type Ports struct {
 	Natt         uint16
 	NatDiscovery uint16
 	Vxlan        uint16
-	Metrics      []uint16
 }

--- a/pkg/cloud/prepare/prepare.go
+++ b/pkg/cloud/prepare/prepare.go
@@ -76,13 +76,6 @@ func getPortConfig(restcfg *restconfig.Producer, ports *cloud.Ports, useNumericE
 
 	input := api.PrepareForSubmarinerInput{}
 
-	for i := range ports.Metrics {
-		port := api.PortSpec{
-			Port: ports.Metrics[i], Protocol: "tcp",
-		}
-		input.InternalPorts = append(input.InternalPorts, port)
-	}
-
 	nwDetails, err := getNetworkDetails(restcfg)
 	if err != nil {
 		return gwPorts, input, errors.Wrapf(err, "failed to discover the network details in the cluster")


### PR DESCRIPTION
With the redesign of metrics, we don't need to open metrics port in the
cloud anymore. This also marks the `metrics-ports` flag as deprecated.

Refer submariner-io/enhancements/pull/128
Depends On submariner-io/submariner-operator/pull/2182

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
