### PR TITLE
Automated backport of #657: Fix flag for unexport service command

### DIFF
--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -61,7 +61,7 @@ var (
 )
 
 func init() {
-	unexportRestConfigProducer.SetupFlags(unexportServiceCmd.Flags())
+	unexportRestConfigProducer.SetupFlags(unexportCmd.PersistentFlags())
 	unexportCmd.AddCommand(unexportServiceCmd)
 	rootCmd.AddCommand(unexportCmd)
 }

--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -61,7 +61,7 @@ var (
 )
 
 func init() {
-	unexportRestConfigProducer.SetupFlags(unexportCmd.Flags())
+	unexportRestConfigProducer.SetupFlags(unexportServiceCmd.Flags())
 	unexportCmd.AddCommand(unexportServiceCmd)
 	rootCmd.AddCommand(unexportCmd)
 }


### PR DESCRIPTION
Backport of #657 on release-0.15.

#657: Fix flag for unexport service command

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.