### PR TITLE
Omit Secret metadata from diff in validate_and_clean_broker_info

### DIFF
--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -135,7 +135,7 @@ function test_subctl_recover_broker_info() {
 
 function validate_and_clean_broker_info() {
   base64 -d broker-info.subm > decoded_broker_info.subm
-  if ! diff <(yq -P eval decoded_broker_info.subm) <(yq -P eval "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig); then
+  if ! diff <(yq -P eval 'del(.ClientToken.metadata)' decoded_broker_info.subm) <(yq -P eval 'del(.ClientToken.metadata)' "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig); then
     echo "Printing the original broker_info.subm file"
     yq -P eval "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig
     echo "Printing the recovered broker_info.subm file"


### PR DESCRIPTION
...to ignore potential updates to `resourceVersion` and other unimportant fields in the _broker.subm_ file.
