### PR TITLE
Fix Lighthouse CoreDNS ocp ClusterRoleBinding

### DIFF
--- a/pkg/lighthouse/ensure.go
+++ b/pkg/lighthouse/ensure.go
@@ -46,7 +46,7 @@ func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClien
 		{
 			ComponentName:          names.LighthouseCoreDNSComponent,
 			ClusterRoleFile:        embeddedyamls.Config_rbac_lighthouse_coredns_ocp_cluster_role_yaml,
-			ClusterRoleBindingFile: embeddedyamls.Config_rbac_lighthouse_coredns_cluster_role_binding_yaml,
+			ClusterRoleBindingFile: embeddedyamls.Config_rbac_lighthouse_coredns_ocp_cluster_role_binding_yaml,
 		},
 	}
 


### PR DESCRIPTION
Fix Lighthouse CoreDNS ocp ClusterRoleBinding file name
Signed-off-by: Yossi Boaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
