### PR TITLE
Correctly skip upgrade-e2e on closed PRs

### DIFF
--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -12,7 +12,7 @@ jobs:
   upgrade-e2e:
     name: Latest Release to Latest Version
     if: |
-      github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test-draft')
+      (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test-draft'))
       && github.event.pull_request.state == 'open'
     timeout-minutes: 30
     runs-on: ubuntu-latest


### PR DESCRIPTION
The check added recently got the operator precedence wrong, and only skipped closed PRs wich a test-draft label. This fixes that to skip all closed PRs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
