### PR TITLE
Rename subctl binary to `subctl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ cmd/bin/subctl: cmd/bin/subctl-$(VERSION)-$(GOOS)-$(GOARCH)$(GOEXE)
 
 dist/subctl-%.tar.xz: cmd/bin/subctl-%
 	mkdir -p dist
-	tar -cJf $@ --transform "s/^cmd.bin/subctl-$(VERSION)/" $<
+	tar -cJf $@ --transform "s|^cmd/bin/subctl-[^/]*|subctl-$(VERSION)/subctl|" $<
 
 dist/subctl-%.tar.gz: cmd/bin/subctl-%
 	mkdir -p dist
-	tar -czf $@ --transform "s/^cmd.bin/subctl-$(VERSION)/" $<
+	tar -czf $@ --transform "s|^cmd/bin/subctl-[^/]*|subctl-$(VERSION)/subctl|" $<
 
 dist/subctl-checksums.txt: $(CROSS_TARBALLS)
 	cd $(@D) && sha256sum $(^F) >> $(@F)


### PR DESCRIPTION
Currently while building a subctl is binary is named as `subctl-$version-$arch`. This PR renames the binary to just `subctl`. This is one of the requirements of Krew.

Depends on https://github.com/submariner-io/get.submariner.io/pull/51

Epic: https://github.com/submariner-io/enhancements/issues/182

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
