### PR TITLE
Bump submariner-operator to get status RBAC fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/submariner-io/lighthouse v0.15.0-m4.0.20230327162337-e5988504cdca
 	github.com/submariner-io/shipyard v0.15.0-rc0
 	github.com/submariner-io/submariner v0.15.0-m4
-	github.com/submariner-io/submariner-operator v0.15.0-m4.0.20230329135312-32d69bfd9fc8
+	github.com/submariner-io/submariner-operator v0.15.0-m4.0.20230331155314-be8318dd1589
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.8.0
 	golang.org/x/oauth2 v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -549,8 +549,8 @@ github.com/submariner-io/shipyard v0.15.0-rc0 h1:ltGZj3qAZJgfwO0Rdl14IAFWgJl3csZ
 github.com/submariner-io/shipyard v0.15.0-rc0/go.mod h1:144QmfjjNMq7yqHrp2DHBrzAhef9laOKJdQq3QtfHGA=
 github.com/submariner-io/submariner v0.15.0-m4 h1:dMCFH09rPK3Vlkl0CutIyT2zf2EiLEWnXUKzHizmHJo=
 github.com/submariner-io/submariner v0.15.0-m4/go.mod h1:jTzblmp5fMVIlfWuuLdm+mzJXRDAsIDnp90bXzm8JyU=
-github.com/submariner-io/submariner-operator v0.15.0-m4.0.20230329135312-32d69bfd9fc8 h1:RXZ8RYLmfBlGTSj4/lFi31rH63kWnAfUk7uX0VUi0K0=
-github.com/submariner-io/submariner-operator v0.15.0-m4.0.20230329135312-32d69bfd9fc8/go.mod h1:qCqBKpiZQeSCmIrvu/ZX6OTtWjVBEfGM4C2gtbKb7sQ=
+github.com/submariner-io/submariner-operator v0.15.0-m4.0.20230331155314-be8318dd1589 h1:vPukAn7I8KOEwhsEbz98HpzZPyYRLbVtsN1hHaWfzg4=
+github.com/submariner-io/submariner-operator v0.15.0-m4.0.20230331155314-be8318dd1589/go.mod h1:ce1pdSCS41+DHMnUi6cgCy0GW8MGZOppuYe8xtuAm/s=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
We need
https://github.com/submariner-io/submariner-operator/commit/c240b256cee17eebb7fe05931da5a3e346478f6e taken into account in the RBAC set up by subctl.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
