### PR TITLE
Automated backport of #602: Support image-override in diagnose all command

### DIFF
--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
@@ -34,6 +35,8 @@ import (
 
 var (
 	diagnoseFirewallOptions diagnose.FirewallOptions
+
+	imageOverrides = []string{}
 
 	diagnoseRestConfigProducer = restconfig.NewProducer().WithDefaultNamespace(constants.OperatorNamespace).WithInClusterFlag()
 
@@ -168,6 +171,7 @@ func init() {
 
 func addDiagnoseSubCommands() {
 	addDiagnoseFWConfigFlags(diagnoseAllCmd)
+	AddImageImageOverrideFlag(diagnoseAllCmd.Flags())
 
 	diagnoseCmd.AddCommand(diagnoseCNICmd)
 	diagnoseCmd.AddCommand(diagnoseConnectionsCmd)
@@ -198,6 +202,10 @@ func addDiagnoseFirewallSubCommands() {
 	diagnoseFirewallCmd.AddCommand(diagnoseFirewallNatDiscovery)
 }
 
+func AddImageImageOverrideFlag(flags *pflag.FlagSet) {
+	flags.StringSliceVar(&imageOverrides, "image-override", nil, "override component image")
+}
+
 func addDiagnoseFWConfigFlags(command *cobra.Command) {
 	command.Flags().UintVar(&diagnoseFirewallOptions.ValidationTimeout, "validation-timeout", 90,
 		"time to run in seconds while validating the firewall")
@@ -223,6 +231,13 @@ var allDiagnoseCommands = []restconfig.PerContextFn{
 }
 
 func diagnoseAll(status reporter.Interface) error {
+	// When imageOverrides is supplied to the diagnose all command, percolate it to the individual commands.
+	if len(imageOverrides) != 0 {
+		diagnose.SetDeploymentImageOverride(imageOverrides)
+		diagnose.SetKubeProxyImageOverride(imageOverrides)
+		diagnose.SetFirewallImageOverride(imageOverrides)
+	}
+
 	err := diagnoseRestConfigProducer.RunOnAllContexts(
 		func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 			diagnoseErrors := []error{}

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -42,6 +42,10 @@ func AddDeploymentImageOverrideFlag(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&deploymentImageOverrides, "image-override", nil, "override component image")
 }
 
+func SetDeploymentImageOverride(imageOverrides []string) {
+	deploymentImageOverrides = imageOverrides
+}
+
 func Deployments(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	mustHaveSubmariner(clusterInfo)
 

--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -67,6 +67,10 @@ func AddFirewallImageOverrideFlag(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&firewallImageOverrides, "image-override", nil, "override component image")
 }
 
+func SetFirewallImageOverride(imageOverrides []string) {
+	firewallImageOverrides = imageOverrides
+}
+
 func spawnClientPodOnNonGatewayNode(client kubernetes.Interface, namespace, podCommand string,
 	imageRepInfo *image.RepositoryInfo,
 ) (*pods.Scheduled, error) {

--- a/pkg/diagnose/kubeproxy.go
+++ b/pkg/diagnose/kubeproxy.go
@@ -39,6 +39,10 @@ func AddKubeProxyImageOverrideFlag(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&kubeProxyImageOverrides, "image-override", nil, "override component image")
 }
 
+func SetKubeProxyImageOverride(imageOverrides []string) {
+	kubeProxyImageOverrides = imageOverrides
+}
+
 func KubeProxyMode(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 	status.Start("Checking Submariner support for the kube-proxy mode")
 	defer status.End()


### PR DESCRIPTION
Backport of #602 on release-0.14.

#602: Support image-override in diagnose all command

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.