### PR TITLE
Make sure to end status on `cloud` commands

### DIFF
--- a/pkg/cloud/cleanup/aws.go
+++ b/pkg/cloud/cleanup/aws.go
@@ -26,6 +26,7 @@ import (
 )
 
 func AWS(clusterInfo *cluster.Info, config *aws.Config, status reporter.Interface) error {
+	defer status.End()
 	err := aws.RunOn(clusterInfo, config, status,
 		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {

--- a/pkg/cloud/cleanup/azure.go
+++ b/pkg/cloud/cleanup/azure.go
@@ -26,6 +26,7 @@ import (
 )
 
 func Azure(clusterInfo *cluster.Info, config *azure.Config, status reporter.Interface) error {
+	defer status.End()
 	err := azure.RunOn(clusterInfo, config, status,
 		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {

--- a/pkg/cloud/cleanup/gcp.go
+++ b/pkg/cloud/cleanup/gcp.go
@@ -26,6 +26,7 @@ import (
 )
 
 func GCP(clusterInfo *cluster.Info, config *gcp.Config, status reporter.Interface) error {
+	defer status.End()
 	err := gcp.RunOn(clusterInfo, config, status,
 		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {

--- a/pkg/cloud/cleanup/generic.go
+++ b/pkg/cloud/cleanup/generic.go
@@ -26,6 +26,7 @@ import (
 )
 
 func GenericCluster(clusterInfo *cluster.Info, status reporter.Interface) error {
+	defer status.End()
 	err := generic.RunOnCluster(clusterInfo, status,
 		func(gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			return gwDeployer.Cleanup(status) //nolint:wrapcheck // No need to wrap here

--- a/pkg/cloud/cleanup/rhos.go
+++ b/pkg/cloud/cleanup/rhos.go
@@ -26,6 +26,7 @@ import (
 )
 
 func RHOS(clusterInfo *cluster.Info, config *rhos.Config, status reporter.Interface) error {
+	defer status.End()
 	err := rhos.RunOn(clusterInfo, config, status,
 		//nolint:wrapcheck // No need to wrap errors here
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {

--- a/pkg/cloud/prepare/aws.go
+++ b/pkg/cloud/prepare/aws.go
@@ -27,6 +27,7 @@ import (
 )
 
 func AWS(clusterInfo *cluster.Info, ports *cloud.Ports, config *aws.Config, useLoadBalancer bool, status reporter.Interface) error {
+	defer status.End()
 	status.Start("Preparing AWS cloud for Submariner deployment")
 
 	gwPorts, input, err := getPortConfig(clusterInfo.ClientProducer, ports, true)

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Azure(clusterInfo *cluster.Info, ports *cloud.Ports, config *azure.Config, useLoadBalancer bool, status reporter.Interface) error {
+	defer status.End()
 	status.Start("Preparing Azure cloud for Submariner deployment")
 
 	gwPorts, input, err := getPortConfig(clusterInfo.ClientProducer, ports, false)

--- a/pkg/cloud/prepare/gcp.go
+++ b/pkg/cloud/prepare/gcp.go
@@ -28,6 +28,8 @@ import (
 )
 
 func GCP(clusterInfo *cluster.Info, ports *cloud.Ports, config *gcp.Config, useLoadBalancer bool, status reporter.Interface) error {
+	defer status.End()
+
 	gwPorts, input, err := getPortConfig(clusterInfo.ClientProducer, ports, false)
 	if err != nil {
 		return status.Error(err, "Failed to prepare the cloud")

--- a/pkg/cloud/prepare/generic.go
+++ b/pkg/cloud/prepare/generic.go
@@ -26,6 +26,8 @@ import (
 )
 
 func GenericCluster(clusterInfo *cluster.Info, gateways int, status reporter.Interface) error {
+	defer status.End()
+
 	//nolint:wrapcheck // No need to wrap errors here.
 	err := generic.RunOnCluster(clusterInfo, status,
 		func(gwDeployer api.GatewayDeployer, status reporter.Interface) error {

--- a/pkg/cloud/prepare/rhos.go
+++ b/pkg/cloud/prepare/rhos.go
@@ -28,6 +28,8 @@ import (
 )
 
 func RHOS(clusterInfo *cluster.Info, ports *cloud.Ports, config *rhos.Config, useLoadBalancer bool, status reporter.Interface) error {
+	defer status.End()
+
 	gwPorts, input, err := getPortConfig(clusterInfo.ClientProducer, ports, false)
 	if err != nil {
 		return status.Error(err, "Failed to prepare the cloud")


### PR DESCRIPTION
When running `cloud prepare` or `cloud cleanup`, make sure to end the status so that it gets properly printed back to the user.

Resolves #519 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
