### PR TITLE
Automated backport of #332: Allow --contexts on subctl show

### DIFF
--- a/cmd/subctl/show.go
+++ b/cmd/subctl/show.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	showRestConfigProducer = restconfig.NewProducer()
+	showRestConfigProducer = restconfig.NewProducer().WithContextsFlag()
 
 	// showCmd represents the show command.
 	showCmd = &cobra.Command{

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -133,7 +133,13 @@ deploy_env_once
 
 # Test subctl show invocations
 
-_subctl show all
+_subctl show all | tee /dev/stderr | sponge | grep -q 'Cluster "cluster2"'
+# Single-context variants don't say 'Cluster "foo"', check what cluster is considered local
+_subctl show all --context cluster1 | tee /dev/stderr | sponge | grep -qv 'cluster2.*local'
+_subctl show all --context cluster2 | tee /dev/stderr | sponge | grep -q 'cluster2.*local'
+# Multiple-context variants list the clusters, even when there's only one
+_subctl show all --contexts cluster1 | tee /dev/stderr | sponge | grep -qv 'Cluster "cluster2"'
+_subctl show all --contexts cluster2 | tee /dev/stderr | sponge | grep -q 'Cluster "cluster2"'
 
 # Test subctl gather invocations
 


### PR DESCRIPTION
Backport of #332 on release-0.14.

#332: Allow --contexts on subctl show

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.