### PR TITLE
Reduce string constant duplication

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -53,8 +53,8 @@ var (
 	awsCleanupCmd = &cobra.Command{
 		Use:   "aws",
 		Short: "Clean up an AWS cloud",
-		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on AWS-based" +
-			" cloud after Submariner uninstallation.",
+		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on " +
+			"AWS-based cloud after Submariner uninstallation.",
 		PreRunE: checkAWSFlags,
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(

--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -52,8 +52,8 @@ var (
 	azureCleanupCmd = &cobra.Command{
 		Use:   "azure",
 		Short: "Clean up an Azure cloud",
-		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on Azure-based" +
-			" cloud after Submariner uninstallation.",
+		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on " +
+			"Azure-based cloud after Submariner uninstallation.",
 		PreRunE: checkAzureFlags,
 		Run: func(cmd *cobra.Command, args []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(


### PR DESCRIPTION
Newer versions of `goconst` detect more instances of string duplication so refactor the offending strings to avoid an error.