### PR TITLE
Use `nettest` image/component names from operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/submariner-io/lighthouse v0.14.0-m2.0.20221013155253-8a8c1fbfc8d3
 	github.com/submariner-io/shipyard v0.14.0-m2
 	github.com/submariner-io/submariner v0.14.0-m1.0.20220926163523-c1aa0f37d980
-	github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221014112443-3df6539abaf1
+	github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221024122505-adc24314a409
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	google.golang.org/api v0.100.0

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/submariner-io/shipyard v0.14.0-m2 h1:C5/Pi/fHPpFWcg7gpUWTaYL+x/ezBSWD
 github.com/submariner-io/shipyard v0.14.0-m2/go.mod h1:W3Oufy60RlxZ6vEQK1obw/jM35a9kNZVj4ls5Pyi+K0=
 github.com/submariner-io/submariner v0.14.0-m1.0.20220926163523-c1aa0f37d980 h1:VJ76kd0sLvUh6uatMghBJgwPvEWNMZx02j4TCfcJsW8=
 github.com/submariner-io/submariner v0.14.0-m1.0.20220926163523-c1aa0f37d980/go.mod h1:UKpHJMg4cQmEgHTlYLFtY6/KXvve9xkr46LKcZQswWA=
-github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221014112443-3df6539abaf1 h1:bXfu8hiP+5edCMnu3oiNukEIUOEnMeofCNf3LLwz0Uw=
-github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221014112443-3df6539abaf1/go.mod h1:X5AxKbqNbK8TWhJMqCMmueesHSYXhoo5Ordw32hAc2A=
+github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221024122505-adc24314a409 h1:sjXNbROuXrjsBi8Tsrq7WkAaF6IWSNrYFXSxD9CRG2c=
+github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221024122505-adc24314a409/go.mod h1:X5AxKbqNbK8TWhJMqCMmueesHSYXhoo5Ordw32hAc2A=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/image/repository_info.go
+++ b/pkg/image/repository_info.go
@@ -49,7 +49,7 @@ func NewRepositoryInfo(name, verion string, overrides map[string]string) *Reposi
 }
 
 func (i *RepositoryInfo) GetNettestImage() string {
-	return images.GetImagePath(i.Name, i.Version, "nettest", "nettest", i.Overrides)
+	return images.GetImagePath(i.Name, i.Version, names.NettestImage, names.NettestComponent, i.Overrides)
 }
 
 func (i *RepositoryInfo) GetOperatorImage() string {

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -49,6 +49,7 @@ var validOverrides = []string{
 	names.NetworkPluginSyncerComponent,
 	names.ServiceDiscoveryComponent,
 	names.LighthouseCoreDNSComponent,
+	names.NettestComponent,
 }
 
 func ClusterToBroker(brokerInfo *broker.Info, options *Options, clientProducer client.Producer, status reporter.Interface,


### PR DESCRIPTION
Instead of hard coding the name of the image and the component. Use the ones from the operator.
This will allow downstream forks to override with a different image name if desired.

Depends on https://github.com/submariner-io/submariner-operator/pull/2293

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
