### PR TITLE
Improve error reporting for failed network pods

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -20,6 +20,8 @@ package pods
 
 import (
 	"context"
+	"encoding/json"
+	goerrors "errors"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -29,6 +31,7 @@ import (
 	"github.com/submariner-io/subctl/pkg/image"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -189,21 +192,27 @@ func (np *Scheduled) Delete() {
 func (np *Scheduled) awaitUntilScheduled() error {
 	pods := np.Config.ClientSet.CoreV1().Pods(np.Config.Namespace)
 
-	pod, _, err := framework.AwaitResultOrError("await pod ready",
+	pod, errmsg, err := framework.AwaitResultOrError("await pod ready",
 		func() (interface{}, error) {
 			return pods.Get(context.TODO(), np.Pod.Name, metav1.GetOptions{})
 		}, func(result interface{}) (bool, string, error) {
 			pod := result.(*v1.Pod)
 			if pod.Status.Phase != v1.PodRunning && pod.Status.Phase != v1.PodSucceeded {
+				statusStr, _ := json.MarshalIndent(pod.Status, "", "  ")
 				if pod.Status.Phase != v1.PodPending {
-					return false, "", fmt.Errorf("unexpected pod phase %v - expected %v or %v",
-						pod.Status.Phase, v1.PodPending, v1.PodRunning)
+					return false, "", fmt.Errorf("expected pod phase %v or %v. Actual pod status: %s",
+						v1.PodPending, v1.PodRunning, statusStr)
 				}
-				return false, fmt.Sprintf("Pod %q is still pending", pod.Name), nil
+
+				return false, fmt.Sprintf("Pod %q is still pending: Pod status: %s", pod.Name, statusStr), nil
 			}
 
 			return true, "", nil // pod is either running or has completed its execution
 		})
+	if goerrors.Is(err, wait.ErrWaitTimeout) {
+		return errors.New(errmsg)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the pod isn't scheduled, capture the reason and the pod status rather than vaguely reporting that it timed out.
