### PR TITLE
Add compliance tests to "subctl verify"

### DIFF
--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -42,6 +42,7 @@ import (
 	"github.com/submariner-io/subctl/internal/exit"
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/cluster"
+	_ "github.com/submariner-io/submariner/test/e2e/compliance"
 	_ "github.com/submariner-io/submariner/test/e2e/dataplane"
 	_ "github.com/submariner-io/submariner/test/e2e/redundancy"
 	"k8s.io/client-go/rest"
@@ -183,6 +184,7 @@ func checkVerifyArguments(cmd *cobra.Command, args []string) error {
 var verifyE2EPatterns = map[string]string{
 	component.Connectivity:     "\\[dataplane",
 	component.ServiceDiscovery: "\\[discovery",
+	"compliance":               "\\[compliance]",
 }
 
 var verifyE2EDisruptivePatterns = map[string]string{


### PR DESCRIPTION
Add compliance test (FIPS) to subctl verify e2e execution.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
