### PR TITLE
Gather: capture CIDRs as part of summary.html page

### DIFF
--- a/internal/gather/layout.gohtml
+++ b/internal/gather/layout.gohtml
@@ -30,6 +30,18 @@
     <td>{{.ClusterConfig.CNIPlugin}}</td>
   </tr>
   <tr>
+    <td>Cluster CIDR:</td>
+    <td>{{.ClusterConfig.ClusterCIDR}}</td>
+  </tr>
+  <tr>
+    <td>Service CIDR:</td>
+    <td>{{.ClusterConfig.ServiceCIDR}}</td>
+  </tr>
+  <tr>
+    <td>Global CIDR:</td>
+    <td>{{.ClusterConfig.GlobalCIDR}}</td>
+  </tr>
+  <tr>
     <td>Cloud Provider:</td>
     <td>{{.ClusterConfig.CloudProvider}}</td>
   </tr>

--- a/internal/gather/summary.go
+++ b/internal/gather/summary.go
@@ -92,10 +92,17 @@ func getClusterConfig(info *Info) clusterConfig {
 	}
 
 	config.CNIPlugin = "Not found"
+	config.GlobalCIDR = "N/A"
 	config.CloudProvider = "N/A" // Broker clusters won't have Submariner to gather information from
 
 	if info.Submariner != nil {
 		config.CNIPlugin = info.Submariner.Status.NetworkPlugin
+		config.ClusterCIDR = info.Submariner.Status.ClusterCIDR
+		config.ServiceCIDR = info.Submariner.Status.ServiceCIDR
+
+		if len(info.Submariner.Status.GlobalCIDR) > 0 {
+			config.GlobalCIDR = info.Submariner.Status.GlobalCIDR
+		}
 	}
 
 	return config

--- a/internal/gather/types.go
+++ b/internal/gather/types.go
@@ -48,6 +48,9 @@ type version struct {
 
 type clusterConfig struct {
 	CNIPlugin        string
+	ServiceCIDR      string
+	ClusterCIDR      string
+	GlobalCIDR       string
 	CloudProvider    v1alpha1.CloudProvider
 	TotalNode        int
 	GatewayNode      map[string]types.UID


### PR DESCRIPTION
As part of subctl gather command, we capture a summary.html page which serves as a quick reference to the clusterInfo and has links to various log files. If we capture the CIDRs as well in this page, it will help in saving time while debugging any issues.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
