### PR TITLE
Return exit code on empty/non-existent KUBECONFIG

### DIFF
--- a/cmd/subctl/execute/execute.go
+++ b/cmd/subctl/execute/execute.go
@@ -34,8 +34,8 @@ type OnClusterFn func(*cluster.Info, reporter.Interface) bool
 func OnMultiCluster(restConfigProducer *restconfig.Producer, run OnClusterFn) {
 	restConfigs := restConfigProducer.MustGetForClusters()
 	if len(restConfigs) == 0 {
-		fmt.Println("No kube config was provided. Please use the --kubeconfig flag or set the KUBECONFIG environment variable")
-		return
+		fmt.Fprintln(os.Stderr, "No kube config was provided. Please use the --kubeconfig flag or set the KUBECONFIG environment variable")
+		os.Exit(1)
 	}
 
 	success := true


### PR DESCRIPTION
Fixes https://github.com/submariner-io/subctl/issues/196