### PR TITLE
Automated backport of #544: Obtain label selector for gathering operator logs

### DIFF
--- a/internal/gather/operator.go
+++ b/internal/gather/operator.go
@@ -19,6 +19,7 @@ limitations under the License.
 package gather
 
 import (
+	"github.com/submariner-io/subctl/pkg/operator/deployment"
 	submarinerOp "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,5 +65,13 @@ func gatherLighthouseCoreDNSDeployment(info *Info, namespace string) {
 }
 
 func gatherSubmarinerOperatorPodLogs(info *Info) {
-	gatherPodLogs("name=submariner-operator", info)
+	labelSelector, err := deployment.GetPodLabelSelector(info.ClientProducer.ForKubernetes(), info.OperatorNamespace())
+	if err != nil {
+		info.Status.Failure("Failed to obtain the operator deployment label: %s", err)
+		return
+	}
+
+	if labelSelector != "" {
+		gatherPodLogs(labelSelector, info)
+	}
 }

--- a/pkg/operator/deployment/ensure.go
+++ b/pkg/operator/deployment/ensure.go
@@ -19,6 +19,7 @@ limitations under the License.
 package deployment
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -26,7 +27,9 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 )
@@ -105,4 +108,17 @@ func Ensure(kubeClient kubernetes.Interface, namespace, image string, debug bool
 	err = deployment.AwaitReady(kubeClient, namespace, opDeployment.Name)
 
 	return created, errors.Wrap(err, "error awaiting Deployment ready")
+}
+
+func GetPodLabelSelector(kubeClient kubernetes.Interface, namespace string) (string, error) {
+	dep, err := kubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), names.OperatorComponent, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	}
+
+	if err != nil {
+		return "", errors.Wrap(err, "error retrieving operator deployment")
+	}
+
+	return labels.SelectorFromSet(dep.Spec.Template.ObjectMeta.Labels).String(), nil
 }


### PR DESCRIPTION
Backport of #544 on release-0.14.

#544: Obtain label selector for gathering operator logs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.