### PR TITLE
subctl diagnose shows pod security warnings on OCP 4.12

### DIFF
--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -42,8 +42,7 @@ func Ensure(status reporter.Interface, clientProducer client.Producer, operatorN
 	}
 
 	operatorNamespaceLabels := map[string]string{
-		"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/audit": "privileged",
-		"pod-security.kubernetes.io/warn": "privileged",
+		"pod-security.kubernetes.io/enforce": "privileged",
 	}
 
 	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace, operatorNamespaceLabels); err != nil {


### PR DESCRIPTION
We set and check for all 3 of the `pod-security.kubernetes.io/*` namespace labels (`audit`, `warn`, and `enforce`) but, when set to the same mode, only one is really necessary since they have precedence. So it seems that OCP 4.12 removes the unnecessary `audit` and `warn` labels when `enforce` is set resulting in a warning from `subctl diagnose`. So the code was changed to only look for one of them and also to set only `enforce`.

From the K8s [Pod Security](https://kubernetes.io/docs/concepts/security/pod-security-admission/) docs:

Mode | Description
-- | --
**enforce** | Policy violations will cause the pod to be rejected.
**audit** | Policy violations will trigger the addition of an audit annotation to the event recorded in the audit log, but are otherwise allowed.
**warn** | Policy violations will trigger a user-facing warning, but are otherwise allowed.

Related to https://github.com/submariner-io/subctl/issues/348
