### PR TITLE
Stop vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ build-cross: $(CROSS_TARBALLS)
 licensecheck: build | bin/lichen
 	bin/lichen -c .lichen.yaml $(BINARIES)
 
-bin/lichen: $(VENDOR_MODULES)
+bin/lichen:
 	mkdir -p $(@D)
 	$(GO) build -o $@ github.com/uw-labs/lichen
 
@@ -104,7 +104,7 @@ cmd/bin/linux/%/subctl: cmd/bin/subctl-$(VERSION)-linux-%
 	ln -sf ../../$(<F) $@
 
 .PRECIOUS: cmd/bin/subctl-%
-cmd/bin/subctl-%: $(shell find . -name "*.go") $(VENDOR_MODULES)
+cmd/bin/subctl-%: $(shell find . -name "*.go")
 	mkdir -p cmd/bin
 	target=$@; \
 	target=$${target%.exe}; \


### PR DESCRIPTION
go mod vendor is no longer necessary; see
https://go.dev/ref/mod#vendoring for details. Dependencies will be fulfilled using the module cache.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
