### PR TITLE
Automated backport of #752: Collect metrics pod info as part of gather
#770: Fix error while running gather in GN setup

### DIFF
--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -28,6 +28,7 @@ const (
 	gatewayPodLabel             = "app=submariner-gateway"
 	routeagentPodLabel          = "app=submariner-routeagent"
 	globalnetPodLabel           = "app=submariner-globalnet"
+	metricsProxyPodLabel        = "app=submariner-metrics-proxy"
 	networkpluginSyncerPodLabel = "app=submariner-networkplugin-syncer"
 	addonPodLabel               = "app=submariner-addon"
 	ovnMasterPodLabelOCP        = "app=ovnkube-master"
@@ -36,6 +37,10 @@ const (
 
 func gatherGatewayPodLogs(info *Info) {
 	gatherPodLogs(gatewayPodLabel, info)
+}
+
+func gatherMetricsProxyPodLogs(info *Info) {
+	gatherPodLogs(metricsProxyPodLabel, info)
 }
 
 func gatherRouteAgentPodLogs(info *Info) {

--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -40,7 +40,11 @@ func gatherGatewayPodLogs(info *Info) {
 }
 
 func gatherMetricsProxyPodLogs(info *Info) {
-	gatherPodLogs(metricsProxyPodLabel, info)
+	gatherPodLogsByContainer(metricsProxyPodLabel, "gateway-metrics-proxy", info)
+
+	if info.Submariner.Spec.GlobalCIDR != "" {
+		gatherPodLogsByContainer(metricsProxyPodLabel, "globalnet-metrics-proxy", info)
+	}
 }
 
 func gatherRouteAgentPodLogs(info *Info) {

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -131,6 +131,7 @@ func gatherConnectivity(dataType string, info Info) bool {
 	case Logs:
 		gatherGatewayPodLogs(&info)
 		gatherRouteAgentPodLogs(&info)
+		gatherMetricsProxyPodLogs(&info)
 		gatherGlobalnetPodLogs(&info)
 		gatherNetworkPluginSyncerPodLogs(&info)
 		gatherAddonPodLogs(&info)
@@ -236,6 +237,7 @@ func gatherOperator(dataType string, info Info) bool {
 		gatherServiceDiscoveries(&info, info.OperatorNamespace())
 		gatherSubmarinerOperatorDeployment(&info, info.OperatorNamespace())
 		gatherGatewayDaemonSet(&info, info.OperatorNamespace())
+		gatherMetricsPodDaemonSet(&info, info.OperatorNamespace())
 		gatherRouteAgentDaemonSet(&info, info.OperatorNamespace())
 		gatherGlobalnetDaemonSet(&info, info.OperatorNamespace())
 		gatherNetworkPluginSyncerDeployment(&info, info.OperatorNamespace())

--- a/internal/gather/operator.go
+++ b/internal/gather/operator.go
@@ -44,6 +44,10 @@ func gatherGatewayDaemonSet(info *Info, namespace string) {
 	gatherDaemonSet(info, namespace, metav1.ListOptions{LabelSelector: gatewayPodLabel})
 }
 
+func gatherMetricsPodDaemonSet(info *Info, namespace string) {
+	gatherDaemonSet(info, namespace, metav1.ListOptions{LabelSelector: metricsProxyPodLabel})
+}
+
 func gatherRouteAgentDaemonSet(info *Info, namespace string) {
 	gatherDaemonSet(info, namespace, metav1.ListOptions{LabelSelector: routeagentPodLabel})
 }


### PR DESCRIPTION
Backport of #752 #770 on release-0.14.

#752: Collect metrics pod info as part of gather
#770: Fix error while running gather in GN setup

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.