### PR TITLE
Automated backport of #645: Support for manual trigger of release image job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 name: Release Images
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - release-0.15


### PR DESCRIPTION
Backport of #645 on release-0.15.

#645: Support for manual trigger of release image job

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.