### PR TITLE
Backport fixes to validate_and_clean_broker_info

### DIFF
--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -135,7 +135,7 @@ function test_subctl_recover_broker_info() {
 
 function validate_and_clean_broker_info() {
   base64 -d broker-info.subm > decoded_broker_info.subm
-  if ! diff <(yq -P eval decoded_broker_info.subm) <(yq -P eval "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig); then
+  if ! diff <(yq -P eval 'del(.ClientToken.metadata)' decoded_broker_info.subm) <(yq -P eval 'del(.ClientToken.metadata)' "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig); then
     echo "Printing the original broker_info.subm file"
     yq -P eval "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig
     echo "Printing the recovered broker_info.subm file"

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -137,9 +137,9 @@ function validate_and_clean_broker_info() {
   base64 -d broker-info.subm > decoded_broker_info.subm
   if ! diff <(yq -P eval decoded_broker_info.subm) <(yq -P eval "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig); then
     echo "Printing the original broker_info.subm file"
-    cat decoded_broker_info.subm.orig
+    yq -P eval "$DAPPER_SOURCE"/output/decoded_broker_info.subm.orig
     echo "Printing the recovered broker_info.subm file"
-    cat decoded_broker_info.subm
+    yq -P eval decoded_broker_info.subm
   fi
   rm -f broker-info.subm decoded_broker_info.subm
 }


### PR DESCRIPTION
Commits backported:

[Fix printing in validate_and_clean_broker_info](https://github.com/submariner-io/subctl/commit/b18f429298dcf0380a2d1c73f530e0520df42cce)
[Omit Secret metadata from diff in validate_and_clean_broker_info](https://github.com/submariner-io/subctl/commit/b19a87af24f90c238419a40edb7197d736ecdfa4)
