### PR TITLE
Failed to diagnose calico when natOutgoing is not found

### DIFF
--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -228,7 +228,8 @@ func getSpecBool(pool unstructured.Unstructured, key string) (bool, error) {
 	}
 
 	if !found {
-		return false, fmt.Errorf("%s status not found for IPPool %q", key, pool.GetName())
+		// for bool type, not found is considered false
+		return false, nil
 	}
 
 	return isDisabled, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->

```
[root@master1 subctl-devel]# subctl-devel diagnose cni
Cluster "cluster.local"
 ✓ Checking Submariner support for the CNI network plugin
 ✓ The detected CNI network plugin ("calico") is supported
 ✗ Calico CNI detected, checking if the Submariner IPPool pre-requisites are configured
 ✗ natOutgoing status not found for IPPool "cluster2-globalcidr"

subctl version: devel

[root@master1 subctl-devel]# calicoctl get ippools -o wide
NAME                  CIDR            NAT     IPIPMODE   VXLANMODE   DISABLED   DISABLEBGPEXPORT   SELECTOR
cluster2-globalcidr   242.1.10.0/24   false   Never      Never       true       false              all()
default-pool          172.20.0.0/16   true    Never      Always      false      false              all()
default-pool-ipv6     fc01::/112      false   Never      Always      false      false              all()

[root@master1 subctl-devel]# calicoctl get ippools cluster2-globalcidr -o yaml
apiVersion: projectcalico.org/v3
kind: IPPool
metadata:
  creationTimestamp: "2023-02-22T14:56:58Z"
  name: cluster2-globalcidr
  resourceVersion: "42048"
  uid: 3462d93f-ba53-4971-b550-083fa0b65dfb
spec:
  allowedUses:
  - Workload
  - Tunnel
  blockSize: 26
  cidr: 242.1.10.0/24
  disabled: true
  ipipMode: Never
  nodeSelector: all()
  vxlanMode: Never
```

`natOutgoing` is of bool type so it should be considered false when not found.
