### PR TITLE
Automated backport of #433: Give more permission for the diagnode pods

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 )
 
 type schedulingType int
@@ -153,6 +154,12 @@ func (np *Scheduled) schedule() error {
 				Add:  []v1.Capability{"NET_ADMIN", "NET_RAW"},
 				Drop: []v1.Capability{"all"},
 			},
+			// Some containers which run os like rhel/fedora runs tcpdump
+			// as specific user id "72". So it needs pods to be privileged
+			// Also setting the runAsUser prevent the pods from starting with
+			// random user id
+			Privileged: pointer.Bool(true),
+			RunAsUser:  pointer.Int64(0),
 		}
 	}
 


### PR DESCRIPTION
Backport of #433 on release-0.13.

#433: Give more permission for the diagnode pods

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.