### PR TITLE
Automated backport of #518: Only call cloud prepare when it's needed

### DIFF
--- a/pkg/cloud/prepare/aws.go
+++ b/pkg/cloud/prepare/aws.go
@@ -53,7 +53,11 @@ func AWS(clusterInfo *cluster.Info, ports *cloud.Ports, config *aws.Config, stat
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare AWS cloud")

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -50,7 +50,11 @@ func Azure(clusterInfo *cluster.Info, ports *cloud.Ports, config *azure.Config, 
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare Azure  cloud")

--- a/pkg/cloud/prepare/gcp.go
+++ b/pkg/cloud/prepare/gcp.go
@@ -47,7 +47,11 @@ func GCP(clusterInfo *cluster.Info, ports *cloud.Ports, config *gcp.Config, stat
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare GCP cloud")

--- a/pkg/cloud/prepare/rhos.go
+++ b/pkg/cloud/prepare/rhos.go
@@ -48,7 +48,11 @@ func RHOS(clusterInfo *cluster.Info, ports *cloud.Ports, config *rhos.Config, st
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare RHOS cloud")


### PR DESCRIPTION
Backport of #518 on release-0.14.

#518: Only call cloud prepare when it's needed

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.