### PR TITLE
Avoid errors caused by sponge's SIGPIPE

### DIFF
--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -133,13 +133,13 @@ deploy_env_once
 
 # Test subctl show invocations
 
-_subctl show all | tee /dev/stderr | sponge | grep -q 'Cluster "cluster2"'
+_subctl show all | tee /dev/stderr | (sponge ||:) | grep -q 'Cluster "cluster2"'
 # Single-context variants don't say 'Cluster "foo"', check what cluster is considered local
-_subctl show all --context cluster1 | tee /dev/stderr | sponge | grep -qv 'cluster2.*local'
-_subctl show all --context cluster2 | tee /dev/stderr | sponge | grep -q 'cluster2.*local'
+_subctl show all --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -qv 'cluster2.*local'
+_subctl show all --context cluster2 | tee /dev/stderr | (sponge ||:) | grep -q 'cluster2.*local'
 # Multiple-context variants list the clusters, even when there's only one
-_subctl show all --contexts cluster1 | tee /dev/stderr | sponge | grep -qv 'Cluster "cluster2"'
-_subctl show all --contexts cluster2 | tee /dev/stderr | sponge | grep -q 'Cluster "cluster2"'
+_subctl show all --contexts cluster1 | tee /dev/stderr | (sponge ||:) | grep -qv 'Cluster "cluster2"'
+_subctl show all --contexts cluster2 | tee /dev/stderr | (sponge ||:) | grep -q 'Cluster "cluster2"'
 
 # Test subctl gather invocations
 
@@ -163,21 +163,21 @@ with_context "${clusters[0]}" test_subctl_diagnose_in_cluster
 
 # Test subctl benchmark invocations
 
-_subctl benchmark latency --context cluster1 | tee /dev/stderr | sponge | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
-_subctl benchmark latency --context cluster1 --tocontext cluster2 | tee /dev/stderr | sponge | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
+_subctl benchmark latency --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark latency --context cluster1 --tocontext cluster2 | tee /dev/stderr | (sponge ||:) | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
 
-_subctl benchmark throughput --context cluster1 | tee /dev/stderr | sponge | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark throughput --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
 _subctl benchmark throughput --context cluster1 --tocontext cluster2
 
 # Deprecated variant with contexts
-_subctl benchmark latency --intra-cluster --kubecontexts cluster1 | tee /dev/stderr | sponge | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
-_subctl benchmark latency --kubecontexts cluster1,cluster2 | tee /dev/stderr | sponge | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
+_subctl benchmark latency --intra-cluster --kubecontexts cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark latency --kubecontexts cluster1,cluster2 | tee /dev/stderr | (sponge ||:) | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
 
-_subctl benchmark throughput --intra-cluster --kubecontexts cluster1 | tee /dev/stderr | sponge | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+_subctl benchmark throughput --intra-cluster --kubecontexts cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
 _subctl benchmark throughput --kubecontexts cluster1,cluster2
 
 # Deprecated variant with kubeconfigs
-_subctl benchmark latency "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 | tee /dev/stderr | sponge | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
+_subctl benchmark latency "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 | tee /dev/stderr | (sponge ||:) | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
 
 _subctl benchmark throughput "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2
 


### PR DESCRIPTION
In system tests, when the tests produce large amounts of output which is ultimately fed to "grep -q", if the sought-after pattern is found early enough, the large quantity of pending output results in a SIGPIPE in sponge (manifesting itself as a 141 error from Make, 141 being 128 + 13, SIGPIPE).

Using "(sponge ||:)" instead of sponge causes sponge's exit status to effectively be ignored. tee doesn't need this handling, ignoring sponge is sufficient.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
