### PR TITLE
Configure dependabot for GHAs on 0.12 and 0.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: weekly
   - package-ecosystem: github-actions
     directory: '/'
+    target-branch: "release-0.12"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: '/'
     target-branch: "release-0.13"
     schedule:
       interval: weekly


### PR DESCRIPTION
Some of the actions we rely on need to be upgrades because of feature deprecations in underlying GHA features.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
