### PR TITLE
[Backport-0.14] Include image-override as a firewall subcmd

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -177,7 +177,6 @@ func addDiagnoseSubCommands() {
 	diagnose.AddKubeProxyImageOverrideFlag(diagnoseKubeProxyModeCmd.Flags())
 	diagnoseCmd.AddCommand(diagnoseKubeProxyModeCmd)
 	diagnoseCmd.AddCommand(diagnoseAllCmd)
-	diagnose.AddFirewallImageOverrideFlag(diagnoseFirewallCmd.Flags())
 	diagnoseCmd.AddCommand(diagnoseFirewallCmd)
 	diagnoseCmd.AddCommand(diagnoseServiceDiscoveryCmd)
 }
@@ -190,6 +189,9 @@ func addDiagnoseFirewallSubCommands() {
 	diagnoseFirewallNatDiscoveryRestConfigProducer.SetupFlags(diagnoseFirewallNatDiscovery.Flags())
 	addDiagnoseFWConfigFlags(diagnoseFirewallNatDiscovery)
 
+	diagnose.AddFirewallImageOverrideFlag(diagnoseFirewallVxLANCmd.Flags())
+	diagnose.AddFirewallImageOverrideFlag(diagnoseFirewallTunnelCmd.Flags())
+	diagnose.AddFirewallImageOverrideFlag(diagnoseFirewallNatDiscovery.Flags())
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallMetricsCmd)
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallVxLANCmd)
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallTunnelCmd)


### PR DESCRIPTION
Currently the image-override flag was added to the main subctl diagnose firewall command and was hence ignored when it was passed to the sub-command like intra-cluster, inter-cluster etc. This PR fixes it.

Usage:
subctl diagnose firewall intra-cluster --image-override=...

Partially fixes: https://github.com/submariner-io/subctl/issues/597
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 9087839acc978377f6498fd6bc68fc5a41a6e6b4)

Conflicts:
   cmd/subctl/diagnose.go

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
