### PR TITLE
Specify the namespace on deprecated verify

### DIFF
--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -118,7 +118,8 @@ prompt for confirmation therefore you must specify --enable-disruptive to run th
 				func(fromClusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 					return restconfig.NewProducerFrom(args[1], "").RunOnSelectedContext( //nolint:wrapcheck // No need to wrap errors here.
 						func(toClusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-							return runVerify(fromClusterInfo, toClusterInfo, namespace, testType)
+							// This deprecated variant doesn't handle a namespace argument
+							return runVerify(fromClusterInfo, toClusterInfo, constants.OperatorNamespace, testType)
 						}, status)
 				}, cli.NewReporter()))
 


### PR DESCRIPTION
subctl verify supports a deprecated two-argument form:

    subctl verify kubeconfig1 kubeconfig2

In this variant, the default namespace isn't set up, since the internal contexts are constructed using the arguments rather than the command-line options (which are configured with the appropriate default namespace). Since the deprecated form never allowed a custom namespace to be specified, the namespace provided by RunOnSelectedContext can be overridden with the correct namespace without having to care about user-specified values.

Fixes: #363
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
