### PR TITLE
[Backport] Gather iptables logs for Calico and kindnet CNIs (#469)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/cloud-prepare v0.13.3
 	github.com/submariner-io/lighthouse v0.13.3
 	github.com/submariner-io/shipyard v0.13.3
-	github.com/submariner-io/submariner v0.13.3
+	github.com/submariner-io/submariner v0.13.4-0.20230113101652-407d8d7488b1
 	github.com/submariner-io/submariner-operator v0.13.3
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb

--- a/go.sum
+++ b/go.sum
@@ -1361,8 +1361,9 @@ github.com/submariner-io/lighthouse v0.13.3 h1:2aYO4V95ZL2i0tMUXURq4dErqXxaWeC7N
 github.com/submariner-io/lighthouse v0.13.3/go.mod h1:3pbAIF+4lwnQaJfvHY6Pzu/5Wcwex5KFzlhh8NcxdM4=
 github.com/submariner-io/shipyard v0.13.3 h1:K/8zoreIg0yFjNltITJQ2WywHvPrJU+JjcB3YJQgqVg=
 github.com/submariner-io/shipyard v0.13.3/go.mod h1:ht4eXvPKlBTUvPy/9hHdxKj2ZwAoyJ6EnsVEVsU+fI8=
-github.com/submariner-io/submariner v0.13.3 h1:MR0vRRV+LjHC9Rs86A5vcSpfSHzSStUz/rhupjBFqoE=
 github.com/submariner-io/submariner v0.13.3/go.mod h1:rC6W8PM5zvj7aORe/0IDZ9sVh/FvGjTZ5SobA2LLDZM=
+github.com/submariner-io/submariner v0.13.4-0.20230113101652-407d8d7488b1 h1:Euk7xrMGisQSq8T/FU53vaSCsIpffi0maHrpKkvVZEE=
+github.com/submariner-io/submariner v0.13.4-0.20230113101652-407d8d7488b1/go.mod h1:rC6W8PM5zvj7aORe/0IDZ9sVh/FvGjTZ5SobA2LLDZM=
 github.com/submariner-io/submariner-operator v0.13.3 h1:WsqtEFkvtPZorywsSntkt+46l5kLuFWcktKES3J/Wkw=
 github.com/submariner-io/submariner-operator v0.13.3/go.mod h1:mRjqYdxwkdCfv1EZR7A6bDG4x0muXz9tkaUt5inQGqY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -20,6 +20,7 @@ package gather
 
 import (
 	"github.com/submariner-io/subctl/internal/pods"
+	"github.com/submariner-io/submariner/pkg/cni"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -78,12 +79,15 @@ var ovnCmds = map[string]string{
 }
 
 var networkPluginCNIType = map[string]string{
-	"generic":       typeIPTables,
-	"canal-flannel": typeIPTables,
-	"weave-net":     typeIPTables,
-	"OpenShiftSDN":  typeIPTables,
-	"OVNKubernetes": typeOvn,
-	"unknown":       typeUnknown,
+	cni.Generic:       typeIPTables,
+	cni.Calico:        typeIPTables,
+	cni.CanalFlannel:  typeIPTables,
+	cni.Flannel:       typeIPTables,
+	cni.KindNet:       typeIPTables,
+	cni.OpenShiftSDN:  typeIPTables,
+	cni.OVNKubernetes: typeOvn,
+	cni.WeaveNet:      typeIPTables,
+	"unknown":         typeUnknown,
 }
 
 func gatherCNIResources(info *Info, networkPlugin string) {


### PR DESCRIPTION
It was seen that subctl gather was not capturing the iptables and other associated details from the worker nodes when the CNI happens to be Calico (as well as kindnet). This PR fixes it.

Depends on https://github.com/submariner-io/submariner/pull/2244
Related to: https://github.com/submariner-io/submariner/issues/2220
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 819bd54794feee95c870b788d1140ae035868087)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
