### PR TITLE
Deprecate `cloud prepare generic` for 0.15

### DIFF
--- a/cmd/subctl/generic_cloud.go
+++ b/cmd/subctl/generic_cloud.go
@@ -34,9 +34,10 @@ var (
 	}
 
 	genericPrepareCmd = &cobra.Command{
-		Use:   "generic",
-		Short: "Prepares a generic cluster for Submariner",
-		Long:  "This command labels the required number of gateway nodes for Submariner installation.",
+		Use:        "generic",
+		Deprecated: "Deprecated in 0.15, to be removed in 0.16. Use `subctl join` instead.",
+		Short:      "Prepares a generic cluster for Submariner",
+		Long:       "This command labels the required number of gateway nodes for Submariner installation.",
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {


### PR DESCRIPTION
We're not actually testing or using the "generic cloud prepare" mode. Furthermore, we already have code for making sure gateways have labels in the `join` command, which makes much more sense. Having a duplicate code path just increases the maintenance burden without adding any value.
Additionally, this mode on cloud prepare adds no special additional capabilities beyond what subctl join already does or can do.

From a technical debt perspective, the code is just sitting there and making cloud-prepare & subctl harder to maintain, with it removed we'll have an easier maintenance burden and could even further simplify cloud prepare code.

Resolves: https://github.com/submariner-io/cloud-prepare/issues/608

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
