### PR TITLE
Print clusterIDs instead of cluster name from kubeconfig

### DIFF
--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -213,6 +213,14 @@ func (rcp *Producer) RunOnSelectedContext(function PerContextFn, status reporter
 		return status.Error(err, "error building the cluster.Info for the default configuration")
 	}
 
+	if clusterInfo.Submariner != nil {
+		clusterInfo.Name = clusterInfo.Submariner.Spec.ClusterID
+	} else if clusterInfo.ServiceDiscovery != nil {
+		clusterInfo.Name = clusterInfo.ServiceDiscovery.Spec.ClusterID
+	}
+
+	fmt.Printf("Cluster %q\n", clusterInfo.Name)
+
 	namespace, overridden, err := clientConfig.Namespace()
 	if err != nil {
 		return status.Error(err, "error retrieving the namespace for the default configuration")
@@ -404,8 +412,6 @@ func (rcp *Producer) RunOnAllContexts(function PerContextFn, status reporter.Int
 }
 
 func (rcp *Producer) overrideContextAndRun(clusterName, contextName string, function PerContextFn, status reporter.Interface) error {
-	fmt.Printf("Cluster %q\n", clusterName)
-
 	rcp.defaultClientConfig.overrides.CurrentContext = contextName
 	if err := rcp.RunOnSelectedContext(function, status); err != nil {
 		return err


### PR DESCRIPTION
whenever possible. So when a cluster is joined with the user-specified clusterID (via --clusterid flag), all subctl commands will print that clusterID and not the clustername from kubeconfig.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
