### PR TITLE
Support image-override in diagnose all command

### DIFF
--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -42,6 +42,10 @@ func AddDeploymentImageOverrideFlag(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&deploymentImageOverrides, "image-override", nil, "override component image")
 }
 
+func SetDeploymentImageOverride(imageOverrides []string) {
+	deploymentImageOverrides = imageOverrides
+}
+
 func Deployments(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	if clusterInfo.Submariner != nil {
 		if err := checkOverlappingCIDRs(clusterInfo, status); err != nil {

--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -68,6 +68,10 @@ func AddFirewallImageOverrideFlag(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&firewallImageOverrides, "image-override", nil, "override component image")
 }
 
+func SetFirewallImageOverride(imageOverrides []string) {
+	firewallImageOverrides = imageOverrides
+}
+
 func spawnClientPodOnNonGatewayNode(client kubernetes.Interface, namespace, podCommand string,
 	imageRepInfo *image.RepositoryInfo,
 ) (*pods.Scheduled, error) {

--- a/pkg/diagnose/kubeproxy.go
+++ b/pkg/diagnose/kubeproxy.go
@@ -39,6 +39,10 @@ func AddKubeProxyImageOverrideFlag(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&kubeProxyImageOverrides, "image-override", nil, "override component image")
 }
 
+func SetKubeProxyImageOverride(imageOverrides []string) {
+	kubeProxyImageOverrides = imageOverrides
+}
+
 func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 	status.Start("Checking Submariner support for the kube-proxy mode")
 	defer status.End()


### PR DESCRIPTION
We support image-override for various individual diagnose commands, but the same was not supported for "subctl diagnose all" command which is widely used. This PR includes the necessary support.

Partially fixes: https://github.com/submariner-io/subctl/issues/597
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
