### PR TITLE
Automated backport of #917: upgrade: Trim prefix from current version

### DIFF
--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -128,7 +128,7 @@ func upgradeSubctl(status reporter.Interface) (string, error) {
 		// semver needs a dotted triplet, which is at least five characters;
 		// on development or unknown versions, assume we need to upgrade
 		if len(version.Version) >= 5 && version.Version[0:5] != "devel" {
-			currentVersion, err := semver.NewVersion(version.Version)
+			currentVersion, err := semver.NewVersion(strings.TrimPrefix(version.Version, "v"))
 			if currentVersion == nil {
 				return "", status.Error(err, "Error parsing current subctl version")
 			}


### PR DESCRIPTION
Backport of #917 on release-0.16.

#917: upgrade: Trim prefix from current version

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.