### PR TITLE
Automated backport of #782: Add air-gapped flag for Azure cloud prepare

### DIFF
--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -71,6 +71,7 @@ func init() {
 	}
 
 	addGeneralAzureFlags(azurePrepareCmd)
+	addAirGappedFlag(azurePrepareCmd, &azureConfig.AirGappedDeployment)
 	azurePrepareCmd.Flags().IntVar(&azureConfig.Gateways, "gateways", defaultNumGateways, "Number of gateways to deploy")
 	// `Standard_F4s_v2` matches the most to `cd5.large` of AWS.
 	azurePrepareCmd.Flags().StringVar(&azureConfig.GWInstanceType, "gateway-instance", "Standard_F4s_v2", "Type of gateways instance machine")

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -65,6 +65,10 @@ var joinCmd = &cobra.Command{
 	},
 }
 
+func addAirGappedFlag(cmd *cobra.Command, p *bool) {
+	cmd.Flags().BoolVar(p, "air-gapped", false, "specifies that the cluster is in an air-gapped environment")
+}
+
 func init() {
 	addJoinFlags(joinCmd)
 	joinRestConfigProducer.SetupFlags(joinCmd.Flags())
@@ -83,8 +87,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&joinFlags.PreferredServer, "preferred-server", false,
 		"enable this cluster as a preferred server for dataplane connections")
 
-	cmd.Flags().BoolVar(&joinFlags.AirGappedDeployment, "air-gapped", false,
-		"specifies that the cluster is in an air-gapped environment")
+	addAirGappedFlag(cmd, &joinFlags.AirGappedDeployment)
 	cmd.Flags().BoolVar(&joinFlags.LoadBalancerEnabled, "load-balancer", false,
 		"enable automatic LoadBalancer in front of the gateways")
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/admiral v0.14.5
-	github.com/submariner-io/cloud-prepare v0.14.5
+	github.com/submariner-io/cloud-prepare v0.14.6-0.20230614155757-52a039ba62e6
 	github.com/submariner-io/lighthouse v0.14.5
 	github.com/submariner-io/shipyard v0.14.5
 	github.com/submariner-io/submariner v0.14.5

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/submariner-io/admiral v0.14.5 h1:vGtGVJPg1Wap/nKzkE4S56QNK6TEjsnk11EZOW1dskg=
 github.com/submariner-io/admiral v0.14.5/go.mod h1:LkpESKH3BOS9bL206BMMyFIvAblqPC03WXFNMutAaRQ=
-github.com/submariner-io/cloud-prepare v0.14.5 h1:lgVi11pF9HtvUgyeR3hWHjGukrODhG+bjT74PgbL25A=
-github.com/submariner-io/cloud-prepare v0.14.5/go.mod h1:KKPosvnFp2NSEgRe4WWNwnhhEeBl2/aD/iaba3eB/Po=
+github.com/submariner-io/cloud-prepare v0.14.6-0.20230614155757-52a039ba62e6 h1:wQsxDnxDPjxbfwR6r3VlF7Aj0DknM01OBKmQS133w9o=
+github.com/submariner-io/cloud-prepare v0.14.6-0.20230614155757-52a039ba62e6/go.mod h1:A+26HLrf4YSDQcoj6ULR++C47r3aWxAKCQKDIFzwnqA=
 github.com/submariner-io/lighthouse v0.14.5 h1:pwYDifzyjVmeoY2sgDLVx6rSvXLZGILBogb1nS2EWCo=
 github.com/submariner-io/lighthouse v0.14.5/go.mod h1:dKy1G+ChwK+jCJlx8FMMKGcJV++dKse6FkGhOefKKkg=
 github.com/submariner-io/shipyard v0.14.5 h1:ojSNM6xOlGgyaZ7YQL/6Jrzs08mn3dXKEuFgJw7/hY0=

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -35,13 +35,14 @@ import (
 )
 
 type Config struct {
-	DedicatedGateway bool
-	Gateways         int
-	InfraID          string
-	Region           string
-	OcpMetadataFile  string
-	AuthFile         string
-	GWInstanceType   string
+	AirGappedDeployment bool
+	DedicatedGateway    bool
+	Gateways            int
+	InfraID             string
+	Region              string
+	OcpMetadataFile     string
+	AuthFile            string
+	GWInstanceType      string
 }
 
 func RunOn(clusterInfo *cluster.Info, config *Config, status reporter.Interface,

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -43,6 +43,7 @@ func Azure(clusterInfo *cluster.Info, ports *cloud.Ports, config *azure.Config, 
 				gwInput := api.GatewayDeployInput{
 					PublicPorts: gwPorts,
 					Gateways:    config.Gateways,
+					AirGapped:   config.AirGappedDeployment,
 				}
 
 				err := gwDeployer.Deploy(gwInput, status)


### PR DESCRIPTION
Backport of #782 on release-0.14.

#782: Add air-gapped flag for Azure cloud prepare

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.