### PR TITLE
Edit arguments given to run new upgraded subctl

### DIFF
--- a/.github/workflows/upgrade-subctl.yml
+++ b/.github/workflows/upgrade-subctl.yml
@@ -33,8 +33,11 @@ jobs:
       - name: Build new subctl
         run: make cmd/bin/subctl
 
-      - name: Run upgrade command
-        run: cmd/bin/subctl upgrade
+      - name: Run upgrade command and check versions after upgrade
+        run: |
+          export KUBECONFIG=$(find $(git rev-parse --show-toplevel)/output/kubeconfigs/ -type f -printf %p:)
+          cmd/bin/subctl upgrade
+          cmd/bin/subctl version && cmd/bin/subctl show versions
 
       - name: Run e2e tests
         run: make e2e

--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -80,7 +80,7 @@ func upgrade(_ *cobra.Command, _ []string) {
 		// Step 2a: subctl was upgraded, so run it instead of continuing
 		cmd := exec.Cmd{
 			Path:   command,
-			Args:   os.Args[1:],
+			Args:   os.Args,
 			Stdin:  os.Stdin,
 			Stdout: os.Stdout,
 			Stderr: os.Stderr,


### PR DESCRIPTION
os.Args[1:] dropped prefix `subctl` so when upgrade is run using upgraded subctl, `upgrade` is considered as the new parent command and hencce complains about the `--to-version` validity.

This PR drops the arg slicing.

Closes: https://github.com/submariner-io/subctl/issues/962

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
