### PR TITLE
Automated backport of #364: Specify the namespace on deprecated verify

### DIFF
--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -118,7 +118,8 @@ prompt for confirmation therefore you must specify --enable-disruptive to run th
 				func(fromClusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 					return restconfig.NewProducerFrom(args[1], "").RunOnSelectedContext( //nolint:wrapcheck // No need to wrap errors here.
 						func(toClusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-							return runVerify(fromClusterInfo, toClusterInfo, namespace, testType)
+							// This deprecated variant doesn't handle a namespace argument
+							return runVerify(fromClusterInfo, toClusterInfo, constants.OperatorNamespace, testType)
 						}, status)
 				}, cli.NewReporter()))
 


### PR DESCRIPTION
Backport of #364 on release-0.14.

#364: Specify the namespace on deprecated verify

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.