### PR TITLE
Automated backport of #349: subctl diagnose shows pod security warnings on OCP 4.12

### DIFF
--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -42,8 +42,7 @@ func Ensure(status reporter.Interface, clientProducer client.Producer, operatorN
 	}
 
 	operatorNamespaceLabels := map[string]string{
-		"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/audit": "privileged",
-		"pod-security.kubernetes.io/warn": "privileged",
+		"pod-security.kubernetes.io/enforce": "privileged",
 	}
 
 	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace, operatorNamespaceLabels); err != nil {


### PR DESCRIPTION
Backport of #349 on release-0.14.

#349: subctl diagnose shows pod security warnings on OCP 4.12

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Fixes https://github.com/submariner-io/subctl/issues/348