### PR TITLE
[Backport] Collect the output of ovn-sbctl show in gather

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -59,10 +59,11 @@ var globalnetCmds = map[string]string{
 	"ipset-list": "ipset list",
 }
 
-const ovnShowCmd = "ovn-nbctl show"
+const ovnNbctlShowCmd = "ovn-nbctl show"
 
 var ovnCmds = map[string]string{
-	"ovn_show":                           ovnShowCmd,
+	"ovn_nbctl_show":                     ovnNbctlShowCmd,
+	"ovn_sbctl_show":                     "ovn-sbctl show",
 	"ovn_lr_ovn_cluster_router_policies": "ovn-nbctl lr-policy-list ovn_cluster_router",
 	"ovn_lr_ovn_cluster_router_routes":   "ovn-nbctl lr-route-list ovn_cluster_router",
 	"ovn_lr_submariner_router_routes":    "ovn-nbctl lr-route-list submariner_router",
@@ -152,7 +153,7 @@ func gatherOVNResources(info *Info, networkPlugin string) {
 	var ovnMasterPod *v1.Pod
 	// ovn-nbctl commands only work on one of the masters, figure out which one
 	for i := range ovnMasterpods.Items {
-		err = tryCmd(info, &ovnMasterpods.Items[i], ovnShowCmd)
+		err = tryCmd(info, &ovnMasterpods.Items[i], ovnNbctlShowCmd)
 		if err == nil {
 			ovnMasterPod = &ovnMasterpods.Items[i]
 			break


### PR DESCRIPTION
In order to know if the logical `submariner_router` is
properly pinned to the active Gateway node in the cluster,
we require the chassis-id to the hostname mapping info which
is part of `ovn-sbctl show` output.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 32e017b6e46029cfe23e89a36dc67366a9e48c29)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
