### PR TITLE
Support air-gapped flag as part of join

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -83,6 +83,8 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&joinFlags.PreferredServer, "preferred-server", false,
 		"enable this cluster as a preferred server for dataplane connections")
 
+	cmd.Flags().BoolVar(&joinFlags.AirGappedDeployment, "air-gapped", false,
+		"specifies that the cluster is in an air-gapped environment")
 	cmd.Flags().BoolVar(&joinFlags.LoadBalancerEnabled, "load-balancer", false,
 		"enable automatic LoadBalancer in front of the gateways")
 

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -40,6 +40,7 @@ type SubmarinerOptions struct {
 	NATTraversal                  bool
 	IPSecDebug                    bool
 	SubmarinerDebug               bool
+	AirGappedDeployment           bool
 	LoadBalancerEnabled           bool
 	HealthCheckEnabled            bool
 	BrokerK8sInsecure             bool
@@ -106,6 +107,7 @@ func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info,
 		CableDriver:              options.CableDriver,
 		ServiceDiscoveryEnabled:  brokerInfo.IsServiceDiscoveryEnabled(),
 		ImageOverrides:           repositoryInfo.Overrides,
+		AirGappedDeployment:      options.AirGappedDeployment,
 		LoadBalancerEnabled:      options.LoadBalancerEnabled,
 		ConnectionHealthCheck: &operatorv1alpha1.HealthCheckSpec{
 			Enabled:            options.HealthCheckEnabled,

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -170,6 +170,7 @@ func submarinerOptionsFrom(joinOptions *Options) *deploy.SubmarinerOptions {
 		NATTraversal:                  joinOptions.NATTraversal,
 		IPSecDebug:                    joinOptions.IPSecDebug,
 		SubmarinerDebug:               joinOptions.SubmarinerDebug,
+		AirGappedDeployment:           joinOptions.AirGappedDeployment,
 		LoadBalancerEnabled:           joinOptions.LoadBalancerEnabled,
 		HealthCheckEnabled:            joinOptions.HealthCheckEnabled,
 		NATTPort:                      joinOptions.NATTPort,

--- a/pkg/join/options.go
+++ b/pkg/join/options.go
@@ -27,6 +27,7 @@ type Options struct {
 	IPSecDebug                    bool
 	SubmarinerDebug               bool
 	OperatorDebug                 bool
+	AirGappedDeployment           bool
 	LoadBalancerEnabled           bool
 	HealthCheckEnabled            bool
 	BrokerK8sSecure               bool

--- a/release-notes/20221014-air-gapped.md
+++ b/release-notes/20221014-air-gapped.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable MD041 -->
+The `subctl join` command now supports an `--air-gapped` option
+that instructs Submariner not to access any external servers for
+`public-ip` resolution.


### PR DESCRIPTION
This PR enables users to specify `--air-gapped` flag as part of `subctl join ...` command which will instruct Submariner gateway pod to avoid making any API calls to external servers while trying to discover the public-ip associated with the Gateway node.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
