### PR TITLE
Automated backport of #913: Use endpoints from Broker while validating overlapping CIDRs

### DIFF
--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/restconfig"
+	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
@@ -68,12 +70,22 @@ func checkOverlappingCIDRs(clusterInfo *cluster.Info, status reporter.Interface)
 
 	defer status.End()
 
+	brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(clusterInfo.Submariner, nil)
+	if err != nil {
+		return status.Error(err, "Error getting the Broker's REST config")
+	}
+
+	clientProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	if err != nil {
+		return status.Error(err, "Error creating broker client Producer")
+	}
+
 	endpointList := &submarinerv1.EndpointList{}
 
-	err := clusterInfo.ClientProducer.ForGeneral().List(context.TODO(), endpointList,
-		controllerClient.InNamespace(clusterInfo.Submariner.Namespace))
+	err = clientProducer.ForGeneral().List(context.TODO(), endpointList,
+		controllerClient.InNamespace(brokerNamespace))
 	if err != nil {
-		return status.Error(err, "Error listing the Submariner endpoints")
+		return status.Error(err, "Error listing the Submariner endpoints from the Broker cluster")
 	}
 
 	tracker := reporter.NewTracker(status)


### PR DESCRIPTION
Backport of #913 on release-0.16.

#913: Use endpoints from Broker while validating overlapping CIDRs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.