### PR TITLE
Automated backport of #970: Edit arguments given to run new upgraded subctl

### DIFF
--- a/.github/workflows/upgrade-subctl.yml
+++ b/.github/workflows/upgrade-subctl.yml
@@ -33,8 +33,11 @@ jobs:
       - name: Build new subctl
         run: make cmd/bin/subctl
 
-      - name: Run upgrade command
-        run: cmd/bin/subctl upgrade
+      - name: Run upgrade command and check versions after upgrade
+        run: |
+          export KUBECONFIG=$(find $(git rev-parse --show-toplevel)/output/kubeconfigs/ -type f -printf %p:)
+          cmd/bin/subctl upgrade
+          cmd/bin/subctl version && cmd/bin/subctl show versions
 
       - name: Run e2e tests
         run: make e2e

--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -80,7 +80,7 @@ func upgrade(_ *cobra.Command, _ []string) {
 		// Step 2a: subctl was upgraded, so run it instead of continuing
 		cmd := exec.Cmd{
 			Path:   command,
-			Args:   os.Args[1:],
+			Args:   os.Args,
 			Stdin:  os.Stdin,
 			Stdout: os.Stdout,
 			Stderr: os.Stderr,


### PR DESCRIPTION
Backport of #970 on release-0.16.

#970: Edit arguments given to run new upgraded subctl

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.