### PR TITLE
Refactor `cloud prepare rhos` flag docs

### DIFF
--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -63,13 +63,13 @@ var (
 
 func init() {
 	addGeneralRHOSFlags := func(command *cobra.Command) {
-		command.Flags().StringVar(&rhosConfig.InfraID, infraIDFlag, "", "RHOS infra ID")
-		command.Flags().StringVar(&rhosConfig.Region, regionFlag, "", "RHOS region")
-		command.Flags().StringVar(&rhosConfig.ProjectID, projectIDFlag, "", "RHOS project ID")
+		command.Flags().StringVar(&rhosConfig.InfraID, infraIDFlag, "", "OpenStack infra ID")
+		command.Flags().StringVar(&rhosConfig.Region, regionFlag, "", "OpenStack region")
+		command.Flags().StringVar(&rhosConfig.ProjectID, projectIDFlag, "", "OpenStack project ID")
 		command.Flags().StringVar(&rhosConfig.OcpMetadataFile, "ocp-metadata", "",
 			"OCP metadata.json file (or the directory containing it) from which to read the RHOS infra ID "+
 				"and region from (takes precedence over the specific flags)")
-		command.Flags().StringVar(&rhosConfig.CloudEntry, cloudEntryFlag, "", "the cloud entry to use")
+		command.Flags().StringVar(&rhosConfig.CloudEntry, cloudEntryFlag, "", "Specific cloud configuration to use from the clouds.yaml")
 	}
 
 	addGeneralRHOSFlags(rhosPrepareCmd)


### PR DESCRIPTION
There are many differences between the subctl output and the docs. Try to take the best from both, and update both to be the same.

Pairs with submariner-io/submariner-website#850 update the docs about the command.

Relates-to: submariner-io/submariner-website#848
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
