### PR TITLE
subctl verify shouldn’t randomize test order

### DIFF
--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -288,6 +288,7 @@ func runVerify(
 
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
 	suiteConfig.FocusStrings = patterns
+	suiteConfig.RandomSeed = 1
 	reporterConfig.Verbose = verboseConnectivityVerification
 	reporterConfig.JUnitReport = junitReport
 	framework.TestContext.SuiteConfig = &suiteConfig


### PR DESCRIPTION
Ginkgo automatically randomizes the order of top-level containers. While this isn't configurable, we can set the random seed to a hard-coded number to effect deterministic behavior.

Fixes https://github.com/submariner-io/subctl/issues/514

