### PR TITLE
Recover broker-info.subm

### DIFF
--- a/pkg/broker/reconstruct.go
+++ b/pkg/broker/reconstruct.go
@@ -1,0 +1,72 @@
+package broker
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/rbac"
+	"github.com/submariner-io/subctl/pkg/cluster"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ReconstructData(
+	brokerCluster, submCluster *cluster.Info, namespace string, status reporter.Interface,
+	ipsecSubmFile string) error {
+	status.Start("Retrieving data to reconstruct broker-info.subm")
+    defer status.End()
+
+	data := &Info{}
+	var err error
+
+	data.BrokerURL = brokerCluster.RestConfig.Host + brokerCluster.RestConfig.APIPath
+
+	data.ClientToken, err = rbac.GetClientTokenSecret(
+		context.TODO(), brokerCluster.ClientProducer.ForKubernetes(), namespace,
+		constants.SubmarinerBrokerAdminSA,
+	)
+	if err != nil {
+		return status.Error(err, "error getting broker client secret")
+	}
+
+	if brokerCluster.Broker != nil {
+		data.Components = brokerCluster.Broker.Spec.Components
+		data.ServiceDiscovery = data.IsServiceDiscoveryEnabled()
+		data.CustomDomains = brokerCluster.Broker.Spec.DefaultCustomDomains
+	} else if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+		return status.Error(err, "error retrieving Broker")
+	}
+
+	if submCluster.Submariner != nil {
+		status.Success("Retrieving IPSec PSK secret from Submariner found on cluster %s", submCluster.Name)
+		data.IPSecPSK = &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ipsecPSKSecretName,
+			},
+			Data: map[string][]byte{"psk": []byte(submCluster.Submariner.Spec.CeIPSecPSK)},
+		}
+	} else if ipsecSubmFile != "" {
+		status.Success("Retrieving IPSec PSK from the file %s", ipsecSubmFile)
+		ipsecData, err := ReadInfoFromFile(ipsecSubmFile)
+		if err != nil {
+			return errors.Wrapf(err, "error importing IPsec PSK secret from file %q", ipsecSubmFile)
+		}
+
+		data.IPSecPSK = ipsecData.IPSecPSK
+	} else {
+		status.Success("Generating new IPSec PSK secret")
+		data.IPSecPSK, err = newIPSECPSKSecret()
+		if err != nil {
+			return status.Error(err, "error generating new IPSec PSK secret")
+		}
+	}
+
+	status.Success("Successfully retrieved the data. Writing it to broker-info.subm")
+
+	err = data.writeToFile("broker-info.subm")
+
+	return status.Error(err, "error reconstructing broker-info.subm")
+}


### PR DESCRIPTION
from the specified Broker and Submariner clusters.

IPSec PSK secret is first looked for in a Submariner CR, then from the file user provided and then generated new.

Epic: https://github.com/submariner-io/enhancements/issues/143

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
