### PR TITLE
Automated backport of #518: Only call cloud prepare when it's needed

### DIFF
--- a/pkg/cloud/prepare/aws.go
+++ b/pkg/cloud/prepare/aws.go
@@ -53,7 +53,11 @@ func AWS(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *aw
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare AWS cloud")

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -50,7 +50,11 @@ func Azure(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare Azure  cloud")

--- a/pkg/cloud/prepare/gcp.go
+++ b/pkg/cloud/prepare/gcp.go
@@ -47,7 +47,11 @@ func GCP(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *gc
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare GCP cloud")

--- a/pkg/cloud/prepare/rhos.go
+++ b/pkg/cloud/prepare/rhos.go
@@ -48,7 +48,11 @@ func RHOS(restConfigProducer *restconfig.Producer, ports *cloud.Ports, config *r
 				}
 			}
 
-			return cloud.PrepareForSubmariner(input, status)
+			if len(input.InternalPorts) > 0 {
+				return cloud.PrepareForSubmariner(input, status)
+			}
+
+			return nil
 		})
 
 	return status.Error(err, "Failed to prepare RHOS cloud")


### PR DESCRIPTION
Backport of #518 on release-0.13.

#518: Only call cloud prepare when it's needed

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.