### PR TITLE
Replace io/ioutil with os or io package

### DIFF
--- a/internal/env/term_test.go
+++ b/internal/env/term_test.go
@@ -18,7 +18,7 @@ package env_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/submariner-io/subctl/internal/env"
@@ -41,7 +41,7 @@ func TestIsTerminal(t *testing.T) {
 	}
 
 	// test a file
-	f, err := ioutil.TempFile("", "kind-isterminal")
+	f, err := os.CreateTemp("", "kind-isterminal")
 	if err != nil {
 		t.Fatalf("Failed to create tempfile %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil
/kind cleanup
