### PR TITLE
Add HTTP proxy args to subctl join, deploy-broker and upgrade commands

### DIFF
--- a/cmd/subctl/deploybroker.go
+++ b/cmd/subctl/deploybroker.go
@@ -61,6 +61,7 @@ var deployBroker = &cobra.Command{
 func init() {
 	addDeployBrokerFlags(deployBroker.Flags())
 	deployRestConfigProducer.SetupFlags(deployBroker.Flags())
+	addHTTPProxyFlags(deployBroker.Flags())
 	rootCmd.AddCommand(deployBroker)
 }
 
@@ -92,6 +93,7 @@ func addDeployBrokerFlags(flags *pflag.FlagSet) {
 
 func deployBrokerInContext(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
 	deployflags.BrokerNamespace = namespace
+	deployflags.HTTPProxyConfig = httpProxyConfig
 
 	if err := deploy.Broker(&deployflags, clusterInfo.ClientProducer, status); err != nil {
 		return err //nolint:wrapcheck // No need to wrap errors here.

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -114,6 +114,7 @@ func addJoinFlags(cmd *cobra.Command) {
 	addAirGappedFlag(cmd, &joinFlags.AirGappedDeployment)
 	addLoadBalancerFlag(cmd, &joinFlags.LoadBalancerEnabled)
 	addImageOverrideFlag(cmd.Flags())
+	addHTTPProxyFlags(cmd.Flags())
 
 	cmd.Flags().BoolVar(&joinFlags.ForceUDPEncaps, "force-udp-encaps", false, "force UDP encapsulation for IPSec")
 
@@ -152,6 +153,7 @@ func joinInContext(brokerInfo *broker.Info, clusterInfo *cluster.Info, status re
 	determineClusterID(clusterInfo.Name, status)
 
 	joinFlags.ImageOverrideArr = imageOverrides
+	joinFlags.HTTPProxyConfig = httpProxyConfig
 
 	ctx := context.TODO()
 	networkDetails := getNetworkDetails(ctx, clusterInfo.ClientProducer, status)

--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -33,6 +33,7 @@ import (
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarineropv1a1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	"golang.org/x/net/http/httpproxy"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -86,6 +87,18 @@ func addImageOverrideFlag(flags *pflag.FlagSet) {
 func checkImageOverrides(_ *cobra.Command, _ []string) error {
 	_, err := cluster.MergeImageOverrides(make(map[string]string), imageOverrides)
 	return err
+}
+
+var httpProxyConfig httpproxy.Config
+
+func addHTTPProxyFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&httpProxyConfig.HTTPProxy, "http-proxy", "",
+		"Proxy URL to use for HTTP requests. Corresponds to the HTTP_PROXY environment variable.")
+	flags.StringVar(&httpProxyConfig.HTTPSProxy, "https-proxy", "",
+		"Proxy URL to use for HTTPS requests. Corresponds to the HTTPS_PROXY environment variable.")
+	flags.StringVar(&httpProxyConfig.NoProxy, "no-proxy", "",
+		"Comma-separated string specifying hosts that should be excluded from HTTP proxying. "+
+			"Corresponds to the NO_PROXY environment variable.")
 }
 
 func setupTestFrameworkBeforeSuite() {

--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -66,6 +66,7 @@ func init() {
 	upgradeCmd.Flags().StringVar(&upgradeSubmarinerVersion, "to-submariner-version", "", "the version of Submariner to which to upgrade")
 	_ = upgradeCmd.Flags().MarkHidden("to-submariner-version")
 	upgradeRestConfigProducer.SetupFlags(upgradeCmd.Flags())
+	addHTTPProxyFlags(upgradeCmd.Flags())
 	rootCmd.AddCommand(upgradeCmd)
 }
 
@@ -244,6 +245,7 @@ func upgradeBroker(ctx context.Context, clusterInfo *cluster.Info, status report
 		ImageVersion:    upgradeOperatorVersion,
 		BrokerNamespace: brokerObj.Namespace,
 		BrokerSpec:      brokerObj.Spec,
+		HTTPProxyConfig: httpProxyConfig,
 	}
 
 	err = deploy.Deploy(ctx, options, status, clusterInfo.ClientProducer)
@@ -271,8 +273,8 @@ func upgradeOperator(ctx context.Context, clusterInfo *cluster.Info, repository 
 
 	repositoryInfo := image.NewRepositoryInfo(repository, upgradeOperatorVersion, imageOverride)
 
-	err = operator.Ensure(
-		ctx, status, clusterInfo.ClientProducer, constants.OperatorNamespace, repositoryInfo.GetOperatorImage(), debug)
+	err = operator.Ensure(ctx, status, clusterInfo.ClientProducer, constants.OperatorNamespace, repositoryInfo.GetOperatorImage(), debug,
+		&httpProxyConfig)
 
 	return status.Error(err, "Error upgrading the Operator")
 }

--- a/pkg/deploy/broker.go
+++ b/pkg/deploy/broker.go
@@ -33,6 +33,7 @@ import (
 	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
+	"golang.org/x/net/http/httpproxy"
 	"k8s.io/utils/set"
 )
 
@@ -43,6 +44,7 @@ type BrokerOptions struct {
 	BrokerNamespace string
 	BrokerURL       string
 	BrokerSpec      operatorv1alpha1.BrokerSpec
+	HTTPProxyConfig httpproxy.Config
 }
 
 var ValidComponents = []string{component.ServiceDiscovery, component.Connectivity}
@@ -97,8 +99,8 @@ func Deploy(ctx context.Context, options *BrokerOptions, status reporter.Interfa
 
 	repositoryInfo := image.NewRepositoryInfo(options.Repository, options.ImageVersion, nil)
 
-	err = operator.Ensure(
-		ctx, status, clientProducer, constants.OperatorNamespace, repositoryInfo.GetOperatorImage(), options.OperatorDebug)
+	err = operator.Ensure(ctx, status, clientProducer, constants.OperatorNamespace, repositoryInfo.GetOperatorImage(),
+		options.OperatorDebug, &options.HTTPProxyConfig)
 	if err != nil {
 		return status.Error(err, "error deploying Submariner operator")
 	}

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -102,7 +102,8 @@ func ClusterToBroker(ctx context.Context, brokerInfo *broker.Info, options *Opti
 
 	repositoryInfo := image.NewRepositoryInfo(options.Repository, options.ImageVersion, imageOverrides)
 
-	err = operator.Ensure(ctx, status, clientProducer, operatorNamespace, repositoryInfo.GetOperatorImage(), options.OperatorDebug)
+	err = operator.Ensure(ctx, status, clientProducer, operatorNamespace, repositoryInfo.GetOperatorImage(), options.OperatorDebug,
+		&options.HTTPProxyConfig)
 	if err != nil {
 		return status.Error(err, "Error deploying the operator")
 	}

--- a/pkg/join/options.go
+++ b/pkg/join/options.go
@@ -18,6 +18,8 @@ limitations under the License.
 
 package join
 
+import "golang.org/x/net/http/httpproxy"
+
 type Options struct {
 	PreferredServer               bool
 	ForceUDPEncaps                bool
@@ -46,4 +48,5 @@ type Options struct {
 	BrokerURL                     string
 	CustomDomains                 []string
 	ImageOverrideArr              []string
+	HTTPProxyConfig               httpproxy.Config
 }

--- a/pkg/operator/ensure.go
+++ b/pkg/operator/ensure.go
@@ -32,11 +32,12 @@ import (
 	"github.com/submariner-io/submariner-operator/pkg/crd"
 	"github.com/submariner-io/submariner-operator/pkg/embeddedyamls"
 	"golang.org/x/net/context"
+	"golang.org/x/net/http/httpproxy"
 )
 
 //nolint:wrapcheck // No need to wrap errors here.
-func Ensure(ctx context.Context,
-	status reporter.Interface, clientProducer client.Producer, operatorNamespace, operatorImage string, debug bool,
+func Ensure(ctx context.Context, status reporter.Interface, clientProducer client.Producer, operatorNamespace, operatorImage string,
+	debug bool, proxyConfig *httpproxy.Config,
 ) error {
 	if created, err := opcrds.Ensure(ctx, crd.UpdaterFromControllerClient(clientProducer.ForGeneral())); err != nil {
 		return err
@@ -83,7 +84,8 @@ func Ensure(ctx context.Context,
 		return err
 	}
 
-	if created, err := deployment.Ensure(ctx, clientProducer.ForKubernetes(), operatorNamespace, operatorImage, debug); err != nil {
+	if created, err := deployment.Ensure(ctx, clientProducer.ForKubernetes(), operatorNamespace, operatorImage, debug,
+		proxyConfig); err != nil {
 		return err
 	} else if created {
 		status.Success("Deployed the operator successfully")


### PR DESCRIPTION
...and propagate to the operator pod env.

See discussion [here](https://github.com/submariner-io/submariner-operator/pull/3013#issuecomment-2035366304) for more context.
