### PR TITLE
[Backport/0.13] Use `nettest` image/component names from operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/submariner-io/lighthouse v0.13.1
 	github.com/submariner-io/shipyard v0.13.1
 	github.com/submariner-io/submariner v0.13.0
-	github.com/submariner-io/submariner-operator v0.13.0
+	github.com/submariner-io/submariner-operator v0.13.2-0.20221027104449-f4add84950b4
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
 	google.golang.org/api v0.84.0

--- a/go.sum
+++ b/go.sum
@@ -712,8 +712,8 @@ github.com/submariner-io/shipyard v0.13.1 h1:h5Qjlb14uAHjyIiJhuKpPkW9dAUpXZzBey4
 github.com/submariner-io/shipyard v0.13.1/go.mod h1:f7+5soL//qKdoK/0vUvLgto/3JFPYtpXJu4e2iWAicM=
 github.com/submariner-io/submariner v0.13.0 h1:4ezPyOC0ldaTFIya+W6oqWHSUR6L64ZSRTJkUEPj19U=
 github.com/submariner-io/submariner v0.13.0/go.mod h1:NRYeNN1tJXXIJIqPqyU3CuYCg8nfpwyNc+tVcP5Eox0=
-github.com/submariner-io/submariner-operator v0.13.0 h1:ex4HEZ6veWDnv3vSjpzJnsjORUVyYZMUY+hzU0RgZtY=
-github.com/submariner-io/submariner-operator v0.13.0/go.mod h1:NydGPO7XscaWpJN0JDercOJV6SXCGpHbcsIc5Q5AqOA=
+github.com/submariner-io/submariner-operator v0.13.2-0.20221027104449-f4add84950b4 h1:Tz0Shs8adn6GeDafw45d0pPZqq1uhteVvcn1URy11dk=
+github.com/submariner-io/submariner-operator v0.13.2-0.20221027104449-f4add84950b4/go.mod h1:xqVV7H6FiC2TwQSkEB+yz3jHtbeUC7eWKvyCf+jYWpQ=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/image/repository_info.go
+++ b/pkg/image/repository_info.go
@@ -18,7 +18,10 @@ limitations under the License.
 
 package image
 
-import "github.com/submariner-io/submariner-operator/pkg/images"
+import (
+	"github.com/submariner-io/submariner-operator/pkg/images"
+	"github.com/submariner-io/submariner-operator/pkg/names"
+)
 
 type RepositoryInfo struct {
 	Name      string
@@ -27,5 +30,5 @@ type RepositoryInfo struct {
 }
 
 func (i *RepositoryInfo) GetNettestImageURL() string {
-	return images.GetImagePath(i.Name, i.Version, "nettest", "nettest", i.Overrides)
+	return images.GetImagePath(i.Name, i.Version, names.NettestImage, names.NettestComponent, i.Overrides)
 }


### PR DESCRIPTION
Instead of hard coding the name of the image and the component. Use the ones from the operator.
This will allow downstream forks to override with a different image name if desired.

Conflicts:
  pkg/image/repository_info.go

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 7af531c1f64bb2cc998e190a4804c2ec319551d3)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
