### PR TITLE
Use endpoints from Broker while validating overlapping CIDRs

### DIFF
--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/restconfig"
+	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
@@ -68,12 +70,22 @@ func checkOverlappingCIDRs(clusterInfo *cluster.Info, status reporter.Interface)
 
 	defer status.End()
 
+	brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(clusterInfo.Submariner, nil)
+	if err != nil {
+		return status.Error(err, "Error getting the Broker's REST config")
+	}
+
+	clientProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	if err != nil {
+		return status.Error(err, "Error creating broker client Producer")
+	}
+
 	endpointList := &submarinerv1.EndpointList{}
 
-	err := clusterInfo.ClientProducer.ForGeneral().List(context.TODO(), endpointList,
-		controllerClient.InNamespace(clusterInfo.Submariner.Namespace))
+	err = clientProducer.ForGeneral().List(context.TODO(), endpointList,
+		controllerClient.InNamespace(brokerNamespace))
 	if err != nil {
-		return status.Error(err, "Error listing the Submariner endpoints")
+		return status.Error(err, "Error listing the Submariner endpoints from the Broker cluster")
 	}
 
 	tracker := reporter.NewTracker(status)


### PR DESCRIPTION
As part of the following PR[1], we no longer sync an endpoint from the Broker if the endpoint has any overlapping CIDRs with the local cluster. This was done to avoid issues on the Gateway node. Consequently, the subctl diagnose code should ideally examine the endpoints on Broker when validating overlapping CIDRs instead of inspecting the endpoints on the local cluster. This PR addresses this issue.

[1] https://github.com/submariner-io/submariner/pull/2263

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
