### PR TITLE
Automated backport of #349: subctl diagnose shows pod security warnings on OCP 4.12

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -293,29 +293,29 @@ func checkNSLabels(config *Config) error {
 		"pod-security.kubernetes.io/warn":    "privileged",
 	}
 
-	missingLabels := map[string]string{}
+	foundOne := false
 
 	for key, expectedLabel := range expectedLabels {
 		actualLabel, found := ns.Labels[key]
-		if !found || actualLabel != expectedLabel {
-			missingLabels[key] = expectedLabel
+		if found && actualLabel == expectedLabel {
+			foundOne = true
+			break
 		}
 	}
 
-	if len(missingLabels) != 0 {
-		warnAbout(missingLabels, ns.Name)
+	if foundOne {
+		return nil
 	}
 
-	return nil
-}
+	labelStr := ""
+	for key, val := range expectedLabels {
+		labelStr += fmt.Sprintf("  %s=%s", key, val) + "\n"
+	}
 
-func warnAbout(missingLabels map[string]string, namespace string) {
 	status := cli.NewReporter()
 	status.Warning("Starting with Kubernetes 1.23, the Pod Security admission controller expects namespaces to have security labels."+
 		" Without these, you will see warnings in subctl's output. subctl should work fine, but you can avoid the warnings and ensure "+
-		"correct behavior by adding these labels to the namespace %s:", namespace)
+		"correct behavior by adding at least one of these labels to the namespace %q:\n%s", config.Namespace, labelStr)
 
-	for key, val := range missingLabels {
-		status.Warning(fmt.Sprintf("%s %s", key, val))
-	}
+	return nil
 }

--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -40,8 +40,7 @@ func Ensure(status reporter.Interface, clientProducer client.Producer, operatorN
 	}
 
 	operatorNamespaceLabels := map[string]string{
-		"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/audit": "privileged",
-		"pod-security.kubernetes.io/warn": "privileged",
+		"pod-security.kubernetes.io/enforce": "privileged",
 	}
 
 	if created, err := namespace.Ensure(clientProducer.ForKubernetes(), operatorNamespace, operatorNamespaceLabels); err != nil {

--- a/scripts/kind-e2e/lib_operator_verify_subm.sh
+++ b/scripts/kind-e2e/lib_operator_verify_subm.sh
@@ -46,8 +46,6 @@ function verify_subm_operator() {
 
   # Verify SubM operator namespace has required pod security labels
   kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/enforce\":\"privileged\"'
-  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/audit\":\"privileged\"'
-  kubectl get ns $subm_ns -o=jsonpath='{.metadata.labels}' | grep '\"pod-security.kubernetes.io/warn\":\"privileged\"'
 
   # Verify SubM Operator CRD
   kubectl get crds submariners.submariner.io


### PR DESCRIPTION
Backport of #349 on release-0.13.

#349: subctl diagnose shows pod security warnings on OCP 4.12

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.