### PR TITLE
Automated backport of #423: Fix ipvs interface missing message

### DIFF
--- a/pkg/diagnose/kubeproxy.go
+++ b/pkg/diagnose/kubeproxy.go
@@ -29,6 +29,7 @@ import (
 const (
 	kubeProxyIPVSIfaceCommand = "ip a s kube-ipvs0"
 	missingInterface          = "ip: can't find device"
+	notEnabled                = "Device \"kube-ipvs0\" does not exist"
 )
 
 func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
@@ -49,7 +50,7 @@ func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.
 		return status.Error(err, "Error spawning the network pod")
 	}
 
-	if !strings.Contains(podOutput, missingInterface) {
+	if !(strings.Contains(podOutput, missingInterface) || strings.Contains(podOutput, notEnabled)) {
 		status.Failure("The cluster is deployed with kube-proxy ipvs mode which Submariner does not support")
 		return nil
 	}


### PR DESCRIPTION
Backport of #423 on release-0.14.

#423: Fix ipvs interface missing message

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.