### PR TITLE
Wrap subctl benchmark

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -268,12 +268,13 @@ func runLocalRemoteCommand(command *cobra.Command, localRemoteRestConfigProducer
 	} else {
 		exit.OnError(localRemoteRestConfigProducer.RunOnSelectedContext(
 			func(localClusterInfo *cluster.Info, localNamespace string, status reporter.Interface) error {
-				return localRemoteRestConfigProducer.RunOnSelectedPrefixedContext( // nolint:wrapcheck // No need to wrap errors here.
+				_, err := localRemoteRestConfigProducer.RunOnSelectedPrefixedContext(
 					"remote",
 					func(remoteClusterInfo *cluster.Info, remoteNamespace string, status reporter.Interface) error {
 						diagnoseFirewallOptions.PodNamespace = remoteNamespace
 						return function(localClusterInfo, remoteClusterInfo, diagnoseFirewallOptions, status)
 					}, status)
+				return err // nolint:wrapcheck // No need to wrap errors here.
 			}, status))
 	}
 }

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -289,3 +289,25 @@ func getVerifyPatterns(csv string, includeDisruptive bool) ([]string, []string, 
 
 	return outputPatterns, outputVerifications, nil
 }
+
+func setUpTestFramework(args []string, restConfigProducer *restconfig.Producer, submarinerNS string) error {
+	if len(args) > 0 {
+		err := restconfig.ConfigureTestFramework(args)
+		if err != nil {
+			return err //nolint:wrapcheck // error can't be wrapped
+		}
+	} else {
+		restConfigProducer.PopulateTestFramework()
+	}
+
+	framework.TestContext.OperationTimeout = operationTimeout
+	framework.TestContext.ConnectionTimeout = connectionTimeout
+	framework.TestContext.ConnectionAttempts = connectionAttempts
+	framework.TestContext.JunitReport = junitReport
+	framework.TestContext.SubmarinerNamespace = submarinerNS
+
+	config.DefaultReporterConfig.Verbose = verboseConnectivityVerification
+	config.DefaultReporterConfig.SlowSpecThreshold = 60
+
+	return nil
+}

--- a/internal/benchmark/latency.go
+++ b/internal/benchmark/latency.go
@@ -35,7 +35,7 @@ type benchmarkTestParams struct {
 	ClientPodScheduling framework.NetworkPodScheduling
 }
 
-func StartLatencyTests(intraCluster, verbose bool) {
+func StartLatencyTests(intraCluster, verbose bool) error {
 	var f *framework.Framework
 
 	if verbose {
@@ -62,7 +62,7 @@ func StartLatencyTests(intraCluster, verbose bool) {
 		if framework.TestContext.GlobalnetEnabled {
 			fmt.Println("Latency test is not supported with Globalnet enabled, skipping the test...")
 
-			return
+			return nil
 		}
 
 		latencyTestParams := benchmarkTestParams{
@@ -92,6 +92,8 @@ func StartLatencyTests(intraCluster, verbose bool) {
 		fmt.Printf("Performing latency tests from Non-Gateway pod to Gateway pod on cluster %q\n", clusterAName)
 		runLatencyTest(f, latencyTestIntraClusterParams, verbose)
 	}
+
+	return nil
 }
 
 func runLatencyTest(f *framework.Framework, testParams benchmarkTestParams, verbose bool) {

--- a/internal/benchmark/throughput.go
+++ b/internal/benchmark/throughput.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func StartThroughputTests(intraCluster, verbose bool) {
+func StartThroughputTests(intraCluster, verbose bool) error {
 	var f *framework.Framework
 
 	if verbose {
@@ -81,6 +81,8 @@ func StartThroughputTests(intraCluster, verbose bool) {
 		fmt.Printf("Performing throughput tests from Non-Gateway pod to Gateway pod on cluster %q\n", clusterAName)
 		runThroughputTest(f, testIntraClusterParams, verbose)
 	}
+
+	return nil
 }
 
 func initFramework(baseName string, verbose bool) *framework.Framework {
@@ -91,7 +93,6 @@ func initFramework(baseName string, verbose bool) *framework.Framework {
 		}
 	})
 
-	framework.ValidateFlags(framework.TestContext)
 	framework.BeforeSuite()
 	f.BeforeEach()
 

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -119,11 +119,23 @@ _subctl diagnose firewall nat-discovery --validation-timeout 20 "${KUBECONFIGS_D
 
 # Test subctl benchmark invocations
 
-_subctl benchmark latency --intra-cluster --kubecontexts cluster1
-_subctl benchmark latency --kubecontexts cluster1,cluster2
+_subctl benchmark latency --context cluster1 | tee /dev/stderr | sponge | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark latency --context cluster1 --tocontext cluster2 | tee /dev/stderr | sponge | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
 
-_subctl benchmark throughput --intra-cluster --kubecontexts cluster1
-_subctl benchmark throughput --verbose --kubecontexts cluster1,cluster2
+_subctl benchmark throughput --context cluster1 | tee /dev/stderr | sponge | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark throughput --context cluster1 --tocontext cluster2
+
+# Deprecated variant with contexts
+_subctl benchmark latency --intra-cluster --kubecontexts cluster1 | tee /dev/stderr | sponge | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark latency --kubecontexts cluster1,cluster2 | tee /dev/stderr | sponge | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
+
+_subctl benchmark throughput --intra-cluster --kubecontexts cluster1 | tee /dev/stderr | sponge | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark throughput --kubecontexts cluster1,cluster2
+
+# Deprecated variant with kubeconfigs
+_subctl benchmark latency "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 | tee /dev/stderr | sponge | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
+
+_subctl benchmark throughput "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2
 
 # Test subctl cloud prepare invocations
 


### PR DESCRIPTION
This needs to know whether contexts have been specified in order to
handle various option selections ("--context ... --tocontext ...",
"--contexts ..." etc.). Instead of counting contexts ahead of time,
the corresponding runners indicate whether they found contexts to
process. This pattern will be generalised so that other multi-context
commands can determine whether they actually did anything.

setupTestFramework is only used for verify, so it's moved there.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
