### PR TITLE
Improve diagnose firewall error output

### DIFF
--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -208,7 +208,7 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, names
 	// The following construct ensures that tcpdump will be stopped as soon as the message is seen, instead of waiting
 	// for a timeout; but when the message isn't seen, it will be killed once the timeout expires
 	podCommand := fmt.Sprintf(
-		"(tcpdump --immediate-mode -ln -Q in -A -s 100 -i any udp and %s & pid=\"$!\"; (sleep %d; kill \"$pid\") &) | grep -m1 '%s'",
+		"(tcpdump --immediate-mode -ln -Q in -A -s 100 -i any udp and %s & pid=\"$!\"; (sleep %d; kill \"$pid\") &) | sed '/%s/q'",
 		portFilter, options.ValidationTimeout, clientMessage)
 
 	sPod, err := spawnSnifferPodOnNode(localClusterInfo.ClientProducer.ForKubernetes(), gwNodeName, namespace, podCommand,
@@ -246,17 +246,29 @@ func verifyConnectivity(localClusterInfo, remoteClusterInfo *cluster.Info, names
 	}
 
 	if options.VerboseOutput {
-		status.Success("tcpdump output from sniffer pod on Gateway node")
-		status.Success(sPod.PodOutput)
+		status.Success("tcpdump output from sniffer pod on Gateway node:\n%s", sPod.PodOutput)
 	}
 
 	if !strings.Contains(sPod.PodOutput, clientMessage) {
 		return status.Error(fmt.Errorf("the tcpdump output from the sniffer pod does not include the message"+
 			" sent from client pod. Please check that your firewall configuration allows UDP/%d traffic"+
-			" on the %q node", destPort, localEndpoint.Spec.Hostname), "Error")
+			" on the %q node. Actual pod output: \n%s", destPort, localEndpoint.Spec.Hostname, truncate(sPod.PodOutput)), "")
 	}
 
 	return nil
+}
+
+func truncate(s string) string {
+	maxLength := 500
+	r := []rune(s)
+
+	if maxLength >= len(r) {
+		return s
+	}
+
+	truncatedText := "... (truncated)"
+
+	return string(r[:maxLength]) + truncatedText
 }
 
 func getTargetPort(submariner *v1alpha1.Submariner, endpoint *subv1.Endpoint, tgtport TargetPort) (int32, error) {

--- a/pkg/diagnose/firewall_vxlan.go
+++ b/pkg/diagnose/firewall_vxlan.go
@@ -112,20 +112,22 @@ func checkFWConfig(clusterInfo *cluster.Info, namespace string, options Firewall
 	}
 
 	if options.VerboseOutput {
-		status.Success("tcpdump output from the sniffer pod on Gateway node")
-		status.Success(sPod.PodOutput)
+		status.Success("tcpdump output from the sniffer pod on Gateway node:\n%s", sPod.PodOutput)
 	}
 
 	// Verify that tcpdump output (i.e, from snifferPod) contains the remoteClusterIP
 	if !strings.Contains(sPod.PodOutput, remoteClusterIP) {
 		status.Failure("The tcpdump output from the sniffer pod does not contain the expected remote"+
-			" endpoint IP %s. Please check that your firewall configuration allows UDP/4800 traffic.", remoteClusterIP)
+			" endpoint IP %s. Please check that your firewall configuration allows UDP/4800 traffic. Actual pod output: \n%s",
+			remoteClusterIP, truncate(sPod.PodOutput))
+
 		return
 	}
 
 	// Verify that tcpdump output (i.e, from snifferPod) contains the clientPod IPaddress
 	if !strings.Contains(sPod.PodOutput, cPod.Pod.Status.PodIP) {
 		status.Failure("The tcpdump output from the sniffer pod does not contain the client pod's IP."+
-			" There seems to be some issue with the IPTable rules programmed on the %q node", cPod.Pod.Spec.NodeName)
+			" There seems to be some issue with the IPTable rules programmed on the %q node, Actual pod output: \n%s",
+			cPod.Pod.Spec.NodeName, truncate(sPod.PodOutput))
 	}
 }


### PR DESCRIPTION
These commands spawn a pod to run a `tcpdump` command and reports a failure if the output doesn't contain an expected string. We should also report the pod output in case the `tcpdump` command fails.

For the `inter-cluster` command, the `tcpdump` output is piped to `grep` to match the expected client message and stop when found. However if an error occurs then the message isn't matched and therefore the pod output is empty which isn't useful. Use `sed` instead of `grep` which also outputs the non-matching lines.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
