### PR TITLE
Automated backport of #654: Gather ipset details from all the nodes

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -38,6 +38,7 @@ var systemCmds = map[string]string{
 	"ip-rules":          "ip rule list",
 	"ip-rules-table150": "ip rule show table 150",
 	"sysctl-a":          "sysctl -a",
+	"ipset-list":        "ipset list",
 }
 
 var ipGatewayCmds = map[string]string{
@@ -56,8 +57,8 @@ var libreswanCmds = map[string]string{
 	"ipsec-trafficstatus": "ipsec --trafficstatus",
 }
 
-var globalnetCmds = map[string]string{
-	"ipset-list": "ipset list",
+var vxlanCmds = map[string]string{
+	"ip-routes-table100": "ip route show table 100",
 }
 
 const ovnNbctlShowCmd = "ovn-nbctl show"
@@ -104,7 +105,6 @@ func gatherCNIResources(info *Info, networkPlugin string) {
 	})
 
 	logCNIGatewayNodeResources(info)
-	logGlobalnetCmds(info)
 }
 
 func logCNIGatewayNodeResources(info *Info) {
@@ -127,14 +127,6 @@ func logIPTablesCmds(info *Info, pod *v1.Pod) {
 	for name, cmd := range ipTablesCmds {
 		logCmdOutput(info, pod, cmd, name, false)
 	}
-}
-
-func logGlobalnetCmds(info *Info) {
-	logPodInfo(info, "globalnet data", globalnetPodLabel, func(info *Info, pod *v1.Pod) {
-		for name, cmd := range globalnetCmds {
-			logCmdOutput(info, pod, cmd, name, false)
-		}
-	})
 }
 
 func gatherOVNResources(info *Info, networkPlugin string) {

--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -57,10 +57,6 @@ var libreswanCmds = map[string]string{
 	"ipsec-trafficstatus": "ipsec --trafficstatus",
 }
 
-var vxlanCmds = map[string]string{
-	"ip-routes-table100": "ip route show table 100",
-}
-
 const ovnNbctlShowCmd = "ovn-nbctl show"
 
 var ovnCmds = map[string]string{


### PR DESCRIPTION
Backport of #654 on release-0.13.

#654: Gather ipset details from all the nodes

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.