### PR TITLE
Temporarily stop checking override key

### DIFF
--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -46,31 +46,16 @@ func ForOperator(imageVersion, repo string, imageOverrideArr []string) (string, 
 }
 
 func GetOverrides(imageOverrideArr []string) (map[string]string, error) {
-	if len(imageOverrideArr) > 0 {
-		imageOverrides := make(map[string]string)
+	imageOverrides := make(map[string]string)
 
-		for _, s := range imageOverrideArr {
-			key := strings.Split(s, "=")[0]
-			if invalidImageName(key) {
-				return nil, fmt.Errorf("invalid image name %s provided. Please choose from %q", key, names.ValidImageNames)
-			}
-
-			value := strings.Split(s, "=")[1]
-			imageOverrides[key] = value
+	for _, s := range imageOverrideArr {
+		key, value, found := strings.Cut(s, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid override %s provided. Please use `a=b` syntax", s)
 		}
 
-		return imageOverrides, nil
+		imageOverrides[key] = value
 	}
 
-	return map[string]string{}, nil
-}
-
-func invalidImageName(key string) bool {
-	for _, name := range names.ValidImageNames {
-		if key == name {
-			return false
-		}
-	}
-
-	return true
+	return imageOverrides, nil
 }


### PR DESCRIPTION
The overrides should be component names as it's whats used in the
operator.
To accommodate the changes in Shipyard properly, temporarily remove
the check and reinstate it once Shipyard has been fixed.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
