### PR TITLE
Give more permission to the diagnose pods

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 )
 
 type schedulingType int
@@ -154,6 +155,12 @@ func (np *Scheduled) schedule() error {
 				Add:  []v1.Capability{"NET_ADMIN", "NET_RAW"},
 				Drop: []v1.Capability{"all"},
 			},
+			// Some containers which run os like rhel/fedora runs tcpdump
+			// as specific user id "72". So it needs pods to be privileged
+			// Also setting the runAsUser prevent the pods from starting with
+			// random user id
+			Privileged: pointer.Bool(true),
+			RunAsUser:  pointer.Int64(0),
 		}
 	}
 


### PR DESCRIPTION
 Some containers which run os like rhel/fedora run tcpdump
as specific user id "72". So it needs pods to be privileged.
Also setting the runAsUser prevents the pods from starting with
random user id

* Make the diagnose pod a privileged
* Run the diagnose pod with userId 0

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
