### PR TITLE
Fix linting errors with golangci-lint v1.57.1

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -44,7 +44,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.AWS( //nolint:wrapcheck // Not needed.
+					return prepare.AWS(
 						clusterInfo, &cloudOptions.ports, &awsConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
@@ -59,7 +59,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.AWS(clusterInfo, &awsConfig, status) //nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.AWS(clusterInfo, &awsConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -43,7 +43,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.Azure( //nolint:wrapcheck // Not needed.
+					return prepare.Azure(
 						clusterInfo, &cloudOptions.ports, &azureConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
@@ -58,7 +58,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.Azure(clusterInfo, &azureConfig, status) //nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.Azure(clusterInfo, &azureConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/diagnose.go
+++ b/cmd/subctl/diagnose.go
@@ -85,7 +85,7 @@ var (
 						return nil
 					}
 
-					return diagnose.Deployments(clusterInfo, ns, status) //nolint:wrapcheck // No need to wrap error here.
+					return diagnose.Deployments(clusterInfo, ns, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/export.go
+++ b/cmd/subctl/export.go
@@ -50,7 +50,7 @@ var (
 
 			exit.OnError(exportRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-					return service.Export(clusterInfo.ClientProducer, namespace, args[0], status) //nolint:wrapcheck // No need to wrap errors here.
+					return service.Export(clusterInfo.ClientProducer, namespace, args[0], status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/gather.go
+++ b/cmd/subctl/gather.go
@@ -54,7 +54,7 @@ var gatherCmd = &cobra.Command{
 
 		exit.OnError(gatherRestConfigProducer.RunOnAllContexts(
 			func(clusterInfo *cluster.Info, _ string, _ reporter.Interface) error {
-				return gather.Data(clusterInfo, options) //nolint:wrapcheck // No need to wrap errors here.
+				return gather.Data(clusterInfo, options)
 			}, status))
 	},
 }

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -46,7 +46,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.GCP( //nolint:wrapcheck // Not needed.
+					return prepare.GCP(
 						clusterInfo, &cloudOptions.ports, &gcpConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
@@ -60,7 +60,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.GCP(clusterInfo, &gcpConfig, status) //nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.GCP(clusterInfo, &gcpConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -242,7 +242,7 @@ func askForClusterID() (string, error) {
 				return nil
 			}
 
-			return cluster.IsValidID(str) //nolint:wrapcheck // No need to wrap
+			return cluster.IsValidID(str)
 		},
 	})
 

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -43,7 +43,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.RHOS( //nolint:wrapcheck // Not needed.
+					return prepare.RHOS(
 						clusterInfo, &cloudOptions.ports, &rhosConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
@@ -58,7 +58,7 @@ var (
 		Run: func(_ *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.RHOS(clusterInfo, &rhosConfig, status) //nolint:wrapcheck // No need to wrap errors here.
+					return cleanup.RHOS(clusterInfo, &rhosConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/unexport.go
+++ b/cmd/subctl/unexport.go
@@ -54,7 +54,7 @@ var (
 						return status.Error(err, "Error creating client")
 					}
 
-					return service.Unexport(mcsClient, namespace, args[0], status) //nolint:wrapcheck // No need to wrap errors here.
+					return service.Unexport(mcsClient, namespace, args[0], status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -229,7 +229,6 @@ func (np *Scheduled) awaitUntilScheduled() error {
 	return nil
 }
 
-//nolint:wrapcheck // No need to wrap errors here.
 func (np *Scheduled) AwaitCompletion() error {
 	pods := np.Config.ClientSet.CoreV1().Pods(np.Config.Namespace)
 

--- a/pkg/cloud/prepare/azure.go
+++ b/pkg/cloud/prepare/azure.go
@@ -36,7 +36,6 @@ func Azure(clusterInfo *cluster.Info, ports *cloud.Ports, config *azure.Config, 
 		return status.Error(err, "Failed to prepare the cloud")
 	}
 
-	//nolint:wrapcheck // No need to wrap errors here.
 	err = azure.RunOn(clusterInfo, config, status,
 		func(cloud api.Cloud, gwDeployer api.GatewayDeployer, status reporter.Interface) error {
 			if config.Gateways > 0 {

--- a/pkg/secret/ensure.go
+++ b/pkg/secret/ensure.go
@@ -30,7 +30,6 @@ import (
 )
 
 func Ensure(ctx context.Context, client kubernetes.Interface, namespace string, secret *v1.Secret) (*v1.Secret, error) {
-	//nolint:wrapcheck // No need to wrap errors here
 	object, err := util.CreateAnew[*v1.Secret](ctx, &resource.InterfaceFuncs[*v1.Secret]{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (*v1.Secret, error) {
 			return client.CoreV1().Secrets(namespace).Get(ctx, name, options)

--- a/pkg/uninstall/all.go
+++ b/pkg/uninstall/all.go
@@ -106,7 +106,6 @@ func unlabelGatewayNodes(clients client.Producer, clusterName string, status rep
 		return status.Error(err, "Error listing Nodes")
 	}
 
-	//nolint:wrapcheck // Let the caller wrap errors
 	nodeInterface := &resource.InterfaceFuncs[*corev1.Node]{
 		GetFunc: func(ctx context.Context, name string, options metav1.GetOptions) (*corev1.Node, error) {
 			return clients.ForKubernetes().CoreV1().Nodes().Get(ctx, name, options)


### PR DESCRIPTION
`wrapcheck` no longer flags anonymous functions.