### PR TITLE
Automated backport of #600: Allow overriding the metrics proxy component

### DIFF
--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -198,6 +198,7 @@ var validOverrides = []string{
 	names.ServiceDiscoveryComponent,
 	names.LighthouseCoreDNSComponent,
 	names.NettestComponent,
+	names.MetricsProxyComponent,
 }
 
 func MergeImageOverrides(imageOverrides map[string]string, localImageOverrides []string) (map[string]string, error) {


### PR DESCRIPTION
Backport of #600 on release-0.14.

#600: Allow overriding the metrics proxy component

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.