### PR TITLE
Automated backport of #698: Release notes for gathering ipset details

### DIFF
--- a/release-notes/20230426-gather-ipset.md
+++ b/release-notes/20230426-gather-ipset.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041 -->
+The `subctl gather` command now collects the `ipset` info from
+all the cluster nodes.


### PR DESCRIPTION
Backport of #698 on release-0.13.

#698: Release notes for gathering ipset details

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.