### PR TITLE
Revert "Remove networkplugin syncer bits"

### DIFF
--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -25,13 +25,14 @@ import (
 )
 
 const (
-	gatewayPodLabel          = "app=submariner-gateway"
-	routeagentPodLabel       = "app=submariner-routeagent"
-	globalnetPodLabel        = "app=submariner-globalnet"
-	metricsProxyPodLabel     = "app=submariner-metrics-proxy"
-	addonPodLabel            = "app=submariner-addon"
-	ovnMasterPodLabelOCP     = "app=ovnkube-master"
-	ovnMasterPodLabelGeneric = "name=ovnkube-master"
+	gatewayPodLabel             = "app=submariner-gateway"
+	routeagentPodLabel          = "app=submariner-routeagent"
+	globalnetPodLabel           = "app=submariner-globalnet"
+	metricsProxyPodLabel        = "app=submariner-metrics-proxy"
+	networkpluginSyncerPodLabel = "app=submariner-networkplugin-syncer"
+	addonPodLabel               = "app=submariner-addon"
+	ovnMasterPodLabelOCP        = "app=ovnkube-master"
+	ovnMasterPodLabelGeneric    = "name=ovnkube-master"
 )
 
 func gatherGatewayPodLogs(info *Info) {
@@ -52,6 +53,10 @@ func gatherRouteAgentPodLogs(info *Info) {
 
 func gatherGlobalnetPodLogs(info *Info) {
 	gatherPodLogs(globalnetPodLabel, info)
+}
+
+func gatherNetworkPluginSyncerPodLogs(info *Info) {
+	gatherPodLogs(networkpluginSyncerPodLabel, info)
 }
 
 func gatherAddonPodLogs(info *Info) {

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -132,6 +132,7 @@ func gatherConnectivity(dataType string, info Info) bool {
 		gatherRouteAgentPodLogs(&info)
 		gatherMetricsProxyPodLogs(&info)
 		gatherGlobalnetPodLogs(&info)
+		gatherNetworkPluginSyncerPodLogs(&info)
 		gatherAddonPodLogs(&info)
 	case Resources:
 		gatherCNIResources(&info, info.Submariner.Status.NetworkPlugin)
@@ -238,6 +239,7 @@ func gatherOperator(dataType string, info Info) bool {
 		gatherMetricsPodDaemonSet(&info, info.OperatorNamespace())
 		gatherRouteAgentDaemonSet(&info, info.OperatorNamespace())
 		gatherGlobalnetDaemonSet(&info, info.OperatorNamespace())
+		gatherNetworkPluginSyncerDeployment(&info, info.OperatorNamespace())
 		gatherLighthouseAgentDeployment(&info, info.OperatorNamespace())
 		gatherLighthouseCoreDNSDeployment(&info, info.OperatorNamespace())
 	default:

--- a/internal/gather/operator.go
+++ b/internal/gather/operator.go
@@ -56,6 +56,10 @@ func gatherGlobalnetDaemonSet(info *Info, namespace string) {
 	gatherDaemonSet(info, namespace, metav1.ListOptions{LabelSelector: globalnetPodLabel})
 }
 
+func gatherNetworkPluginSyncerDeployment(info *Info, namespace string) {
+	gatherDeployment(info, namespace, metav1.ListOptions{LabelSelector: networkpluginSyncerPodLabel})
+}
+
 func gatherLighthouseAgentDeployment(info *Info, namespace string) {
 	gatherDeployment(info, namespace, metav1.ListOptions{LabelSelector: "app=submariner-lighthouse-agent"})
 }

--- a/internal/show/versions.go
+++ b/internal/show/versions.go
@@ -89,7 +89,8 @@ func Versions(clusterInfo *cluster.Info, _ string, status reporter.Interface) er
 	}
 
 	err = printDeploymentVersions(
-		clusterInfo, &printer, names.OperatorComponent, names.ServiceDiscoveryComponent, names.LighthouseCoreDNSComponent)
+		clusterInfo, &printer, names.OperatorComponent, names.ServiceDiscoveryComponent, names.LighthouseCoreDNSComponent,
+		names.NetworkPluginSyncerComponent)
 	if err != nil {
 		return status.Error(err, "Error retrieving Deployment versions")
 	}

--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -211,6 +211,7 @@ var validOverrides = []string{
 	names.GatewayComponent,
 	names.RouteAgentComponent,
 	names.GlobalnetComponent,
+	names.NetworkPluginSyncerComponent,
 	names.ServiceDiscoveryComponent,
 	names.LighthouseCoreDNSComponent,
 	names.NettestComponent,

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -29,6 +29,7 @@ import (
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
+	"github.com/submariner-io/submariner/pkg/cni"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -132,6 +133,12 @@ func checkPods(clusterInfo *cluster.Info, status reporter.Interface) error {
 		// Check if globalnet components are deployed and running if enabled
 		if clusterInfo.Submariner.Spec.GlobalCIDR != "" {
 			checkDaemonset(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace, "submariner-globalnet", tracker)
+		}
+
+		// check if networkplugin syncer components are deployed and running if enabled
+		if clusterInfo.Submariner.Status.NetworkPlugin == cni.OVNKubernetes {
+			checkDeployment(clusterInfo.ClientProducer.ForKubernetes(), constants.OperatorNamespace,
+				"submariner-networkplugin-syncer", tracker)
 		}
 
 		checkDaemonset(clusterInfo.ClientProducer.ForKubernetes(), clusterInfo.Submariner.Namespace, "submariner-metrics-proxy", tracker)

--- a/pkg/submariner/ensure.go
+++ b/pkg/submariner/ensure.go
@@ -59,6 +59,11 @@ func Ensure(ctx context.Context, status reporter.Interface, kubeClient kubernete
 			ClusterRoleFile:        embeddedyamls.Config_rbac_submariner_diagnose_ocp_cluster_role_yaml,
 			ClusterRoleBindingFile: embeddedyamls.Config_rbac_submariner_diagnose_ocp_cluster_role_binding_yaml,
 		},
+		{
+			ComponentName:          names.NetworkPluginSyncerComponent,
+			ClusterRoleFile:        embeddedyamls.Config_rbac_networkplugin_syncer_ocp_cluster_role_yaml,
+			ClusterRoleBindingFile: embeddedyamls.Config_rbac_networkplugin_syncer_ocp_cluster_role_binding_yaml,
+		},
 	}
 
 	if created, err := ocp.EnsureRBAC(ctx, dynClient, kubeClient, operatorNamespace, componentsRbac); err != nil {

--- a/pkg/submariner/serviceaccount/ensure.go
+++ b/pkg/submariner/serviceaccount/ensure.go
@@ -60,6 +60,7 @@ func Ensure(ctx context.Context, kubeClient kubernetes.Interface, namespace stri
 	return createdSA || createdRole || createdRB || createdCR || createdCRB, nil
 }
 
+//nolint:dupl // Similar code in ensureClusterRoleBindings, ensureRoles, ensureRoleBindings but not duplicated
 func ensureServiceAccounts(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (bool, error) {
 	createdSubmarinerSA, err := serviceaccount.EnsureFromYAML(ctx, kubeClient, namespace,
 		embeddedyamls.Config_rbac_submariner_gateway_service_account_yaml)
@@ -81,9 +82,15 @@ func ensureServiceAccounts(ctx context.Context, kubeClient kubernetes.Interface,
 
 	createdDiagnoseSA, err := serviceaccount.EnsureFromYAML(ctx, kubeClient, namespace,
 		embeddedyamls.Config_rbac_submariner_diagnose_service_account_yaml)
+	if err != nil {
+		return false, errors.Wrap(err, "error provisioning diagnose ServiceAccount resource")
+	}
 
-	return createdSubmarinerSA || createdRouteAgentSA || createdGlobalnetSA || createdDiagnoseSA,
-		errors.Wrap(err, "error provisioning diagnose ServiceAccount resource")
+	createdNPSyncerSA, err := serviceaccount.EnsureFromYAML(ctx, kubeClient, namespace,
+		embeddedyamls.Config_rbac_networkplugin_syncer_service_account_yaml)
+
+	return createdSubmarinerSA || createdRouteAgentSA || createdGlobalnetSA || createdNPSyncerSA || createdDiagnoseSA,
+		errors.Wrap(err, "error provisioning operator networkplugin syncer resource")
 }
 
 func ensureClusterRoles(ctx context.Context, kubeClient kubernetes.Interface) (bool, error) {
@@ -103,11 +110,17 @@ func ensureClusterRoles(ctx context.Context, kubeClient kubernetes.Interface) (b
 	}
 
 	createdDiagnoseCR, err := clusterrole.EnsureFromYAML(ctx, kubeClient, embeddedyamls.Config_rbac_submariner_diagnose_cluster_role_yaml)
+	if err != nil {
+		return false, errors.Wrap(err, "error provisioning diagnose ClusterRole resource")
+	}
 
-	return createdSubmarinerCR || createdRouteAgentCR || createdGlobalnetCR || createdDiagnoseCR,
-		errors.Wrap(err, "error provisioning diagnose ClusterRole resource")
+	createdNPSyncerCR, err := clusterrole.EnsureFromYAML(ctx, kubeClient, embeddedyamls.Config_rbac_networkplugin_syncer_cluster_role_yaml)
+
+	return createdSubmarinerCR || createdRouteAgentCR || createdGlobalnetCR || createdNPSyncerCR || createdDiagnoseCR,
+		errors.Wrap(err, "error provisioning networkplugin syncer ClusterRole resource")
 }
 
+//nolint:dupl // Similar code in ensureServiceAccounts, ensureRoles, ensureRoleBindings but not duplicated
 func ensureClusterRoleBindings(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (bool, error) {
 	createdSubmarinerCRB, err := clusterrolebinding.EnsureFromYAML(ctx, kubeClient, namespace,
 		embeddedyamls.Config_rbac_submariner_gateway_cluster_role_binding_yaml)
@@ -129,9 +142,15 @@ func ensureClusterRoleBindings(ctx context.Context, kubeClient kubernetes.Interf
 
 	createdDiagnoseCRB, err := clusterrolebinding.EnsureFromYAML(ctx, kubeClient, namespace,
 		embeddedyamls.Config_rbac_submariner_diagnose_cluster_role_binding_yaml)
+	if err != nil {
+		return false, errors.Wrap(err, "error provisioning diagnose ClusterRoleBinding resource")
+	}
 
-	return createdSubmarinerCRB || createdRouteAgentCRB || createdGlobalnetCRB || createdDiagnoseCRB,
-		errors.Wrap(err, "error provisioning diagnose ClusterRoleBinding resource")
+	createdNPSyncerCRB, err := clusterrolebinding.EnsureFromYAML(ctx, kubeClient, namespace,
+		embeddedyamls.Config_rbac_networkplugin_syncer_cluster_role_binding_yaml)
+
+	return createdSubmarinerCRB || createdRouteAgentCRB || createdGlobalnetCRB || createdNPSyncerCRB || createdDiagnoseCRB,
+		errors.Wrap(err, "error provisioning networkplugin syncer ClusterRoleBinding resource")
 }
 
 //nolint:dupl // Similar code in ensureServiceAccounts, ensureClusterRoleBindings, ensureRoleBindings but not duplicated


### PR DESCRIPTION
Reverts submariner-io/subctl#875, which broke CI across the board (it needs other PRs to be merged first).