### PR TITLE
Fix flag for unexport service command

### DIFF
--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -61,7 +61,7 @@ var (
 )
 
 func init() {
-	unexportRestConfigProducer.SetupFlags(unexportServiceCmd.Flags())
+	unexportRestConfigProducer.SetupFlags(unexportCmd.PersistentFlags())
 	unexportCmd.AddCommand(unexportServiceCmd)
 	rootCmd.AddCommand(unexportCmd)
 }

--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -61,7 +61,7 @@ var (
 )
 
 func init() {
-	unexportRestConfigProducer.SetupFlags(unexportCmd.Flags())
+	unexportRestConfigProducer.SetupFlags(unexportServiceCmd.Flags())
 	unexportCmd.AddCommand(unexportServiceCmd)
 	rootCmd.AddCommand(unexportCmd)
 }


### PR DESCRIPTION
We need to `SetupFlags` for unexportServiceCmd. Otherwise, we couldn't use the basic flag (e.g., --context) under `subctl unexport service` command, for example:

```bash
subctl unexport --context <context-name> service <service-name>
Error: unknown flag: --context
Usage:
  subctl unexport service <serviceName> [flags]

Flags:
  -h, --help   help for service

unknown flag: --context
```