### PR TITLE
Disable depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,7 @@ linters:
     - bodyclose
     - contextcheck
     # - cyclop # This is equivalent to gocyclo
-    - depguard
+    # - depguard # Disabled temporarily during the v1-v2 migration
     - dogsled
     - dupl
     - durationcheck


### PR DESCRIPTION
For the golangci-lint v1.53 migration, we need to disable depguard because its configuration changed. It will be updated to v2 format and re-enabled once Shipyard has bumped.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
