### PR TITLE
Automated backport of #1005: Correct the non_deploy flag used in upgrade command

### DIFF
--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -1,4 +1,4 @@
-//go:build !deploy
+//go:build !non_deploy
 
 /*
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Backport of #1005 on release-0.16.

#1005: Correct the non_deploy flag used in upgrade command

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.