### PR TITLE
WIP: Read gather version from submariner.status

### DIFF
--- a/internal/gather/summary.go
+++ b/internal/gather/summary.go
@@ -123,7 +123,7 @@ func getVersions(info *Info) version {
 
 	Versions.Subm = "Not installed"
 	if info.Submariner != nil {
-		Versions.Subm = info.Submariner.Spec.Version
+		Versions.Subm = (*(info.Submariner.Status.Gateways))[0].Version
 	}
 
 	return Versions


### PR DESCRIPTION
Retrieve subctl gather version from submariner.status instead of submariner.spec


Fixes:  https://github.com/submariner-io/subctl/issues/746

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
