### PR TITLE
Automated backport of #1128: Set the operator up with enforced secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.17.2
 	github.com/submariner-io/shipyard v0.17.2
 	github.com/submariner-io/submariner v0.17.2
-	github.com/submariner-io/submariner-operator v0.17.2
+	github.com/submariner-io/submariner-operator v0.17.3-0.20240709140014-b957cc9ca3c3
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.23.0
 	golang.org/x/oauth2 v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,8 @@ github.com/submariner-io/shipyard v0.17.2 h1:+ev89enbv98uP6BgrIRyVoyXYqOD/+9o49E
 github.com/submariner-io/shipyard v0.17.2/go.mod h1:Mrp0LPXBXYpbjMwhqq89G86Xgjz+U4vZM9Qg+F1ZBQw=
 github.com/submariner-io/submariner v0.17.2 h1:6kyT5cJk+4+PzBxcsCbd5sFtkdxE34j/uHMaQCKqUtA=
 github.com/submariner-io/submariner v0.17.2/go.mod h1:zbM5q83U7gkuty+fTJm7Dj1/lzfR4bBgKwQIPn0bY88=
-github.com/submariner-io/submariner-operator v0.17.2 h1:7bG8swDCQBmL6bkxZK9GtR7qvGfC76/1wZgO7SNtIxU=
-github.com/submariner-io/submariner-operator v0.17.2/go.mod h1:PoSGGrq810UdJwNmQC5LswOZ82zR7nMvoTOF5ZzZZqg=
+github.com/submariner-io/submariner-operator v0.17.3-0.20240709140014-b957cc9ca3c3 h1:zeC3KgkAEst9vR6ng+VlEiHoqxq9fzMoKaKwL/ApNrE=
+github.com/submariner-io/submariner-operator v0.17.3-0.20240709140014-b957cc9ca3c3/go.mod h1:PoSGGrq810UdJwNmQC5LswOZ82zR7nMvoTOF5ZzZZqg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -209,7 +209,7 @@ func populateBrokerSecret(brokerInfo *broker.Info) *v1.Secret {
 	// We need to copy the broker token secret as an opaque secret to store it in the connecting cluster
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "broker-secret-",
+			Name: "submariner-broker-secret",
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: brokerInfo.ClientToken.Data,

--- a/pkg/serviceaccount/ensure.go
+++ b/pkg/serviceaccount/ensure.go
@@ -43,11 +43,7 @@ const (
 )
 
 func ensure(ctx context.Context, kubeClient kubernetes.Interface, namespace string, sa *corev1.ServiceAccount) (bool, error) {
-	result, err := util.CreateOrUpdate(ctx, resource.ForServiceAccount(kubeClient, namespace), sa,
-		func(existing *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			existing.Secrets = nil
-			return existing, nil
-		})
+	result, err := util.CreateOrUpdate(ctx, resource.ForServiceAccount(kubeClient, namespace), sa, util.Replace(sa))
 
 	return result == util.OperationResultCreated, errors.Wrapf(err, "error creating or updating ServiceAccount %q", sa.Name)
 }


### PR DESCRIPTION
Backport of #1128 on release-0.17.

#1128: Set the operator up with enforced secrets

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on https://github.com/submariner-io/submariner-operator/pull/3143