### PR TITLE
Automated backport of #596: Fix image-overrides for diagnose kube-proxy-mode

### DIFF
--- a/pkg/diagnose/kubeproxy.go
+++ b/pkg/diagnose/kubeproxy.go
@@ -36,7 +36,7 @@ const (
 var kubeProxyImageOverrides = []string{}
 
 func AddKubeProxyImageOverrideFlag(flags *pflag.FlagSet) {
-	flags.StringSliceVar(&firewallImageOverrides, "image-override", nil, "override component image")
+	flags.StringSliceVar(&kubeProxyImageOverrides, "image-override", nil, "override component image")
 }
 
 func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {


### PR DESCRIPTION
Backport of #596 on release-0.14.

#596: Fix image-overrides for diagnose kube-proxy-mode

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.