### PR TITLE
Set the operator up with enforced secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.18.0-m3
 	github.com/submariner-io/shipyard v0.18.0-m3
 	github.com/submariner-io/submariner v0.18.0-m3
-	github.com/submariner-io/submariner-operator v0.18.0-m3.0.20240507123154-22f72647baf5
+	github.com/submariner-io/submariner-operator v0.18.0-m3.0.20240516153438-6117e1c64a89
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.25.0
 	golang.org/x/oauth2 v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/submariner-io/shipyard v0.18.0-m3 h1:N0/BAwTv5p6O7PgvQeouUzcgybJtq7QQ
 github.com/submariner-io/shipyard v0.18.0-m3/go.mod h1:qs1LOCrPfM6H3JzR8TWNXFW4hvBiY+8gJ6OOjF4o4E0=
 github.com/submariner-io/submariner v0.18.0-m3 h1:IVpsPwFHLc1AK4/Ga8GtgdXVxnu3w7SfmoEgprmrcOw=
 github.com/submariner-io/submariner v0.18.0-m3/go.mod h1:tvUTVjiY98DavqZODJtP8Qu5ubyrsR9ej8kahSCY8G8=
-github.com/submariner-io/submariner-operator v0.18.0-m3.0.20240507123154-22f72647baf5 h1:b95vo3VsbKgyxc3nHDCGZl7ifleK7GSyjmooxYxfCJQ=
-github.com/submariner-io/submariner-operator v0.18.0-m3.0.20240507123154-22f72647baf5/go.mod h1:JIxqSFy3BCA12tTi3rfO5BfYfpUq0dx/PHv/KR7ypUo=
+github.com/submariner-io/submariner-operator v0.18.0-m3.0.20240516153438-6117e1c64a89 h1:fSgHwb2vd+7X4PoVJSXDHfC3oEEgA3HeZVPldqtZCPc=
+github.com/submariner-io/submariner-operator v0.18.0-m3.0.20240516153438-6117e1c64a89/go.mod h1:9vo1bFNhNOpyd/+qjbW2MhQBA33jk9ZPHK7uFZC8zm0=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -210,7 +210,7 @@ func populateBrokerSecret(brokerInfo *broker.Info) *v1.Secret {
 	// We need to copy the broker token secret as an opaque secret to store it in the connecting cluster
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "broker-secret-",
+			Name: "submariner-broker-secret",
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: brokerInfo.ClientToken.Data,

--- a/pkg/serviceaccount/ensure.go
+++ b/pkg/serviceaccount/ensure.go
@@ -43,11 +43,7 @@ const (
 )
 
 func ensure(ctx context.Context, kubeClient kubernetes.Interface, namespace string, sa *corev1.ServiceAccount) (bool, error) {
-	result, err := util.CreateOrUpdate(ctx, resource.ForServiceAccount(kubeClient, namespace), sa,
-		func(existing *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			existing.Secrets = nil
-			return existing, nil
-		})
+	result, err := util.CreateOrUpdate(ctx, resource.ForServiceAccount(kubeClient, namespace), sa, util.Replace(sa))
 
 	return result == util.OperationResultCreated, errors.Wrapf(err, "error creating or updating ServiceAccount %q", sa.Name)
 }


### PR DESCRIPTION
To prevent arbitrary secret access using compromised SAs, the SAs created by Submariner are now configured to enforce mountable secrets. This requires that accessible secrets be listed explicitly in the SA. To make this simple, use a static name for the broker secret. To allow secrets to be configured, leave them alone when creating or updating the SAs.

Depends on https://github.com/submariner-io/submariner-operator/pull/3064
Depends on https://github.com/submariner-io/submariner-operator/pull/3067

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
