### PR TITLE
Add missing components to show versions

### DIFF
--- a/internal/show/versions.go
+++ b/internal/show/versions.go
@@ -82,13 +82,15 @@ func Versions(clusterInfo *cluster.Info, _ string, status reporter.Interface) er
 		{Name: "VERSION"},
 	}}
 
-	err := printDaemonSetVersions(clusterInfo, &printer, names.GatewayComponent, names.RouteAgentComponent, names.GlobalnetComponent)
+	err := printDaemonSetVersions(clusterInfo, &printer, names.GatewayComponent, names.RouteAgentComponent, names.GlobalnetComponent,
+		names.MetricsProxyComponent)
 	if err != nil {
 		return status.Error(err, "Error retrieving DaemonSet versions")
 	}
 
 	err = printDeploymentVersions(
-		clusterInfo, &printer, names.OperatorComponent, names.ServiceDiscoveryComponent, names.LighthouseCoreDNSComponent)
+		clusterInfo, &printer, names.OperatorComponent, names.ServiceDiscoveryComponent, names.LighthouseCoreDNSComponent,
+		names.NetworkPluginSyncerComponent)
 	if err != nil {
 		return status.Error(err, "Error retrieving Deployment versions")
 	}


### PR DESCRIPTION
show versions doesn't show the versions of the metrics proxy and plugin syncer, this fixes that.

Fixes: #796

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
