### PR TITLE
Automated backport of #782: Add air-gapped flag for Azure cloud prepare

### DIFF
--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -72,6 +72,7 @@ func init() {
 	}
 
 	addGeneralAzureFlags(azurePrepareCmd)
+	addAirGappedFlag(azurePrepareCmd, &azureConfig.AirGappedDeployment)
 	azurePrepareCmd.Flags().IntVar(&azureConfig.Gateways, "gateways", defaultNumGateways, "Number of gateways to deploy")
 	// `Standard_F4s_v2` matches the most to `cd5.large` of AWS.
 	azurePrepareCmd.Flags().StringVar(&azureConfig.GWInstanceType, "gateway-instance", "Standard_F4s_v2", "Type of gateways instance machine")

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -69,6 +69,10 @@ func addLoadBalancerFlag(cmd *cobra.Command, p *bool) {
 	cmd.Flags().BoolVar(p, "load-balancer", false, "enable automatic LoadBalancer in front of the gateways")
 }
 
+func addAirGappedFlag(cmd *cobra.Command, p *bool) {
+	cmd.Flags().BoolVar(p, "air-gapped", false, "specifies that the cluster is in an air-gapped environment")
+}
+
 func init() {
 	addJoinFlags(joinCmd)
 	joinRestConfigProducer.SetupFlags(joinCmd.Flags())
@@ -87,8 +91,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&joinFlags.PreferredServer, "preferred-server", false,
 		"enable this cluster as a preferred server for dataplane connections")
 
-	cmd.Flags().BoolVar(&joinFlags.AirGappedDeployment, "air-gapped", false,
-		"specifies that the cluster is in an air-gapped environment")
+	addAirGappedFlag(cmd, &joinFlags.AirGappedDeployment)
 	addLoadBalancerFlag(cmd, &joinFlags.LoadBalancerEnabled)
 
 	cmd.Flags().BoolVar(&joinFlags.ForceUDPEncaps, "force-udp-encaps", false, "force UDP encapsulation for IPSec")

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/admiral v0.15.1
-	github.com/submariner-io/cloud-prepare v0.15.1
+	github.com/submariner-io/cloud-prepare v0.15.2-0.20230614155712-6db2dabe6608
 	github.com/submariner-io/lighthouse v0.15.1
 	github.com/submariner-io/shipyard v0.15.1
 	github.com/submariner-io/submariner v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/submariner-io/admiral v0.15.1 h1:DXYh0GqcKRm+mCMY8CrVayraITcwUVzSo/FWsBp7wSY=
 github.com/submariner-io/admiral v0.15.1/go.mod h1:w4IzXaQG8V5hl/naKCWjNQf2nZiqlEAnJ4M/WH16D54=
-github.com/submariner-io/cloud-prepare v0.15.1 h1:pG1Ekeo/Q/ppVJ/P00FpGUwhXB3FA4t73hzMUywiA80=
-github.com/submariner-io/cloud-prepare v0.15.1/go.mod h1:DSGuPTCsykfrTN5U3UA3HNAk8sEv7kbdQhVy1JCdq0A=
+github.com/submariner-io/cloud-prepare v0.15.2-0.20230614155712-6db2dabe6608 h1:uCCsIQHTe4h4WrutNWuWUmSfnnIvoI4Ob9QNX9QzVUo=
+github.com/submariner-io/cloud-prepare v0.15.2-0.20230614155712-6db2dabe6608/go.mod h1:DSGuPTCsykfrTN5U3UA3HNAk8sEv7kbdQhVy1JCdq0A=
 github.com/submariner-io/lighthouse v0.15.1 h1:6xP2oEIhVsBAHlKr2x411vsEduVxXqvQqotoFTnrfnA=
 github.com/submariner-io/lighthouse v0.15.1/go.mod h1:CAnXGOC8q4AFgFcs07urnNg5LYPmPhFf+CwAWT6gNR0=
 github.com/submariner-io/shipyard v0.15.1 h1:0oypbZJWXod/cFExaXOmu9ZD+/OOfk27D6ImDLADtdk=

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -35,13 +35,14 @@ import (
 )
 
 type Config struct {
-	DedicatedGateway bool
-	Gateways         int
-	InfraID          string
-	Region           string
-	OcpMetadataFile  string
-	AuthFile         string
-	GWInstanceType   string
+	AirGappedDeployment bool
+	DedicatedGateway    bool
+	Gateways            int
+	InfraID             string
+	Region              string
+	OcpMetadataFile     string
+	AuthFile            string
+	GWInstanceType      string
 }
 
 func RunOn(clusterInfo *cluster.Info, config *Config, status reporter.Interface,

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -44,6 +44,7 @@ func Azure(clusterInfo *cluster.Info, ports *cloud.Ports, config *azure.Config, 
 					PublicPorts:     gwPorts,
 					Gateways:        config.Gateways,
 					UseLoadBalancer: useLoadBalancer,
+					AirGapped:       config.AirGappedDeployment,
 				}
 
 				err := gwDeployer.Deploy(gwInput, status)


### PR DESCRIPTION
Backport of #782 on release-0.15.

#782: Add air-gapped flag for Azure cloud prepare

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.