### PR TITLE
Fix ipvs interface missing message

### DIFF
--- a/pkg/diagnose/kubeproxy.go
+++ b/pkg/diagnose/kubeproxy.go
@@ -29,6 +29,7 @@ import (
 const (
 	kubeProxyIPVSIfaceCommand = "ip a s kube-ipvs0"
 	missingInterface          = "ip: can't find device"
+	notEnabled                = "Device \"kube-ipvs0\" does not exist"
 )
 
 func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
@@ -49,7 +50,7 @@ func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.
 		return status.Error(err, "Error spawning the network pod")
 	}
 
-	if !strings.Contains(podOutput, missingInterface) {
+	if !(strings.Contains(podOutput, missingInterface) || strings.Contains(podOutput, notEnabled)) {
 		status.Failure("The cluster is deployed with kube-proxy ipvs mode which Submariner does not support")
 		return nil
 	}


### PR DESCRIPTION
When ipvs interface is missing, upstream and downstream ip tools dislay different output messages. Check for both the messages in our kube proxy support mode test.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
