### PR TITLE
Automated backport of #326: Use the canonical namespace in diagnose

### DIFF
--- a/pkg/diagnose/firewall_natdiscovery.go
+++ b/pkg/diagnose/firewall_natdiscovery.go
@@ -25,12 +25,12 @@ import (
 	"github.com/submariner-io/subctl/pkg/cluster"
 )
 
-func NatDiscoveryConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, options FirewallOptions,
+func NatDiscoveryConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, namespace string, options FirewallOptions,
 	status reporter.Interface,
 ) error {
 	message := fmt.Sprintf("Checking if nat-discovery port is opened on the gateway node of cluster %q", localClusterInfo.Name)
 
-	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, options, status, NatDiscoveryPort, message)
+	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, namespace, options, status, NatDiscoveryPort, message)
 	if err != nil {
 		status.Failure("Could not determine if nat-discovery port is allowed in the cluster %q", localClusterInfo.Name)
 	} else {

--- a/pkg/diagnose/firewall_tunnel.go
+++ b/pkg/diagnose/firewall_tunnel.go
@@ -25,12 +25,12 @@ import (
 	"github.com/submariner-io/subctl/pkg/cluster"
 )
 
-func TunnelConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, options FirewallOptions,
+func TunnelConfigAcrossClusters(localClusterInfo, remoteClusterInfo *cluster.Info, namespace string, options FirewallOptions,
 	status reporter.Interface,
 ) error {
 	message := fmt.Sprintf("Checking if tunnels can be setup on the gateway node of cluster %q", localClusterInfo.Name)
 
-	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, options, status, TunnelPort, message)
+	err := verifyConnectivity(localClusterInfo, remoteClusterInfo, namespace, options, status, TunnelPort, message)
 	if err != nil {
 		status.Failure("Could not determine if Tunnels can be established on the gateway node of cluster %q", localClusterInfo.Name)
 	} else {


### PR DESCRIPTION
Backport of #326 on release-0.14.

#326: Use the canonical namespace in diagnose

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.