### PR TITLE
When upgrading, deploy with the downloaded subctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,10 @@ export PATH := $(CURDIR)/cmd/bin:$(PATH)
 # Targets to make
 
 # Build subctl before deploying to ensure we use that
-# (with the PATH set above)
+# (with the PATH set above), unless we're deploying "latest"
+ifneq (latest,$(SUBCTL_VERSION))
 deploy: cmd/bin/subctl
+endif
 
 # [system-test] runs system level tests for the various `subctl` commands
 system-test:


### PR DESCRIPTION
The upgrade test relies on a series of prerequisites defined in Shipyard:

    upgrade-e2e: deploy-latest deploy e2e

The deploy-latest target runs Make again with the deploy target and various settings to ensure that the initial deployment downloads the latest release of subctl before deploying. The default PATH in our containers then results in that downloaded subctl being used to deploy Submariner.

In the subctl project, we want to test the locally-built subctl instead of whatever subctl is available on the PATH; to that end, the cmd/bin directory, containing the local subctl, is preprended to the PATH. In addition, the deploy target is amended to ensure that subctl is built before it is run.

The overall result is that upgrade-e2e, through deploy-latest, invokes deploy, but that builds subctl first and the whole operation uses the new subctl instead of the version downloaded for the upgrade test.

This fixes the issue by skipping the deploy amendment if the requested subctl version is "latest" (i.e. the latest release). This works, at least in CI, because when upgrade-e2e ends up running deploy, the build is skipped, so the initial deployment uses the only available version of subctl, which is the version downloaded as the latest release. The second time upgrade-e2e gets to the deploy phase, SUBCTL_VERSION isn't set, and the local subctl is built and run as expected.

Fixes: #876

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
