### PR TITLE
upgrade: Trim prefix from current version

### DIFF
--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -128,7 +128,7 @@ func upgradeSubctl(status reporter.Interface) (string, error) {
 		// semver needs a dotted triplet, which is at least five characters;
 		// on development or unknown versions, assume we need to upgrade
 		if len(version.Version) >= 5 && version.Version[0:5] != "devel" {
-			currentVersion, err := semver.NewVersion(version.Version)
+			currentVersion, err := semver.NewVersion(strings.TrimPrefix(version.Version, "v"))
 			if currentVersion == nil {
 				return "", status.Error(err, "Error parsing current subctl version")
 			}


### PR DESCRIPTION
Semver API expects versions to be without `v` prefix. Current subctl version in `version.Version` includes the prefix. So trim it before calling semver.NewVersion()

Fixes #912

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
