### PR TITLE
[Backport]Gather iptables logs for Calico and kindnet CNIs (#469)

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -20,6 +20,7 @@ package gather
 
 import (
 	"github.com/submariner-io/subctl/internal/pods"
+	"github.com/submariner-io/submariner/pkg/cni"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -83,12 +84,15 @@ var ovnCmds = map[string]string{
 }
 
 var networkPluginCNIType = map[string]string{
-	"generic":       typeIPTables,
-	"canal-flannel": typeIPTables,
-	"weave-net":     typeIPTables,
-	"OpenShiftSDN":  typeIPTables,
-	"OVNKubernetes": typeOvn,
-	"unknown":       typeUnknown,
+	cni.Generic:       typeIPTables,
+	cni.Calico:        typeIPTables,
+	cni.CanalFlannel:  typeIPTables,
+	cni.Flannel:       typeIPTables,
+	cni.KindNet:       typeIPTables,
+	cni.OpenShiftSDN:  typeIPTables,
+	cni.OVNKubernetes: typeOvn,
+	cni.WeaveNet:      typeIPTables,
+	"unknown":         typeUnknown,
 }
 
 func gatherCNIResources(info *Info, networkPlugin string) {


### PR DESCRIPTION
It was seen that subctl gather was not capturing the iptables and other associated details from the worker nodes when the CNI happens to be Calico (as well as kindnet). This PR fixes it.

Related to: https://github.com/submariner-io/submariner/issues/2220
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 819bd54794feee95c870b788d1140ae035868087)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
