### PR TITLE
Automated backport of #1052: Add Makefile.shipyard to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ vendor/
 .shflags
 junit.xml
 Makefile.dapper
+Makefile.shipyard
 /Dockerfile.*
 


### PR DESCRIPTION
Backport of #1052 on release-0.17.

#1052: Add Makefile.shipyard to .gitignore

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.