### PR TITLE
Allow kindnet in subctl diagnose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/submariner-io/cloud-prepare v0.14.0-m1
 	github.com/submariner-io/lighthouse v0.14.0-m1
 	github.com/submariner-io/shipyard v0.14.0-m1
-	github.com/submariner-io/submariner v0.14.0-m1
+	github.com/submariner-io/submariner v0.14.0-m1.0.20220926163523-c1aa0f37d980
 	github.com/submariner-io/submariner-operator v0.14.0-m1
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094

--- a/go.sum
+++ b/go.sum
@@ -748,8 +748,8 @@ github.com/submariner-io/lighthouse v0.14.0-m1 h1:XIFNfSqwYxL805yYKDigk1EMcuKMR4
 github.com/submariner-io/lighthouse v0.14.0-m1/go.mod h1:Mnkdms9XyPxop23WtLaDvP6QUJUVlku2jjdWnXLbUqo=
 github.com/submariner-io/shipyard v0.14.0-m1 h1:w8onUPOIxcmjWtUZJ8+BlQOCA8Sz/w4KUwcKfGlordE=
 github.com/submariner-io/shipyard v0.14.0-m1/go.mod h1:W3Oufy60RlxZ6vEQK1obw/jM35a9kNZVj4ls5Pyi+K0=
-github.com/submariner-io/submariner v0.14.0-m1 h1:dVmhvA7DzPIxVSgQSD4R/T1dwzum5WPEQoS1WLGAo3U=
-github.com/submariner-io/submariner v0.14.0-m1/go.mod h1:6A0Dv+YqdFI601flZ+FmSASWqPZgG/5DXCIbJwvnK4Y=
+github.com/submariner-io/submariner v0.14.0-m1.0.20220926163523-c1aa0f37d980 h1:VJ76kd0sLvUh6uatMghBJgwPvEWNMZx02j4TCfcJsW8=
+github.com/submariner-io/submariner v0.14.0-m1.0.20220926163523-c1aa0f37d980/go.mod h1:UKpHJMg4cQmEgHTlYLFtY6/KXvve9xkr46LKcZQswWA=
 github.com/submariner-io/submariner-operator v0.14.0-m1 h1:fnfCQhlUHlHbLytzmzLBjH7OSivihkVgATMDMWuLotk=
 github.com/submariner-io/submariner-operator v0.14.0-m1/go.mod h1:1q2TprfCUiN0vlYuGCInOvypAGXwLxoRTBEe7Tm5mYo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -48,6 +48,7 @@ const (
 var supportedNetworkPlugins = []string{
 	cni.Generic, cni.CanalFlannel, cni.WeaveNet,
 	cni.OpenShiftSDN, cni.OVNKubernetes, cni.Calico,
+	cni.KindNet,
 }
 
 var calicoGVR = schema.GroupVersionResource{


### PR DESCRIPTION
kindnet is now identified explicitly, subctl diagnose needs to be updated to recognise that.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
