### PR TITLE
Automated backport of #372: Use clusterID instead of clusterName to get endpoint

### DIFF
--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -244,7 +244,7 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, names
 
 	defer sPod.Delete()
 
-	gatewayPodIP, err := getGatewayIP(remoteClusterInfo, localClusterInfo.Name, status)
+	gatewayPodIP, err := getGatewayIP(remoteClusterInfo, localClusterInfo.Submariner.Status.ClusterID, status)
 	if err != nil {
 		return status.Error(err, "Error retrieving the gateway IP of cluster %q", localClusterInfo.Name)
 	}


### PR DESCRIPTION
Backport of #372 on release-0.14.

#372: Use clusterID instead of clusterName to get endpoint

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.