### PR TITLE
Automated backport of #366: Fix operator OCP cluster role setup

### DIFF
--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -60,7 +60,7 @@ func Ensure(status reporter.Interface, clientProducer client.Producer, operatorN
 	componentsRbac := []ocp.RbacInfo{
 		{
 			ComponentName:          names.OperatorComponent,
-			ClusterRoleFile:        embeddedyamls.Config_rbac_submariner_operator_cluster_role_yaml,
+			ClusterRoleFile:        embeddedyamls.Config_rbac_submariner_operator_ocp_cluster_role_yaml,
 			ClusterRoleBindingFile: embeddedyamls.Config_rbac_submariner_operator_ocp_cluster_role_binding_yaml,
 		},
 	}


### PR DESCRIPTION
Backport of #366 on release-0.14.

#366: Fix operator OCP cluster role setup

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.