### PR TITLE
Move cloudPorts into cloudOptions

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -42,7 +42,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.AWS(clusterInfo, &cloudPorts, &awsConfig, cloudOptions.useLoadBalancer, status) //nolint:wrapcheck // Not needed.
+					return prepare.AWS( //nolint:wrapcheck // Not needed.
+						clusterInfo, &cloudOptions.ports, &awsConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -41,7 +41,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.Azure(clusterInfo, &cloudPorts, &azureConfig, cloudOptions.useLoadBalancer, status) //nolint:wrapcheck // Not needed.
+					return prepare.Azure( //nolint:wrapcheck // Not needed.
+						clusterInfo, &cloudOptions.ports, &azureConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/cloud.go
+++ b/cmd/subctl/cloud.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	cloudPorts   cloud.Ports
 	cloudOptions struct {
+		ports           cloud.Ports
 		useLoadBalancer bool
 	}
 
@@ -64,11 +64,11 @@ func init() {
 	cloudRestConfigProducer.SetupFlags(cloudCmd.PersistentFlags())
 	rootCmd.AddCommand(cloudCmd)
 
-	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Natt, "natt-port", port.ExternalTunnel,
+	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudOptions.ports.Natt, "natt-port", port.ExternalTunnel,
 		"IPSec NAT traversal port")
-	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.NatDiscovery, "nat-discovery-port",
+	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudOptions.ports.NatDiscovery, "nat-discovery-port",
 		port.NATTDiscovery, "NAT discovery port")
-	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudPorts.Vxlan, "vxlan-port", port.IntraClusterVxLAN, "Internal VXLAN port")
+	cloudPrepareCmd.PersistentFlags().Uint16Var(&cloudOptions.ports.Vxlan, "vxlan-port", port.IntraClusterVxLAN, "Internal VXLAN port")
 
 	ports := []uint16{}
 

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -44,7 +44,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.GCP(clusterInfo, &cloudPorts, &gcpConfig, cloudOptions.useLoadBalancer, status) //nolint:wrapcheck // Not needed.
+					return prepare.GCP( //nolint:wrapcheck // Not needed.
+						clusterInfo, &cloudOptions.ports, &gcpConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -41,7 +41,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return prepare.RHOS(clusterInfo, &cloudPorts, &rhosConfig, cloudOptions.useLoadBalancer, status) //nolint:wrapcheck // Not needed.
+					return prepare.RHOS( //nolint:wrapcheck // Not needed.
+						clusterInfo, &cloudOptions.ports, &rhosConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/submariner-io/submariner v0.14.0-m2.0.20221122092810-c3c4cb4ea0e9
 	github.com/submariner-io/submariner-operator v0.14.0-m2.0.20221115181201-e6890cc75dfa
 	github.com/uw-labs/lichen v0.1.7
+	golang.org/x/net v0.2.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	google.golang.org/api v0.103.0
 	k8s.io/api v0.25.4
@@ -107,7 +108,6 @@ require (
 	github.com/urfave/cli/v2 v2.4.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.0.0-20220511200225-c6db032c6c88 // indirect
-	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect


### PR DESCRIPTION
Now that we have a data structure for cloud options, use it for all options.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
