### PR TITLE
Defer cleanupFramework after initFramework

### DIFF
--- a/internal/benchmark/latency.go
+++ b/internal/benchmark/latency.go
@@ -52,6 +52,7 @@ func StartLatencyTests(intraCluster, verbose bool) {
 	})
 
 	f = initFramework("latency", verbose)
+	defer cleanupFramework(f)
 
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 
@@ -60,7 +61,6 @@ func StartLatencyTests(intraCluster, verbose bool) {
 
 		if framework.TestContext.GlobalnetEnabled {
 			fmt.Println("Latency test is not supported with Globalnet enabled, skipping the test...")
-			cleanupFramework(f)
 
 			return
 		}
@@ -92,8 +92,6 @@ func StartLatencyTests(intraCluster, verbose bool) {
 		fmt.Printf("Performing latency tests from Non-Gateway pod to Gateway pod on cluster %q\n", clusterAName)
 		runLatencyTest(f, latencyTestIntraClusterParams, verbose)
 	}
-
-	cleanupFramework(f)
 }
 
 func runLatencyTest(f *framework.Framework, testParams benchmarkTestParams, verbose bool) {

--- a/internal/benchmark/throughput.go
+++ b/internal/benchmark/throughput.go
@@ -47,6 +47,7 @@ func StartThroughputTests(intraCluster, verbose bool) {
 	})
 
 	f = initFramework("throughput", verbose)
+	defer cleanupFramework(f)
 
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 
@@ -80,8 +81,6 @@ func StartThroughputTests(intraCluster, verbose bool) {
 		fmt.Printf("Performing throughput tests from Non-Gateway pod to Gateway pod on cluster %q\n", clusterAName)
 		runThroughputTest(f, testIntraClusterParams, verbose)
 	}
-
-	cleanupFramework(f)
 }
 
 func initFramework(baseName string, verbose bool) *framework.Framework {


### PR DESCRIPTION
This avoids having to special-case early returns.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
