### PR TITLE
Deprecate `dedicated-gateway` for 0.15

### DIFF
--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -79,6 +79,9 @@ func init() {
 		"Whether a dedicated gateway node has to be deployed")
 	cloudPrepareCmd.AddCommand(azurePrepareCmd)
 
+	_ = azurePrepareCmd.Flags().MarkDeprecated("dedicated-gateway", "to be removed in 0.16. "+
+		"To deploy without dedicated gateways, use the Load Balancer mode instead.")
+
 	addGeneralAzureFlags(azureCleanupCmd)
 	cloudCleanupCmd.AddCommand(azureCleanupCmd)
 }

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -89,6 +89,9 @@ func init() {
 	gcpPrepareCmd.Flags().BoolVar(&gcpConfig.DedicatedGateway, "dedicated-gateway", true,
 		"Whether a dedicated gateway node has to be deployed")
 
+	_ = gcpPrepareCmd.Flags().MarkDeprecated("dedicated-gateway", "to be removed in 0.16. "+
+		"To deploy without dedicated gateways, use the Load Balancer mode instead.")
+
 	cloudPrepareCmd.AddCommand(gcpPrepareCmd)
 
 	addGCPGeneralFlags(gcpCleanupCmd)

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -81,6 +81,9 @@ func init() {
 	rhosPrepareCmd.Flags().BoolVar(&rhosConfig.DedicatedGateway, "dedicated-gateway", true,
 		"Whether a dedicated gateway node has to be deployed")
 
+	_ = rhosPrepareCmd.Flags().MarkDeprecated("dedicated-gateway", "to be removed in 0.16. "+
+		"To deploy without dedicated gateways, use the Load Balancer mode instead.")
+
 	cloudPrepareCmd.AddCommand(rhosPrepareCmd)
 
 	addGeneralRHOSFlags(rhosCleanupCmd)


### PR DESCRIPTION
We're not actually testing or using non-dedicated gateway mode from cloud prepare.
Furthermore, a more K8s native approach is to deploy with LB mode which actually handles the cloud related operations properly.

From a technical debt perspective, the code is just sitting there and making cloud-prepare and subctl harder to maintain, with it removed we'll have an easier maintenance burden and could even further simplify the cloud prepare code.

Resolves [#603](https://github.com/submariner-io/cloud-prepare/issues/603)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
