### PR TITLE
Check for request construction errors

### DIFF
--- a/internal/pods/exec.go
+++ b/internal/pods/exec.go
@@ -87,8 +87,13 @@ func ExecWithOptions(ctx context.Context, config ExecConfig, options *ExecOption
 		TTY:       tty,
 	}, scheme.ParameterCodec)
 
+	err := req.Error()
+	if err != nil {
+		return "", "", err
+	}
+
 	var stdout, stderr bytes.Buffer
-	err := execute(ctx, "POST", req.URL(), config.RestConfig, options.Stdin, &stdout, &stderr, tty)
+	err = execute(ctx, "POST", req.URL(), config.RestConfig, options.Stdin, &stdout, &stderr, tty)
 
 	if options.PreserveWhitespace {
 		return stdout.String(), stderr.String(), err

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -316,6 +316,11 @@ func getOVNNBVersion(ctx context.Context, clientSet kubernetes.Interface, config
 		TTY:       false,
 	}, scheme.ParameterCodec)
 
+	err := req.Error()
+	if err != nil {
+		return nil, err
+	}
+
 	var stdout, stderr bytes.Buffer
 
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())


### PR DESCRIPTION
Especially when constructing HTTP requests, it's possible for errors to occur. K8s 1.27 added a request.Error() function to retrieve such errors, which allows for clearer diagnoses when things go wrong.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
