### PR TITLE
Remove space between // and nolint

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:dupl // Similar code in aws.go, azure.go, rhos.go, but not duplicate
+//nolint:dupl // Similar code in aws.go, azure.go, rhos.go, but not duplicate
 package subctl
 
 import (
@@ -42,7 +42,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.AWS(clusterInfo, &cloudPorts, &awsConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return prepare.AWS(clusterInfo, &cloudPorts, &awsConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}
@@ -56,7 +56,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return cleanup.AWS(clusterInfo, &awsConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.AWS(clusterInfo, &awsConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:dupl // Similar code in aws.go, azure.go, rhos.go, but not duplicate
+//nolint:dupl // Similar code in aws.go, azure.go, rhos.go, but not duplicate
 package subctl
 
 import (
@@ -41,7 +41,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.Azure(clusterInfo, &cloudPorts, &azureConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return prepare.Azure(clusterInfo, &cloudPorts, &azureConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}
@@ -55,7 +55,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return cleanup.Azure(clusterInfo, &azureConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.Azure(clusterInfo, &azureConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -86,10 +86,10 @@ func addDeployBrokerFlags() {
 
 func deployBrokerInContext(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 	if err := deploy.Broker(&deployflags, clusterInfo.ClientProducer, status); err != nil {
-		return err // nolint:wrapcheck // No need to wrap errors here.
+		return err //nolint:wrapcheck // No need to wrap errors here.
 	}
 
-	return broker.WriteInfoToFile( // nolint:wrapcheck // No need to wrap errors here.
+	return broker.WriteInfoToFile( //nolint:wrapcheck // No need to wrap errors here.
 		clusterInfo.RestConfig, deployflags.BrokerNamespace, ipsecSubmFile,
 		stringset.New(deployflags.BrokerSpec.Components...), deployflags.BrokerSpec.DefaultCustomDomains, status)
 }

--- a/cmd/subctl/export.go
+++ b/cmd/subctl/export.go
@@ -51,7 +51,7 @@ var (
 
 			exit.OnError(exportRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return service.Export(clusterInfo.ClientProducer, namespace, args[0], status) // nolint:wrapcheck // No need to wrap errors here.
+					return service.Export(clusterInfo.ClientProducer, namespace, args[0], status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -44,7 +44,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.GCP(clusterInfo, &cloudPorts, &gcpConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return prepare.GCP(clusterInfo, &cloudPorts, &gcpConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}
@@ -57,7 +57,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return cleanup.GCP(clusterInfo, &gcpConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.GCP(clusterInfo, &gcpConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/generic_cloud.go
+++ b/cmd/subctl/generic_cloud.go
@@ -40,7 +40,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.GenericCluster( // nolint:wrapcheck // No need to wrap errors here.
+					return prepare.GenericCluster( //nolint:wrapcheck // No need to wrap errors here.
 						clusterInfo, genericCloudConfig.gateways, status)
 				}, cli.NewReporter()))
 		},
@@ -53,7 +53,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return cleanup.GenericCluster(clusterInfo, status) // nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.GenericCluster(clusterInfo, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -136,7 +136,7 @@ func joinInContext(brokerInfo *broker.Info, clusterInfo *cluster.Info, status re
 		joinFlags.CustomDomains = *brokerInfo.CustomDomains
 	}
 
-	return join.ClusterToBroker( // nolint:wrapcheck // No need to wrap errors here.
+	return join.ClusterToBroker( //nolint:wrapcheck // No need to wrap errors here.
 		brokerInfo, &joinFlags, clusterInfo.ClientProducer, status)
 }
 
@@ -201,7 +201,7 @@ func askForGatewayNode(workerNodeNames []string) (string, error) {
 
 	err := survey.Ask(qs, &answers)
 	if err != nil {
-		return "", err // nolint:wrapcheck // No need to wrap here
+		return "", err //nolint:wrapcheck // No need to wrap here
 	}
 
 	return answers.Node, nil
@@ -226,7 +226,7 @@ func askForClusterID() (string, error) {
 				return nil
 			}
 
-			return cluster.IsValidID(str) // nolint:wrapcheck // No need to wrap
+			return cluster.IsValidID(str) //nolint:wrapcheck // No need to wrap
 		},
 	})
 
@@ -237,7 +237,7 @@ func askForClusterID() (string, error) {
 	err := survey.Ask(qs, &answers)
 	// Most likely a programming error
 	if err != nil {
-		return "", err // nolint:wrapcheck // No need to wrap
+		return "", err //nolint:wrapcheck // No need to wrap
 	}
 
 	return answers.ClusterID, nil
@@ -256,7 +256,7 @@ func askForCIDR(name string) (string, error) {
 
 	err := survey.Ask(qs, &answers)
 	if err != nil {
-		return "", err // nolint:wrapcheck // No need to wrap here
+		return "", err //nolint:wrapcheck // No need to wrap here
 	}
 
 	return strings.TrimSpace(answers.Cidr), nil

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:dupl // Similar code in aws.go, azure.go, rhos.go, but not duplicate
+//nolint:dupl // Similar code in aws.go, azure.go, rhos.go, but not duplicate
 package subctl
 
 import (
@@ -41,7 +41,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.RHOS(clusterInfo, &cloudPorts, &rhosConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return prepare.RHOS(clusterInfo, &cloudPorts, &rhosConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}
@@ -55,7 +55,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return cleanup.RHOS(clusterInfo, &rhosConfig, status) // nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.RHOS(clusterInfo, &rhosConfig, status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -55,7 +55,7 @@ var (
 						return status.Error(err, "Error creating client")
 					}
 
-					return service.Unexport(mcsClient, namespace, args[0], status) // nolint:wrapcheck // No need to wrap errors here.
+					return service.Unexport(mcsClient, namespace, args[0], status) //nolint:wrapcheck // No need to wrap errors here.
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/uninstall.go
+++ b/cmd/subctl/uninstall.go
@@ -70,6 +70,6 @@ func uninstallInContext(clusterInfo *cluster.Info, namespace string, status repo
 		}
 	}
 
-	return uninstall.All( // nolint:wrapcheck // No need to wrap errors here.
+	return uninstall.All( //nolint:wrapcheck // No need to wrap errors here.
 		clusterInfo.ClientProducer, clusterInfo.Name, namespace, status)
 }

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package subctl
 
-// nolint:revive // Blank imports below are intentional.
+//nolint:revive // Blank imports below are intentional.
 import (
 	"errors"
 	"fmt"

--- a/internal/cli/logger.go
+++ b/internal/cli/logger.go
@@ -83,7 +83,7 @@ func (l *Logger) write(p []byte) (n int, err error) {
 	l.writerMu.Lock()
 	defer l.writerMu.Unlock()
 
-	return l.writer.Write(p) // nolint:wrapcheck // No need to wrap here
+	return l.writer.Write(p) //nolint:wrapcheck // No need to wrap here
 }
 
 // writeBuffer writes buf with write, ensuring there is a trailing newline.

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -160,12 +160,12 @@ func (s *Spinner) Write(p []byte) (n int, err error) {
 	defer s.mu.Unlock()
 	// it the spinner is not running, just write directly.
 	if !s.running {
-		return s.writer.Write(p) // nolint:wrapcheck // No need to wrap here
+		return s.writer.Write(p) //nolint:wrapcheck // No need to wrap here
 	}
 	// otherwise: we will rewrite the line first.
 	if _, err := s.writer.Write([]byte("\r")); err != nil {
-		return 0, err // nolint:wrapcheck // No need to wrap here
+		return 0, err //nolint:wrapcheck // No need to wrap here
 	}
 
-	return s.writer.Write(p) // nolint:wrapcheck // No need to wrap here
+	return s.writer.Write(p) //nolint:wrapcheck // No need to wrap here
 }

--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -200,7 +200,7 @@ func logVxlanCmds(info *Info, pod *v1.Pod) {
 	}
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func execCmdInBash(info *Info, pod *v1.Pod, cmd string) (string, string, error) {
 	execOptions := pods.ExecOptionsFromPod(pod)
 	execConfig := pods.ExecConfig{

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -120,7 +120,7 @@ func gatherDataByCluster(clusterInfo *cluster.Info, options Options) {
 	gatherClusterSummary(&info)
 }
 
-// nolint:gocritic // hugeParam: info - purposely passed by value.
+//nolint:gocritic // hugeParam: info - purposely passed by value.
 func gatherConnectivity(dataType string, info Info) bool {
 	if info.Submariner == nil {
 		info.Status.Warning("The Submariner connectivity components are not installed")
@@ -151,7 +151,7 @@ func gatherConnectivity(dataType string, info Info) bool {
 	return true
 }
 
-// nolint:gocritic // hugeParam: info - purposely passed by value.
+//nolint:gocritic // hugeParam: info - purposely passed by value.
 func gatherDiscovery(dataType string, info Info) bool {
 	if info.ServiceDiscovery == nil {
 		info.Status.Warning("The Submariner service discovery components are not installed")
@@ -176,7 +176,7 @@ func gatherDiscovery(dataType string, info Info) bool {
 	return true
 }
 
-// nolint:gocritic // hugeParam: info - purposely passed by value.
+//nolint:gocritic // hugeParam: info - purposely passed by value.
 func gatherBroker(dataType string, info Info) bool {
 	switch dataType {
 	case Resources:
@@ -226,7 +226,7 @@ func gatherBroker(dataType string, info Info) bool {
 	return true
 }
 
-// nolint:gocritic // hugeParam: info - purposely passed by value.
+//nolint:gocritic // hugeParam: info - purposely passed by value.
 func gatherOperator(dataType string, info Info) bool {
 	switch dataType {
 	case Logs:

--- a/internal/gather/logs.go
+++ b/internal/gather/logs.go
@@ -59,7 +59,7 @@ func gatherPodLogsByContainer(podLabelSelector, container string, info *Info) {
 	}
 }
 
-// nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
+//nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
 func outputPodLogs(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, info *Info) (podLogInfo LogInfo) {
 	podLogInfo.Namespace = pod.Namespace
 	podLogInfo.PodState = pod.Status.Phase
@@ -128,7 +128,7 @@ func findPods(clientSet kubernetes.Interface, byLabelSelector string) (*corev1.P
 	return pods, nil
 }
 
-// nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
+//nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
 func outputPreviousPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, info *Info, podLogInfo *LogInfo) error {
 	podLogOptions.Previous = true
 	logRequest := info.ClientProducer.ForKubernetes().CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOptions)
@@ -157,7 +157,7 @@ func outputPreviousPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, i
 	return nil
 }
 
-// nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
+//nolint:gocritic // hugeParam: podLogOptions - purposely passed by value.
 func outputCurrentPodLog(pod *corev1.Pod, podLogOptions corev1.PodLogOptions, info *Info, podLogInfo *LogInfo) error {
 	// Running with Previous = false on the same pod
 	podLogOptions.Previous = false

--- a/internal/gather/resource.go
+++ b/internal/gather/resource.go
@@ -36,7 +36,7 @@ import (
 
 var fileNameRegexp = regexp.MustCompile(`[<>:"/\|?*]`)
 
-// nolint:gocritic // hugeParam: listOptions - match K8s API.
+//nolint:gocritic // hugeParam: listOptions - match K8s API.
 func ResourcesToYAMLFile(info *Info, ofType schema.GroupVersionResource, namespace string, listOptions metav1.ListOptions) {
 	err := func() error {
 		list, err := info.ClientProducer.ForDynamic().Resource(ofType).Namespace(namespace).List(context.TODO(), listOptions)
@@ -94,17 +94,17 @@ func ResourcesToYAMLFile(info *Info, ofType schema.GroupVersionResource, namespa
 	}
 }
 
-// nolint:gocritic // hugeParam: listOptions - match K8s API.
+//nolint:gocritic // hugeParam: listOptions - match K8s API.
 func gatherDaemonSet(info *Info, namespace string, listOptions metav1.ListOptions) {
 	ResourcesToYAMLFile(info, appsv1.SchemeGroupVersion.WithResource("daemonsets"), namespace, listOptions)
 }
 
-// nolint:gocritic // hugeParam: listOptions - match K8s API.
+//nolint:gocritic // hugeParam: listOptions - match K8s API.
 func gatherDeployment(info *Info, namespace string, listOptions metav1.ListOptions) {
 	ResourcesToYAMLFile(info, appsv1.SchemeGroupVersion.WithResource("deployments"), namespace, listOptions)
 }
 
-// nolint:gocritic // hugeParam: listOptions - match K8s API.
+//nolint:gocritic // hugeParam: listOptions - match K8s API.
 func gatherConfigMaps(info *Info, namespace string, listOptions metav1.ListOptions) {
 	ResourcesToYAMLFile(info, corev1.SchemeGroupVersion.WithResource("configmaps"), namespace, listOptions)
 }

--- a/internal/gather/summary.go
+++ b/internal/gather/summary.go
@@ -206,7 +206,7 @@ func getFormattedIP(ipAddrList, ipaddr string) string {
 	return ipaddr
 }
 
-// nolint:gocritic // hugeParam: listOptions - match K8s API.
+//nolint:gocritic // hugeParam: listOptions - match K8s API.
 func listNodes(info *Info, listOptions metav1.ListOptions) (*v1.NodeList, error) {
 	nodes, err := info.ClientProducer.ForKubernetes().CoreV1().Nodes().List(context.TODO(), listOptions)
 	if err != nil {

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -115,7 +115,7 @@ func addLabels(clientset kubernetes.Interface, nodeName string, labelsToAdd map[
 		_, lastErr = clientset.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
 		if lastErr != nil {
 			if !k8serrors.IsConflict(lastErr) {
-				return false, lastErr // nolint:wrapcheck // No need to wrap here
+				return false, lastErr //nolint:wrapcheck // No need to wrap here
 			}
 
 			return false, nil
@@ -125,10 +125,10 @@ func addLabels(clientset kubernetes.Interface, nodeName string, labelsToAdd map[
 	})
 
 	if goerrors.Is(err, wait.ErrWaitTimeout) {
-		return lastErr // nolint:wrapcheck // No need to wrap here
+		return lastErr //nolint:wrapcheck // No need to wrap here
 	}
 
-	return err // nolint:wrapcheck // No need to wrap here
+	return err //nolint:wrapcheck // No need to wrap here
 }
 
 var nodeLabelBackoff wait.Backoff = wait.Backoff{

--- a/internal/pods/exec.go
+++ b/internal/pods/exec.go
@@ -96,7 +96,7 @@ func ExecWithOptions(config ExecConfig, options *ExecOptions) (string, string, e
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func execute(method string, link *url.URL, config *rest.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
 	exec, err := remotecommand.NewSPDYExecutor(config, method, link)
 	if err != nil {

--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -185,7 +185,7 @@ func (np *Scheduled) Delete() {
 	_ = pc.Delete(context.TODO(), np.Pod.Name, metav1.DeleteOptions{})
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (np *Scheduled) awaitUntilScheduled() error {
 	pods := np.Config.ClientSet.CoreV1().Pods(np.Config.Namespace)
 
@@ -213,7 +213,7 @@ func (np *Scheduled) awaitUntilScheduled() error {
 	return nil
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func (np *Scheduled) AwaitCompletion() error {
 	pods := np.Config.ClientSet.CoreV1().Pods(np.Config.Namespace)
 
@@ -223,7 +223,7 @@ func (np *Scheduled) AwaitCompletion() error {
 		}, func(result interface{}) (bool, string, error) {
 			np.Pod = result.(*v1.Pod)
 
-			switch np.Pod.Status.Phase { // nolint:exhaustive // 'missing cases in switch' - OK
+			switch np.Pod.Status.Phase { //nolint:exhaustive // 'missing cases in switch' - OK
 			case v1.PodSucceeded:
 				return true, "", nil
 			case v1.PodFailed:

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -50,7 +50,7 @@ func GetClientTokenSecret(kubeClient kubernetes.Interface, namespace, serviceAcc
 
 	for _, secret := range sa.Secrets {
 		if strings.HasPrefix(secret.Name, tokenPrefix) {
-			// nolint:wrapcheck // No need to wrap here
+			//nolint:wrapcheck // No need to wrap here
 			return kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
 		}
 	}

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -458,7 +458,7 @@ func ConfigureTestFramework(args []string) error {
 
 		clusterName, err := rcp.clusterNameFromContext()
 		if err != nil {
-			// nolint:nilerr // This is intentional.
+			//nolint:nilerr // This is intentional.
 			return nil
 		}
 

--- a/pkg/broker/ensure.go
+++ b/pkg/broker/ensure.go
@@ -71,7 +71,7 @@ func Ensure(crdUpdater crd.Updater, kubeClient kubernetes.Interface, componentAr
 	// Create the namespace
 	_, err := namespace.Ensure(kubeClient, brokerNS, brokerNamespaceLabels)
 	if err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	}
 
 	// Create administrator SA, Role, and bind them
@@ -172,7 +172,7 @@ func WaitForClientToken(kubeClient kubernetes.Interface, submarinerBrokerSA, inN
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		secret, lastErr = rbac.GetClientTokenSecret(kubeClient, inNamespace, submarinerBrokerSA)
 		if lastErr != nil {
-			// nolint:nilerr // Intentional - the error is propagated via the outer-scoped var 'lastErr'
+			//nolint:nilerr // Intentional - the error is propagated via the outer-scoped var 'lastErr'
 			return false, nil
 		}
 
@@ -180,23 +180,23 @@ func WaitForClientToken(kubeClient kubernetes.Interface, submarinerBrokerSA, inN
 	})
 
 	if goerrors.Is(err, wait.ErrWaitTimeout) {
-		return nil, lastErr // nolint:wrapcheck // No need to wrap here
+		return nil, lastErr //nolint:wrapcheck // No need to wrap here
 	}
 
-	return secret, err // nolint:wrapcheck // No need to wrap here
+	return secret, err //nolint:wrapcheck // No need to wrap here
 }
 
-// nolint:wrapcheck // No need to wrap here
+//nolint:wrapcheck // No need to wrap here
 func CreateOrUpdateClusterBrokerRole(kubeClient kubernetes.Interface, inNamespace string) (bool, error) {
 	return role.Ensure(kubeClient, inNamespace, NewBrokerClusterRole())
 }
 
-// nolint:wrapcheck // No need to wrap here
+//nolint:wrapcheck // No need to wrap here
 func CreateOrUpdateBrokerAdminRole(clientset kubernetes.Interface, inNamespace string) (created bool, err error) {
 	return role.Ensure(clientset, inNamespace, NewBrokerAdminRole())
 }
 
-// nolint:wrapcheck // No need to wrap here
+//nolint:wrapcheck // No need to wrap here
 func CreateNewBrokerRoleBinding(kubeClient kubernetes.Interface, serviceAccount, roleName, inNamespace string) (
 	brokerRoleBinding *rbacv1.RoleBinding, err error,
 ) {
@@ -204,7 +204,7 @@ func CreateNewBrokerRoleBinding(kubeClient kubernetes.Interface, serviceAccount,
 		context.TODO(), NewBrokerRoleBinding(serviceAccount, roleName, inNamespace), metav1.CreateOptions{})
 }
 
-// nolint:wrapcheck // No need to wrap here
+//nolint:wrapcheck // No need to wrap here
 func CreateNewBrokerSA(kubeClient kubernetes.Interface, submarinerBrokerSA, inNamespace string) (err error) {
 	sa := NewBrokerSA(submarinerBrokerSA)
 	_, err = serviceaccount.Ensure(kubeClient, inNamespace, sa, true)

--- a/pkg/broker/file.go
+++ b/pkg/broker/file.go
@@ -125,5 +125,5 @@ func backupIfExists(fileName string) (string, error) {
 	nowStr := strings.ReplaceAll(now.Format(time.RFC3339), ":", "_")
 	newFilename := fileName + "." + nowStr
 
-	return newFilename, os.Rename(fileName, newFilename) // nolint:wrapcheck // No need to wrap here
+	return newFilename, os.Rename(fileName, newFilename) //nolint:wrapcheck // No need to wrap here
 }

--- a/pkg/broker/ipsec_psk.go
+++ b/pkg/broker/ipsec_psk.go
@@ -35,7 +35,7 @@ func generateRandomPSK(n int) ([]byte, error) {
 	psk := make([]byte, n)
 	_, err := rand.Read(psk)
 
-	return psk, err // nolint:wrapcheck // No need to wrap here
+	return psk, err //nolint:wrapcheck // No need to wrap here
 }
 
 func newIPSECPSKSecret() (*v1.Secret, error) {

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -90,5 +90,5 @@ func readMetadataFile(fileName string) (string, string, error) {
 
 	err := cloud.ReadMetadataFile(fileName, &metadata)
 
-	return metadata.InfraID, metadata.AWS.Region, err // nolint:wrapcheck // No need to wrap here
+	return metadata.InfraID, metadata.AWS.Region, err //nolint:wrapcheck // No need to wrap here
 }

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -123,7 +123,7 @@ func readMetadataFile(fileName string) (string, string, error) {
 
 	err := cloud.ReadMetadataFile(fileName, &metadata)
 
-	return metadata.InfraID, metadata.Azure.Region, err // nolint:wrapcheck // No need to wrap here
+	return metadata.InfraID, metadata.Azure.Region, err //nolint:wrapcheck // No need to wrap here
 }
 
 func initializeFromAuthFile(authFile string) (string, error) {

--- a/pkg/cloud/cleanup/aws.go
+++ b/pkg/cloud/cleanup/aws.go
@@ -27,7 +27,7 @@ import (
 
 func AWS(clusterInfo *cluster.Info, config *aws.Config, status reporter.Interface) error {
 	err := aws.RunOn(clusterInfo, config, status,
-		// nolint:wrapcheck // No need to wrap errors here
+		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			err := gwDeployer.Cleanup(status)
 			if err != nil {

--- a/pkg/cloud/cleanup/azure.go
+++ b/pkg/cloud/cleanup/azure.go
@@ -27,7 +27,7 @@ import (
 
 func Azure(clusterInfo *cluster.Info, config *azure.Config, status reporter.Interface) error {
 	err := azure.RunOn(clusterInfo, config, status,
-		// nolint:wrapcheck // No need to wrap errors here
+		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			err := gwDeployer.Cleanup(status)
 			if err != nil {

--- a/pkg/cloud/cleanup/gcp.go
+++ b/pkg/cloud/cleanup/gcp.go
@@ -27,7 +27,7 @@ import (
 
 func GCP(clusterInfo *cluster.Info, config *gcp.Config, status reporter.Interface) error {
 	err := gcp.RunOn(clusterInfo, config, status,
-		// nolint:wrapcheck // No need to wrap errors here
+		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			err := gwDeployer.Cleanup(status)
 			if err != nil {

--- a/pkg/cloud/cleanup/generic.go
+++ b/pkg/cloud/cleanup/generic.go
@@ -28,7 +28,7 @@ import (
 func GenericCluster(clusterInfo *cluster.Info, status reporter.Interface) error {
 	err := generic.RunOnCluster(clusterInfo, status,
 		func(gwDeployer api.GatewayDeployer, status reporter.Interface) error {
-			return gwDeployer.Cleanup(status) // nolint:wrapcheck // No need to wrap here
+			return gwDeployer.Cleanup(status) //nolint:wrapcheck // No need to wrap here
 		})
 
 	return status.Error(err, "Failed to cleanup generic K8s cluster")

--- a/pkg/cloud/cleanup/rhos.go
+++ b/pkg/cloud/cleanup/rhos.go
@@ -27,7 +27,7 @@ import (
 
 func RHOS(clusterInfo *cluster.Info, config *rhos.Config, status reporter.Interface) error {
 	err := rhos.RunOn(clusterInfo, config, status,
-		// nolint:wrapcheck // No need to wrap errors here
+		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			err := gwDeployer.Cleanup(status)
 			if err != nil {

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -125,7 +125,7 @@ func readMetadataFile(fileName string) (string, string, string, error) {
 
 	err := cloud.ReadMetadataFile(fileName, &metadata)
 
-	return metadata.InfraID, metadata.GCP.Region, metadata.GCP.ProjectID, err // nolint:wrapcheck // No need to wrap here
+	return metadata.InfraID, metadata.GCP.Region, metadata.GCP.ProjectID, err //nolint:wrapcheck // No need to wrap here
 }
 
 func getCredentials(credentialsFile string) (*google.Credentials, error) {

--- a/pkg/cloud/prepare/aws.go
+++ b/pkg/cloud/prepare/aws.go
@@ -39,7 +39,7 @@ func AWS(clusterInfo *cluster.Info, ports *cloud.Ports, config *aws.Config, stat
 		input.InternalPorts = append(input.InternalPorts, gwPorts...)
 	}
 
-	// nolint:wrapcheck // No need to wrap errors here.
+	//nolint:wrapcheck // No need to wrap errors here.
 	err = aws.RunOn(clusterInfo, config, status,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -35,7 +35,7 @@ func Azure(clusterInfo *cluster.Info, ports *cloud.Ports, config *azure.Config, 
 		return status.Error(err, "Failed to prepare the cloud")
 	}
 
-	// nolint:wrapcheck // No need to wrap errors here.
+	//nolint:wrapcheck // No need to wrap errors here.
 	err = azure.RunOn(clusterInfo, config, status,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {

--- a/pkg/cloud/prepare/gcp.go
+++ b/pkg/cloud/prepare/gcp.go
@@ -33,7 +33,7 @@ func GCP(clusterInfo *cluster.Info, ports *cloud.Ports, config *gcp.Config, stat
 		return status.Error(err, "Failed to prepare the cloud")
 	}
 
-	// nolint:wrapcheck // No need to wrap errors here.
+	//nolint:wrapcheck // No need to wrap errors here.
 	err = gcp.RunOn(clusterInfo, config, cli.NewReporter(),
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {

--- a/pkg/cloud/prepare/generic.go
+++ b/pkg/cloud/prepare/generic.go
@@ -26,7 +26,7 @@ import (
 )
 
 func GenericCluster(clusterInfo *cluster.Info, gateways int, status reporter.Interface) error {
-	// nolint:wrapcheck // No need to wrap errors here.
+	//nolint:wrapcheck // No need to wrap errors here.
 	err := generic.RunOnCluster(clusterInfo, status,
 		func(gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if gateways > 0 {

--- a/pkg/cloud/prepare/rhos.go
+++ b/pkg/cloud/prepare/rhos.go
@@ -33,7 +33,7 @@ func RHOS(clusterInfo *cluster.Info, ports *cloud.Ports, config *rhos.Config, st
 		return status.Error(err, "Failed to prepare the cloud")
 	}
 
-	// nolint:wrapcheck // No need to wrap errors here.
+	//nolint:wrapcheck // No need to wrap errors here.
 	err = rhos.RunOn(clusterInfo, config, status,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {

--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -117,5 +117,5 @@ func readMetadataFile(fileName string) (string, string, error) {
 
 	err := cloud.ReadMetadataFile(fileName, &metadata)
 
-	return metadata.InfraID, metadata.RHOS.ProjectID, err // nolint:wrapcheck // No need to wrap here
+	return metadata.InfraID, metadata.RHOS.ProjectID, err //nolint:wrapcheck // No need to wrap here
 }

--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -95,7 +95,7 @@ func (c *Info) GetGateways() ([]submarinerv1.Gateway, error) {
 			return []submarinerv1.Gateway{}, nil
 		}
 
-		return nil, err // nolint:wrapcheck // error can't be wrapped.
+		return nil, err //nolint:wrapcheck // error can't be wrapped.
 	}
 
 	return gateways.Items, nil

--- a/pkg/clusterrole/ensure.go
+++ b/pkg/clusterrole/ensure.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func EnsureFromYAML(kubeClient kubernetes.Interface, yaml string) (bool, error) {
 	role := &rbacv1.ClusterRole{}
 
@@ -40,7 +40,7 @@ func EnsureFromYAML(kubeClient kubernetes.Interface, yaml string) (bool, error) 
 	return Ensure(kubeClient, role)
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, role *rbacv1.ClusterRole) (bool, error) {
 	return resourceutil.CreateOrUpdate(context.TODO(), resource.ForClusterRole(kubeClient), role)
 }

--- a/pkg/clusterrolebinding/ensure.go
+++ b/pkg/clusterrolebinding/ensure.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 
@@ -42,7 +42,7 @@ func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bo
 	return Ensure(kubeClient, clusterRoleBinding)
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, clusterRoleBinding *rbacv1.ClusterRoleBinding) (bool, error) {
 	return resourceutil.CreateOrUpdate(context.TODO(), resource.ForClusterRoleBinding(kubeClient), clusterRoleBinding)
 }

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -122,7 +122,7 @@ func isValidComponents(componentSet stringset.Interface) error {
 	return nil
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func checkGlobalnetConfig(options *BrokerOptions) error {
 	var err error
 

--- a/pkg/deployment/await.go
+++ b/pkg/deployment/await.go
@@ -39,7 +39,7 @@ const (
 func AwaitReady(kubeClient kubernetes.Interface, namespace, deployment string) error {
 	deployments := kubeClient.AppsV1().Deployments(namespace)
 
-	// nolint:wrapcheck // No need to wrap here
+	//nolint:wrapcheck // No need to wrap here
 	return wait.PollImmediate(checkInterval, waitTime, func() (bool, error) {
 		dp, err := deployments.Get(context.TODO(), deployment, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/deployment/ensure.go
+++ b/pkg/deployment/ensure.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, namespace string, deployment *appsv1.Deployment) (bool, error) {
 	return resourceutil.CreateOrUpdate(context.TODO(), resource.ForDeployment(kubeClient, namespace), deployment)
 }

--- a/pkg/lighthouse/ensure.go
+++ b/pkg/lighthouse/ensure.go
@@ -32,7 +32,7 @@ func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClien
 	operatorNamespace string,
 ) error {
 	if created, err := serviceaccount.Ensure(kubeClient, operatorNamespace); err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	} else if created {
 		status.Success("Created lighthouse service account and role")
 	}
@@ -51,7 +51,7 @@ func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClien
 	}
 
 	if created, err := ocp.EnsureRBAC(dynClient, kubeClient, operatorNamespace, componentsRbac); err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	} else if created {
 		status.Success("Updated the OCP roles")
 	}

--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -33,7 +33,7 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/names"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(status reporter.Interface, clientProducer client.Producer, operatorNamespace, operatorImage string, debug bool) error {
 	if created, err := opcrds.Ensure(crd.UpdaterFromControllerClient(clientProducer.ForGeneral())); err != nil {
 		return err

--- a/pkg/resource/create_or_update.go
+++ b/pkg/resource/create_or_update.go
@@ -28,5 +28,5 @@ import (
 
 func CreateOrUpdate(ctx context.Context, client resource.Interface, obj runtime.Object) (bool, error) {
 	result, err := util.CreateOrUpdate(ctx, client, obj, util.Replace(obj))
-	return result == util.OperationResultCreated, err // nolint:wrapcheck // No need to wrap.
+	return result == util.OperationResultCreated, err //nolint:wrapcheck // No need to wrap.
 }

--- a/pkg/role/ensure.go
+++ b/pkg/role/ensure.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	role := &rbacv1.Role{}
 
@@ -40,7 +40,7 @@ func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bo
 	return Ensure(kubeClient, namespace, role)
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, namespace string, role *rbacv1.Role) (bool, error) {
 	return resourceutil.CreateOrUpdate(context.TODO(), resource.ForRole(kubeClient, namespace), role)
 }

--- a/pkg/rolebinding/ensure.go
+++ b/pkg/rolebinding/ensure.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bool, error) {
 	roleBinding := &rbacv1.RoleBinding{}
 
@@ -40,7 +40,7 @@ func EnsureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (bo
 	return Ensure(kubeClient, namespace, roleBinding)
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, namespace string, roleBinding *rbacv1.RoleBinding) (bool, error) {
 	return resourceutil.CreateOrUpdate(context.TODO(), resource.ForRoleBinding(kubeClient, namespace), roleBinding)
 }

--- a/pkg/secret/ensure.go
+++ b/pkg/secret/ensure.go
@@ -31,7 +31,7 @@ import (
 )
 
 func Ensure(client kubernetes.Interface, namespace string, secret *v1.Secret) (*v1.Secret, error) {
-	// nolint:wrapcheck // No need to wrap errors here
+	//nolint:wrapcheck // No need to wrap errors here
 	object, err := util.CreateAnew(context.TODO(), &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return client.CoreV1().Secrets(namespace).Get(ctx, name, options)

--- a/pkg/serviceaccount/ensure.go
+++ b/pkg/serviceaccount/ensure.go
@@ -44,7 +44,7 @@ const (
 )
 
 // ensureFromYAML creates the given service account.
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func ensureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (*corev1.ServiceAccount, error) {
 	sa := &corev1.ServiceAccount{}
 
@@ -61,7 +61,7 @@ func ensureFromYAML(kubeClient kubernetes.Interface, namespace, yaml string) (*c
 	return sa, err
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func ensure(kubeClient kubernetes.Interface, namespace string, sa *corev1.ServiceAccount, onlyCreate bool) error {
 	if onlyCreate {
 		_, err := kubeClient.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), sa.Name, metav1.GetOptions{})
@@ -76,7 +76,7 @@ func ensure(kubeClient kubernetes.Interface, namespace string, sa *corev1.Servic
 	return err
 }
 
-// nolint:wrapcheck // No need to wrap errors here.
+//nolint:wrapcheck // No need to wrap errors here.
 func Ensure(kubeClient kubernetes.Interface, namespace string, sa *corev1.ServiceAccount, onlyCreate bool) (*corev1.ServiceAccount, error) {
 	err := ensure(kubeClient, namespace, sa, onlyCreate)
 	if err != nil {
@@ -192,7 +192,7 @@ func getSecretForSA(client kubernetes.Interface, sa *corev1.ServiceAccount) (*co
 	}, sa.Name)
 }
 
-// nolint:gosec // we need a pseudo random string for name.
+//nolint:gosec // we need a pseudo random string for name.
 func generateRandomString(length int) string {
 	rand.Seed(time.Now().UnixNano())
 

--- a/pkg/submariner/ensure.go
+++ b/pkg/submariner/ensure.go
@@ -32,7 +32,7 @@ func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClien
 	operatorNamespace string,
 ) error {
 	if created, err := serviceaccount.Ensure(kubeClient, operatorNamespace); err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	} else if created {
 		status.Success("Created submariner service account and role")
 	}
@@ -66,7 +66,7 @@ func Ensure(status reporter.Interface, kubeClient kubernetes.Interface, dynClien
 	}
 
 	if created, err := ocp.EnsureRBAC(dynClient, kubeClient, operatorNamespace, componentsRbac); err != nil {
-		return err // nolint:wrapcheck // No need to wrap here
+		return err //nolint:wrapcheck // No need to wrap here
 	} else if created {
 		status.Success("Updated the OCP roles")
 	}

--- a/pkg/uninstall/all.go
+++ b/pkg/uninstall/all.go
@@ -102,7 +102,7 @@ func unlabelGatewayNodes(clients client.Producer, clusterName string, status rep
 		return status.Error(err, "Error listing Nodes")
 	}
 
-	// nolint:wrapcheck // Let the caller wrap errors
+	//nolint:wrapcheck // Let the caller wrap errors
 	nodeInterface := &resource.InterfaceFuncs{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (runtime.Object, error) {
 			return clients.ForKubernetes().CoreV1().Nodes().Get(ctx, name, options)
@@ -246,7 +246,7 @@ func ensureDeleted(controllerClient controller.Client, obj controller.Object) er
 	const maxWait = componentReadyTimeout + time.Second*30
 	const checkInterval = 2 * time.Second
 
-	// nolint:wrapcheck // Let the caller wrap errors
+	//nolint:wrapcheck // Let the caller wrap errors
 	return wait.PollImmediate(checkInterval, maxWait, func() (bool, error) {
 		err := controllerClient.Delete(context.TODO(), obj)
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
This is enforced by newer releases of golangci-lint.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
