### PR TITLE
Wrap subctl verify

### DIFF
--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -19,11 +19,9 @@ limitations under the License.
 package subctl
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/subctl/internal/exit"
@@ -66,20 +64,6 @@ func setupTestFrameworkBeforeSuite() {
 	framework.TestContext.GlobalnetEnabled = clusterInfo.Submariner.Spec.GlobalCIDR != ""
 
 	framework.TestContext.NettestImageURL = clusterInfo.GetImageRepositoryInfo().GetNettestImage()
-}
-
-func compareFiles(file1, file2 string) (bool, error) {
-	first, err := os.ReadFile(file1)
-	if err != nil {
-		return false, errors.Wrapf(err, "error reading file %q", file1)
-	}
-
-	second, err := os.ReadFile(file2)
-	if err != nil {
-		return false, errors.Wrapf(err, "error reading file %q", file2)
-	}
-
-	return bytes.Equal(first, second), nil
 }
 
 // expectFlag exits with an error if the flag value is empty.


### PR DESCRIPTION
This removes the last use of AddKubeContextMultiFlag(), so all the infrastructure for that is removed too.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
