### PR TITLE
Stop pretending to support Kubernetes 1.17

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -31,8 +31,8 @@ import (
 var Version = "devel"
 
 const (
-	minK8sMajor = 1 // We need K8s 1.17 for endpoint slices
-	minK8sMinor = 17
+	minK8sMajor = 1  // We need K8s 1.17 for endpoint slices;
+	minK8sMinor = 19 // 1.19 is the oldest we test with
 )
 
 // PrintSubctlVersion will print the version subctl was compiled under.


### PR DESCRIPTION
At some point we lost the ability to test against Kubernetes 1.17; let's stop pretending to support it (it reached EOL on 2021-01-13).

The oldest version we test against after 1.17 is 1.19; this reached its EOL on 2021-10-28. (See
https://kubernetes.io/releases/patch-releases/ for details.)

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
