### PR TITLE
Automated backport of #911: Add check for OVN pods in IC deployments

### DIFF
--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -32,6 +32,7 @@ const (
 	addonPodLabel            = "app=submariner-addon"
 	ovnMasterPodLabelOCP     = "app=ovnkube-master"
 	ovnMasterPodLabelGeneric = "name=ovnkube-master"
+	ovnKubePodLabel          = "app=ovnkube-node"
 )
 
 func gatherGatewayPodLogs(info *Info) {


### PR DESCRIPTION
Backport of #911 on release-0.16.

#911: Add check for OVN pods in IC deployments

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.