### PR TITLE
Remove cloud prepare dedicated-gateway flags

### DIFF
--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -78,12 +78,7 @@ func init() {
 	azurePrepareCmd.Flags().IntVar(&azureConfig.Gateways, "gateways", defaultNumGateways, "Number of gateways to deploy")
 	// `Standard_F4s_v2` matches the most to `cd5.large` of AWS.
 	azurePrepareCmd.Flags().StringVar(&azureConfig.GWInstanceType, "gateway-instance", "Standard_F4s_v2", "Type of gateways instance machine")
-	azurePrepareCmd.Flags().BoolVar(&azureConfig.DedicatedGateway, "dedicated-gateway", true,
-		"Whether a dedicated gateway node has to be deployed")
 	cloudPrepareCmd.AddCommand(azurePrepareCmd)
-
-	_ = azurePrepareCmd.Flags().MarkDeprecated("dedicated-gateway", "to be removed in 0.16. "+
-		"To deploy without dedicated gateways, use the Load Balancer mode instead.")
 
 	addGeneralAzureFlags(azureCleanupCmd)
 	cloudCleanupCmd.AddCommand(azureCleanupCmd)

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -88,11 +88,6 @@ func init() {
 	gcpPrepareCmd.Flags().StringVar(&gcpConfig.GWInstanceType, "gateway-instance", "n1-standard-4", "Type of gateway instance machine")
 	gcpPrepareCmd.Flags().IntVar(&gcpConfig.Gateways, "gateways", defaultNumGateways,
 		"Number of gateways to deploy")
-	gcpPrepareCmd.Flags().BoolVar(&gcpConfig.DedicatedGateway, "dedicated-gateway", true,
-		"Whether a dedicated gateway node has to be deployed")
-
-	_ = gcpPrepareCmd.Flags().MarkDeprecated("dedicated-gateway", "to be removed in 0.16. "+
-		"To deploy without dedicated gateways, use the Load Balancer mode instead.")
 
 	cloudPrepareCmd.AddCommand(gcpPrepareCmd)
 

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -80,11 +80,6 @@ func init() {
 		"Number of gateways to deploy")
 	rhosPrepareCmd.Flags().StringVar(&rhosConfig.GWInstanceType, "gateway-instance", "PnTAE.CPU_4_Memory_8192_Disk_50",
 		"Type of gateway instance machine")
-	rhosPrepareCmd.Flags().BoolVar(&rhosConfig.DedicatedGateway, "dedicated-gateway", true,
-		"Whether a dedicated gateway node has to be deployed")
-
-	_ = rhosPrepareCmd.Flags().MarkDeprecated("dedicated-gateway", "to be removed in 0.16. "+
-		"To deploy without dedicated gateways, use the Load Balancer mode instead.")
 
 	cloudPrepareCmd.AddCommand(rhosPrepareCmd)
 

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -36,7 +36,6 @@ import (
 
 type Config struct {
 	AirGappedDeployment bool
-	DedicatedGateway    bool
 	Gateways            int
 	InfraID             string
 	Region              string
@@ -106,7 +105,7 @@ func RunOn(clusterInfo *cluster.Info, config *Config, status reporter.Interface,
 
 	status.End()
 
-	gwDeployer, err := azure.NewOcpGatewayDeployer(cloudInfo, azureCloud, msDeployer, config.GWInstanceType, config.DedicatedGateway)
+	gwDeployer, err := azure.NewOcpGatewayDeployer(cloudInfo, azureCloud, msDeployer, config.GWInstanceType, true)
 	if err != nil {
 		return status.Error(err, "Failed to initialize a GatewayDeployer config")
 	}

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -39,14 +39,13 @@ import (
 )
 
 type Config struct {
-	DedicatedGateway bool
-	Gateways         int
-	InfraID          string
-	Region           string
-	ProjectID        string
-	CredentialsFile  string
-	OcpMetadataFile  string
-	GWInstanceType   string
+	Gateways        int
+	InfraID         string
+	Region          string
+	ProjectID       string
+	CredentialsFile string
+	OcpMetadataFile string
+	GWInstanceType  string
 }
 
 // RunOn runs the given function on GCP, supplying it with a cloud instance connected to GCP and a reporter that writes to CLI.
@@ -109,7 +108,7 @@ func RunOn(clusterInfo *cluster.Info, config *Config, status reporter.Interface,
 	msDeployer := ocp.NewK8sMachinesetDeployer(restMapper, dynamicClient)
 	// TODO: Ideally we should be able to specify the image for GWNode, but it was seen that
 	// with certain images, the instance is not coming up. Needs to be investigated further.
-	gwDeployer := gcp.NewOcpGatewayDeployer(gcpCloudInfo, msDeployer, config.GWInstanceType, "", config.DedicatedGateway, k8sClientSet)
+	gwDeployer := gcp.NewOcpGatewayDeployer(gcpCloudInfo, msDeployer, config.GWInstanceType, "", true, k8sClientSet)
 
 	return function(gcpCloud, gwDeployer, status)
 }

--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -34,14 +34,13 @@ import (
 )
 
 type Config struct {
-	DedicatedGateway bool
-	Gateways         int
-	InfraID          string
-	Region           string
-	ProjectID        string
-	OcpMetadataFile  string
-	CloudEntry       string
-	GWInstanceType   string
+	Gateways        int
+	InfraID         string
+	Region          string
+	ProjectID       string
+	OcpMetadataFile string
+	CloudEntry      string
+	GWInstanceType  string
 }
 
 // RunOn runs the given function on RHOS, supplying it with a cloud instance connected to RHOS and a reporter that writes to CLI.
@@ -101,8 +100,7 @@ func RunOn(clusterInfo *cluster.Info, config *Config, status reporter.Interface,
 	}
 	rhosCloud := rhos.NewCloud(cloudInfo)
 	msDeployer := ocp.NewK8sMachinesetDeployer(restMapper, dynamicClient)
-	gwDeployer := rhos.NewOcpGatewayDeployer(cloudInfo, msDeployer, config.ProjectID, config.GWInstanceType,
-		"", config.CloudEntry, config.DedicatedGateway)
+	gwDeployer := rhos.NewOcpGatewayDeployer(cloudInfo, msDeployer, config.ProjectID, config.GWInstanceType, "", config.CloudEntry, true)
 
 	return function(rhosCloud, gwDeployer, status)
 }


### PR DESCRIPTION
These were marked as deprecated in 0.15 to be removed in 0.16 although it wasn't done in 0.16.
