### PR TITLE
Add check for OVN pods in IC deployments

### DIFF
--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -32,6 +32,7 @@ const (
 	addonPodLabel            = "app=submariner-addon"
 	ovnMasterPodLabelOCP     = "app=ovnkube-master"
 	ovnMasterPodLabelGeneric = "name=ovnkube-master"
+	ovnKubePodLabel          = "app=ovnkube-node"
 )
 
 func gatherGatewayPodLogs(info *Info) {


### PR DESCRIPTION
OVN IC deployments don't have a OVN Master node and use a different label. This change adds a check for additional `ovnKubePodLabel = "app=ovnkube-node"` when looking for pods to run OVN commands on.

We also no longer create `submariner_router` so remove references to it.

Fixes #910

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
