### PR TITLE
Make getSpecBool generic, simplify its return

### DIFF
--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -222,17 +222,9 @@ func checkCalicoEncapsulation(gateway *submv1.Gateway, ippools map[string]unstru
 }
 
 func getSpecBool(pool unstructured.Unstructured, key string) (bool, error) {
-	isDisabled, found, err := unstructured.NestedBool(pool.Object, "spec", key)
-	if err != nil {
-		return false, errors.Wrap(err, "error getting spec field")
-	}
-
-	if !found {
-		// for bool type, not found is considered false
-		return false, nil
-	}
-
-	return isDisabled, nil
+	// value defaults to false when not found; not finding a bool isn't an error
+	value, _, err := unstructured.NestedBool(pool.Object, "spec", key)
+	return value, errors.Wrap(err, "error getting spec field")
 }
 
 func getSpecString(pool unstructured.Unstructured, key string) (string, error) {
@@ -242,7 +234,7 @@ func getSpecString(pool unstructured.Unstructured, key string) (string, error) {
 	}
 
 	if !found {
-		return "", fmt.Errorf("%s status not found for IPPool %q", key, pool.GetName())
+		return "", fmt.Errorf("%s value not found for IPPool %q", key, pool.GetName())
 	}
 
 	return value, nil


### PR DESCRIPTION
getSpecBool still referred to the role it had before it was extracted as a separate function, with an isDisabled variable. Generify it by naming the variable "value", in the same style as getSpecString.

Also simplify the return statement and clarify the test on found.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
