### PR TITLE
Diagnose validate Calico IPPool configuration

### DIFF
--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -137,7 +137,7 @@ func checkCalicoIPPoolsIfCalicoCNI(info *cluster.Info, status reporter.Interface
 		ippools[cidr] = pool
 	}
 
-	checkGatewaySubnets(gateways, ippools, tracker)
+	checkCalicoIPPools(gateways, ippools, tracker)
 
 	if tracker.HasFailures() {
 		return errors.New("failures while diagnosing CNI")
@@ -146,36 +146,76 @@ func checkCalicoIPPoolsIfCalicoCNI(info *cluster.Info, status reporter.Interface
 	return nil
 }
 
-func checkGatewaySubnets(gateways []submv1.Gateway, ippools map[string]unstructured.Unstructured, status reporter.Interface) {
+func checkCalicoIPPools(gateways []submv1.Gateway, ippools map[string]unstructured.Unstructured, status reporter.Interface) {
 	for i := range gateways {
 		gateway := &gateways[i]
 		if gateway.Status.HAStatus != submv1.HAStatusActive {
 			continue
 		}
 
-		for j := range gateway.Status.Connections {
-			connection := &gateway.Status.Connections[j]
-			for _, subnet := range connection.Endpoint.Subnets {
-				ipPool, found := ippools[subnet]
-				if found {
-					isDisabled, err := getSpecBool(ipPool, "disabled")
-					if err != nil {
-						status.Failure(err.Error())
-						continue
-					}
+		checkCalicoSubmConfig(gateway, ippools, status)
+		checkCalicoEncapsulation(gateway, ippools, status)
+	}
+}
 
-					// When disabled is set to true, Calico IPAM will not assign addresses from this Pool.
-					// The IPPools configured for Submariner remote CIDRs should have disabled as true.
-					if !isDisabled {
-						status.Failure("The IPPool %q with CIDR %q for remote endpoint"+
-							" %q has disabled set to false", ipPool.GetName(), subnet, connection.Endpoint.CableName)
-						continue
-					}
-				} else {
-					status.Failure("Could not find any IPPool with CIDR %q for remote"+
-						" endpoint %q", subnet, connection.Endpoint.CableName)
+func checkCalicoSubmConfig(gateway *submv1.Gateway, ippools map[string]unstructured.Unstructured, status reporter.Interface) {
+	for j := range gateway.Status.Connections {
+		connection := &gateway.Status.Connections[j]
+		for _, subnet := range connection.Endpoint.Subnets {
+			ipPool, found := ippools[subnet]
+			if found {
+				isDisabled, err := getSpecBool(ipPool, "disabled")
+				if err != nil {
+					status.Failure(err.Error())
 					continue
 				}
+
+				// When spec.disabled is set to true, Calico IPAM will not assign addresses from this Pool.
+				// The IPPools configured for Submariner remote CIDRs should have disabled as true.
+				if !isDisabled {
+					status.Failure("The IPPool %q with CIDR %q for remote endpoint"+
+						" %q has disabled set to false", ipPool.GetName(), subnet, connection.Endpoint.CableName)
+					continue
+				}
+
+				natOutgoing, err := getSpecBool(ipPool, "natOutgoing")
+				if err != nil {
+					status.Failure(err.Error())
+					continue
+				}
+
+				// When spec.natOutgoing is set to true, packets from K8s pods to destinations outside of
+				// any Calico IP pools will be masqueraded.
+				// The IPPools configured for Submariner remote CIDRs should have natOutgoing as false.
+				if natOutgoing {
+					status.Failure("The IPPool %q with CIDR %q for remote endpoint"+
+						" %q has natOutgoing set to true", ipPool.GetName(), subnet, connection.Endpoint.CableName)
+					continue
+				}
+			} else {
+				status.Failure("Could not find any IPPool with CIDR %q for remote"+
+					" endpoint %q", subnet, connection.Endpoint.CableName)
+				continue
+			}
+		}
+	}
+}
+
+func checkCalicoEncapsulation(gateway *submv1.Gateway, ippools map[string]unstructured.Unstructured, status reporter.Interface) {
+	for _, subnet := range gateway.Status.LocalEndpoint.Subnets {
+		ipPool, found := ippools[subnet]
+		if found {
+			vxlanMode, err := getSpecString(ipPool, "vxlanMode")
+			if err != nil {
+				status.Failure(err.Error())
+				continue
+			}
+
+			// Calico supports different types of overlay networking. Currently, Submariner is validated only
+			// when Calico is deployed with VXLAN encapsulation.
+			if vxlanMode != "Always" {
+				status.Failure("Calico IPPool %q does not seem to be configured with VXLAN overlay encapsulation.", ipPool.GetName())
+				continue
 			}
 		}
 	}
@@ -192,6 +232,19 @@ func getSpecBool(pool unstructured.Unstructured, key string) (bool, error) {
 	}
 
 	return isDisabled, nil
+}
+
+func getSpecString(pool unstructured.Unstructured, key string) (string, error) {
+	value, found, err := unstructured.NestedString(pool.Object, "spec", key)
+	if err != nil {
+		return "", errors.Wrap(err, "error getting spec field")
+	}
+
+	if !found {
+		return "", fmt.Errorf("%s status not found for IPPool %q", key, pool.GetName())
+	}
+
+	return value, nil
 }
 
 func mustHaveSubmariner(clusterInfo *cluster.Info) {


### PR DESCRIPTION
Calico supports different types of Overlay networking. Currently, Submariner is validated only when Calico is deployed with VxLAN encapsulation.

In this PR, the diagnose code is enhanced to check the IPPool config and return an appropriate error if the config does not match with Submariner requirements.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
