### PR TITLE
Automated backport of #494: Add release notes for PR469

### DIFF
--- a/release-notes/20230111-gather-iptables.md
+++ b/release-notes/20230111-gather-iptables.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041 -->
+The `subctl gather` command now collects the iptables info from
+the cluster nodes for Calico and kindnet CNIs.


### PR DESCRIPTION
Backport of #494 on release-0.14.

#494: Add release notes for PR469

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.