### PR TITLE
Enhance diagnose connection error output

### DIFF
--- a/pkg/diagnose/connections.go
+++ b/pkg/diagnose/connections.go
@@ -19,6 +19,8 @@ limitations under the License.
 package diagnose
 
 import (
+	"encoding/json"
+
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -59,7 +61,13 @@ func Connections(clusterInfo *cluster.Info, status reporter.Interface) bool {
 			if connection.Status == submv1.Connecting {
 				tracker.Failure("Connection to cluster %q is in progress", connection.Endpoint.ClusterID)
 			} else if connection.Status == submv1.ConnectionError {
-				tracker.Failure("Connection to cluster %q is not established", connection.Endpoint.ClusterID)
+				out, err := json.MarshalIndent(connection, "", "  ")
+				if err != nil {
+					tracker.Warning("Unable to marshal Connection to json: %v", err)
+				}
+
+				tracker.Failure("Connection to cluster %q is not established. Connection details:\n%s",
+					connection.Endpoint.ClusterID, out)
 			}
 		}
 	}


### PR DESCRIPTION
When a connection isn't established, it simply prints that fact. It would be useful to see more detail to possibly help ascertain the reason so output the full `Connection` instance in json.

Example output (although it was actually connected):

```
Connection to cluster "cluster1" is not established. Connection details:
  {
    "status": "connected",
    "statusMessage": "",
    "endpoint": {
      "cluster_id": "cluster1",
      "cable_name": "submariner-cable-cluster1-172-18-0-6",
      "healthCheckIP": "10.130.1.1",
      "hostname": "cluster1-worker",
      "subnets": [
        "100.66.0.0/16",
        "10.130.0.0/16"
      ],
      "private_ip": "172.18.0.6",
      "public_ip": "20.168.195.221",
      "nat_enabled": false,
      "backend": "libreswan",
      "backend_config": {
        "natt-discovery-port": "4490",
        "preferred-server": "false",
        "udp-port": "4500"
      }
    },
    "usingIP": "172.18.0.6",
    "latencyRTT": {
      "last": "176.502µs",
      "min": "141.401µs",
      "average": "198.609µs",
      "max": "270.903µs",
      "stdDev": "32.437µs"
    }
  }

```