### PR TITLE
Minimize GHA permissions

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -4,6 +4,8 @@ name: Branch Checks
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   target_branch:
     name: PR targets branch

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -7,6 +7,8 @@ on:
       - 'CODEOWNERS'
       - 'CODEOWNERS.in'
 
+permissions: {}
+
 jobs:
   updated:
     name: Up-to-date

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types: [ready_for_review, opened, reopened, synchronize, converted_to_draft, labeled]
 
+permissions: {}
+
 jobs:
   cross:
     name: Cross-Build

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -19,6 +19,11 @@ on:
   schedule:
     - cron: '0 0/6 * * *'  # every 6 hours
 
+permissions:
+  issues: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   check:
     name: Check Dependencies

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types: [labeled, opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   e2e:
     name: E2E

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,8 @@ name: End to End Default
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   e2e:
     name: E2E

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,8 @@ name: Linting
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   apply-suggestions-commits:
     name: 'No "Apply suggestions from code review" Commits'

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -4,6 +4,8 @@ name: Multi-arch Builds
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   check-multiarch:
     name: Check the multi-arch builds

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions: {}
+
 jobs:
   markdown-link-check-periodic:
     name: Markdown Links (all files)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
       - devel
       - release-*
 
+permissions: {}
+
 jobs:
   release:
     name: Release Images

--- a/.github/workflows/release_subctl_on_push.yml
+++ b/.github/workflows/release_subctl_on_push.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - devel
 
+permissions: {}
+
 jobs:
   release-subctl-on-push:
     if: github.repository_owner == 'submariner-io'

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -7,11 +7,15 @@ on:
       - devel
       - release-*
 
+permissions: {}
+
 jobs:
   vulnerability-scan:
     name: Vulnerability Scanning
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -4,6 +4,8 @@ name: System Tests
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   system-test:
     name: Subctl Commands

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - 'v**'
 
+permissions: {}
+
 jobs:
   unit-testing:
     name: Go Unit Tests

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -6,6 +6,8 @@ on:
     types: [ready_for_review, opened, reopened, synchronize, converted_to_draft, labeled]
     branches: [devel]
 
+permissions: {}
+
 jobs:
   upgrade-e2e:
     name: Latest Release to Latest Version


### PR DESCRIPTION
Set the GitHub Actions token permission to null in most workflows.

This results in:

GITHUB_TOKEN Permissions
  Metadata: read

The default permissions, used without the null override, are either

GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write

or

GITHUB_TOKEN Permissions
  Actions: read
  Checks: read
  Contents: read
  Deployments: read
  Discussions: read
  Issues: read
  Metadata: read
  Packages: read
  Pages: read
  PullRequests: read
  RepositoryProjects: read
  SecurityEvents: read
  Statuses: read

Jobs triggered by PRs get read permissions, other jobs get write.

Two jobs require non-null permissions to function.

The Anchore vulnerability scan GHA that reports results on merges needs
security-events write permission to publish SARIF reports using
github/codeql-action/upload-sarif. Fails with HTTP 403 otherwise.

The dependent issues GHA needs PR/issues write permissions to add/remove
`dependent` labels. It needs status write permission to block/unblock
PRs when dependencies are missing/met. Fails with HttpError otherwise.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
