### PR TITLE
Improve messages when components aren't installed

### DIFF
--- a/cmd/subctl/show.go
+++ b/cmd/subctl/show.go
@@ -42,7 +42,7 @@ var (
 		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			exit.OnError(
-				showRestConfigProducer.RunOnAllContexts(restconfig.IfSubmarinerInstalled(show.Connections), cli.NewReporter()))
+				showRestConfigProducer.RunOnAllContexts(restconfig.IfConnectivityInstalled(show.Connections), cli.NewReporter()))
 		},
 	}
 	endpointsCmd = &cobra.Command{
@@ -52,7 +52,7 @@ var (
 		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			exit.OnError(
-				showRestConfigProducer.RunOnAllContexts(restconfig.IfSubmarinerInstalled(show.Endpoints), cli.NewReporter()))
+				showRestConfigProducer.RunOnAllContexts(restconfig.IfConnectivityInstalled(show.Endpoints), cli.NewReporter()))
 		},
 	}
 	gatewaysCmd = &cobra.Command{
@@ -62,7 +62,7 @@ var (
 		PreRunE: showRestConfigProducer.CheckVersionMismatch,
 		Run: func(command *cobra.Command, args []string) {
 			exit.OnError(
-				showRestConfigProducer.RunOnAllContexts(restconfig.IfSubmarinerInstalled(show.Gateways), cli.NewReporter()))
+				showRestConfigProducer.RunOnAllContexts(restconfig.IfConnectivityInstalled(show.Gateways), cli.NewReporter()))
 		},
 	}
 	networksCmd = &cobra.Command{

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,8 +24,9 @@ const (
 	OperatorNamespace            = "submariner-operator"
 	SubmarinerBrokerAdminSA      = "submariner-k8s-broker-admin"
 	SubmarinerGatewayLabel       = "submariner.io/gateway"
-	SubmarinerNotInstalled       = "Submariner is not installed"
-	ServiceDiscoveryNotInstalled = "Service discovery is not installed"
+	SubmarinerNotInstalled       = "No Submariner feature is installed"
+	ConnectivityNotInstalled     = "Submariner connectivity feature is not installed"
+	ServiceDiscoveryNotInstalled = "Submariner service discovery feature is not installed"
 	TransientLabel               = "submariner.io/transient"
 	TrueLabel                    = "true"
 )

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -519,10 +519,10 @@ func (rcp *Producer) CheckVersionMismatch(cmd *cobra.Command, args []string) err
 	}, cli.NewReporter())
 }
 
-func IfSubmarinerInstalled(functions ...PerContextFn) PerContextFn {
+func IfConnectivityInstalled(functions ...PerContextFn) PerContextFn {
 	return func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 		if clusterInfo.Submariner == nil {
-			status.Warning(constants.SubmarinerNotInstalled)
+			status.Warning(constants.ConnectivityNotInstalled)
 
 			return nil
 		}

--- a/internal/show/all.go
+++ b/internal/show/all.go
@@ -48,7 +48,7 @@ func All(clusterInfo *cluster.Info, namespace string, status reporter.Interface)
 
 		fmt.Println()
 
-		status.Warning(constants.SubmarinerNotInstalled)
+		status.Warning(constants.ConnectivityNotInstalled)
 
 		return errors.NewAggregate(allErrors)
 	}

--- a/pkg/diagnose/deployment_metrics.go
+++ b/pkg/diagnose/deployment_metrics.go
@@ -34,6 +34,10 @@ const (
 )
 
 func checkMetricsConfig(clusterInfo *cluster.Info, status reporter.Interface) error {
+	if clusterInfo.Submariner == nil {
+		return nil
+	}
+
 	metricsErrors := []error{}
 	if err := checkComponentMetrics(clusterInfo, status, "gateway", gwCurlMetricsCommand); err != nil {
 		metricsErrors = append(metricsErrors, err)


### PR DESCRIPTION
The messages now reflect the specific component that isn't installed. The `diagnose deployment` command applies to both components so it was refactored accordingly.

Fixes https://github.com/submariner-io/subctl/issues/327
