### PR TITLE
Automated backport of #922: Remove redundant diagnose messages

### DIFF
--- a/pkg/diagnose/connections.go
+++ b/pkg/diagnose/connections.go
@@ -79,7 +79,5 @@ func Connections(clusterInfo *cluster.Info, _ string, status reporter.Interface)
 		return errors.New("failures while diagnosing connections")
 	}
 
-	status.Success("All connections are established")
-
 	return nil
 }

--- a/pkg/diagnose/deployment_metrics.go
+++ b/pkg/diagnose/deployment_metrics.go
@@ -53,7 +53,7 @@ func checkMetricsConfig(clusterInfo *cluster.Info, status reporter.Interface) er
 }
 
 func checkComponentMetrics(clusterInfo *cluster.Info, status reporter.Interface, component, command string) error {
-	status.Start("Checking if %s metrics are accessible from non-gateway nodes", component)
+	status.Start("Checking that %s metrics are accessible from non-gateway nodes", component)
 	defer status.End()
 
 	singleNode, err := clusterInfo.HasSingleNode()
@@ -88,8 +88,6 @@ func checkComponentMetrics(clusterInfo *cluster.Info, status reporter.Interface,
 		return status.Error(errors.Errorf("Unexpected output %v", cPod.PodOutput),
 			"Unable to access %s metrics service in submariner-operator namespace", component)
 	}
-
-	status.Success("The %s metrics are accessible", component)
 
 	return nil
 }

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -63,9 +63,9 @@ func Deployments(clusterInfo *cluster.Info, _ string, status reporter.Interface)
 
 func checkOverlappingCIDRs(clusterInfo *cluster.Info, status reporter.Interface) error {
 	if clusterInfo.Submariner.Spec.GlobalCIDR != "" {
-		status.Start("Globalnet deployment detected - checking if globalnet CIDRs overlap")
+		status.Start("Globalnet deployment detected - checking that globalnet CIDRs do not overlap")
 	} else {
-		status.Start("Non-Globalnet deployment detected - checking if cluster CIDRs overlap")
+		status.Start("Non-Globalnet deployment detected - checking that cluster CIDRs do not overlap")
 	}
 
 	defer status.End()
@@ -123,12 +123,6 @@ func checkOverlappingCIDRs(clusterInfo *cluster.Info, status reporter.Interface)
 
 	if tracker.HasFailures() {
 		return errors.New("failures while diagnosing overlapping CIDRs")
-	}
-
-	if clusterInfo.Submariner.Spec.GlobalCIDR != "" {
-		status.Success("Clusters do not have overlapping globalnet CIDRs")
-	} else {
-		status.Success("Clusters do not have overlapping CIDRs")
 	}
 
 	return nil

--- a/pkg/diagnose/firewall_vxlan.go
+++ b/pkg/diagnose/firewall_vxlan.go
@@ -34,7 +34,7 @@ const (
 func FirewallIntraVxLANConfig(clusterInfo *cluster.Info, namespace string, options FirewallOptions, status reporter.Interface) error {
 	mustHaveSubmariner(clusterInfo)
 
-	status.Start("Checking the firewall configuration to determine if intra-cluster VXLAN traffic is allowed")
+	status.Start("Checking that firewall configuration allows intra-cluster VXLAN traffic")
 	defer status.End()
 
 	singleNode, err := clusterInfo.HasSingleNode()
@@ -55,14 +55,11 @@ func FirewallIntraVxLANConfig(clusterInfo *cluster.Info, namespace string, optio
 		return errors.New("failures while diagnosing the intra-VXLAN firewall configuration")
 	}
 
-	status.Success("The firewall configuration allows intra-cluster VXLAN traffic")
-
 	return nil
 }
 
 func checkFWConfig(clusterInfo *cluster.Info, namespace string, options FirewallOptions, status reporter.Interface) {
 	if clusterInfo.Submariner.Status.NetworkPlugin == "OVNKubernetes" {
-		status.Success("This check is not necessary for the OVNKubernetes CNI plugin")
 		return
 	}
 

--- a/pkg/diagnose/globalnet.go
+++ b/pkg/diagnose/globalnet.go
@@ -40,11 +40,10 @@ func GlobalnetConfig(clusterInfo *cluster.Info, _ string, status reporter.Interf
 	mustHaveSubmariner(clusterInfo)
 
 	if clusterInfo.Submariner.Spec.GlobalCIDR == "" {
-		status.Success("Globalnet is not installed - skipping")
 		return nil
 	}
 
-	status.Start("Checking Globalnet configuration")
+	status.Start("Checking that Globalnet is correctly configured and functioning")
 	defer status.End()
 
 	tracker := reporter.NewTracker(status)
@@ -56,8 +55,6 @@ func GlobalnetConfig(clusterInfo *cluster.Info, _ string, status reporter.Interf
 	if tracker.HasFailures() {
 		return errors.New("failures while diagnosing Globalnet")
 	}
-
-	status.Success("Globalnet is properly configured and functioning")
 
 	return nil
 }

--- a/pkg/diagnose/servicediscovery.go
+++ b/pkg/diagnose/servicediscovery.go
@@ -39,7 +39,7 @@ import (
 )
 
 func ServiceDiscovery(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-	status.Start("Checking if services have been exported properly")
+	status.Start("Checking that services have been exported properly")
 	defer status.End()
 
 	tracker := reporter.NewTracker(status)
@@ -49,8 +49,6 @@ func ServiceDiscovery(clusterInfo *cluster.Info, _ string, status reporter.Inter
 	if tracker.HasFailures() {
 		return errors.New("failures while diagnosing service discovery")
 	}
-
-	status.Success("All services have been exported properly")
 
 	return nil
 }


### PR DESCRIPTION
Backport of #922 on release-0.16.

#922: Remove redundant diagnose messages

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.