### PR TITLE
[Backport] Use submariner-operator ns in diagnose firewall cmd

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -247,8 +247,10 @@ func runLocalRemoteCommand(command *cobra.Command, localRemoteRestConfigProducer
 	if len(args) == 2 {
 		status.Warning("The two-argument form of %s is deprecated, see the documentation for details", command.Name())
 
-		localProducer := restconfig.NewProducerFrom(args[0], "")
-		remoteProducer := restconfig.NewProducerFrom(args[1], "")
+		localProducer := restconfig.NewProducerFrom(args[0], "").
+			WithDefaultNamespace(constants.OperatorNamespace)
+		remoteProducer := restconfig.NewProducerFrom(args[1], "").
+			WithDefaultNamespace(constants.OperatorNamespace)
 
 		exit.OnError(localProducer.RunOnSelectedContext(
 			func(localClusterInfo *cluster.Info, localNamespace string, status reporter.Interface) error {


### PR DESCRIPTION
When passing individual kubeconfigs for subctl diagnose firewall cmd, it was noticed that we were not overriding the namespace to submariner-operator, because of this, the diagnose pods were scheduled in the default namespace which is not what we want. This PR fixes it.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit c180809a5245b5ccc335960d0ffe08d7ca61ebd1)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
