### PR TITLE
Automated backport of #797: Add missing components to show versions

### DIFF
--- a/internal/show/versions.go
+++ b/internal/show/versions.go
@@ -82,13 +82,15 @@ func Versions(clusterInfo *cluster.Info, _ string, status reporter.Interface) er
 		{Name: "VERSION"},
 	}}
 
-	err := printDaemonSetVersions(clusterInfo, &printer, names.GatewayComponent, names.RouteAgentComponent, names.GlobalnetComponent)
+	err := printDaemonSetVersions(clusterInfo, &printer, names.GatewayComponent, names.RouteAgentComponent, names.GlobalnetComponent,
+		names.MetricsProxyComponent)
 	if err != nil {
 		return status.Error(err, "Error retrieving DaemonSet versions")
 	}
 
 	err = printDeploymentVersions(
-		clusterInfo, &printer, names.OperatorComponent, names.ServiceDiscoveryComponent, names.LighthouseCoreDNSComponent)
+		clusterInfo, &printer, names.OperatorComponent, names.ServiceDiscoveryComponent, names.LighthouseCoreDNSComponent,
+		names.NetworkPluginSyncerComponent)
 	if err != nil {
 		return status.Error(err, "Error retrieving Deployment versions")
 	}


### PR DESCRIPTION
Backport of #797 on release-0.15.

#797: Add missing components to show versions

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.