### PR TITLE
Automated backport of #699: Release notes for Calico IPPool validation

### DIFF
--- a/release-notes/20230426-calico-ippools.md
+++ b/release-notes/20230426-calico-ippools.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable MD041 -->
+The `subctl diagnose` command now validates the Calico IPPool configuration
+to match with Submariner requirements.


### PR DESCRIPTION
Backport of #699 on release-0.15.

#699: Release notes for Calico IPPool validation

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.