### PR TITLE
Gather ipset details from all the nodes

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -41,6 +41,7 @@ var systemCmds = map[string]string{
 	"ip-rules":          "ip rule list",
 	"ip-rules-table150": "ip rule show table 150",
 	"sysctl-a":          "sysctl -a",
+	"ipset-list":        "ipset list",
 }
 
 var ipGatewayCmds = map[string]string{
@@ -57,10 +58,6 @@ var libreswanCmds = map[string]string{
 	"ip-xfrm-state":       "ip xfrm state",
 	"ipsec-status":        "ipsec status",
 	"ipsec-trafficstatus": "ipsec --trafficstatus",
-}
-
-var globalnetCmds = map[string]string{
-	"ipset-list": "ipset list",
 }
 
 var vxlanCmds = map[string]string{
@@ -111,7 +108,6 @@ func gatherCNIResources(info *Info, networkPlugin string) {
 	})
 
 	logCNIGatewayNodeResources(info)
-	logGlobalnetCmds(info)
 }
 
 func logCNIGatewayNodeResources(info *Info) {
@@ -134,14 +130,6 @@ func logIPTablesCmds(info *Info, pod *v1.Pod) {
 	for name, cmd := range ipTablesCmds {
 		logCmdOutput(info, pod, cmd, name, false)
 	}
-}
-
-func logGlobalnetCmds(info *Info) {
-	logPodInfo(info, "globalnet data", globalnetPodLabel, func(info *Info, pod *v1.Pod) {
-		for name, cmd := range globalnetCmds {
-			logCmdOutput(info, pod, cmd, name, false)
-		}
-	})
 }
 
 func gatherOVNResources(info *Info, networkPlugin string) {


### PR DESCRIPTION
Currently, as part of "subctl gather ..." we used to collect the output of ipset list only if the deployment was a Globalnet deployment. However, ipsets are used even for MTU support in vanilla Submariner deployment. This PR includes the output of ipset list from all the nodes of the cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
