### PR TITLE
Add contents:write perms to subctl release GHA

### DIFF
--- a/.github/workflows/release_subctl_on_push.yml
+++ b/.github/workflows/release_subctl_on_push.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - devel
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   release-subctl-on-push:


### PR DESCRIPTION
I think this should fix the 403 error it's currently failing with.

docs.github.com/en/rest/overview/permissions-required-for-github-apps

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
