### PR TITLE
Automated backport of #277: Allow the broker to watch secrets

### DIFF
--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -55,7 +55,7 @@ func NewBrokerAdminRole() *rbacv1.Role {
 				Resources: []string{"clusters", "endpoints"},
 			},
 			{
-				Verbs:     []string{"create", "get", "list", "update", "delete"},
+				Verbs:     []string{"create", "get", "list", "update", "delete", "watch"},
 				APIGroups: []string{""},
 				Resources: []string{"serviceaccounts", "secrets", "configmaps"},
 			},
@@ -101,7 +101,7 @@ func NewBrokerClusterRole() *rbacv1.Role {
 				Resources: []string{"endpointslices", "endpointslices/restricted"},
 			},
 			{
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
 			},


### PR DESCRIPTION
Backport of #277 on release-0.13.

#277: Allow the broker to watch secrets

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.