### PR TITLE
Automated backport of #1128: Set the operator up with enforced secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.16.7
 	github.com/submariner-io/shipyard v0.16.7
 	github.com/submariner-io/submariner v0.16.7
-	github.com/submariner-io/submariner-operator v0.16.7
+	github.com/submariner-io/submariner-operator v0.16.8-0.20240709144215-1b44b4f78f1f
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.23.0
 	golang.org/x/oauth2 v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -556,8 +556,8 @@ github.com/submariner-io/shipyard v0.16.7 h1:lqUHMS8TW9rNMC1I982imguPpiZnaA/89OY
 github.com/submariner-io/shipyard v0.16.7/go.mod h1:ZsUnkTPsq7SbgU4gCSefTgh0znuxKm8VGMo4SP8VVT0=
 github.com/submariner-io/submariner v0.16.7 h1:Yr1z6hUL3I3RPLoCYa9D8MAitVZbTsgY/UJza+Xl1hU=
 github.com/submariner-io/submariner v0.16.7/go.mod h1:SFFP6TkoeicKPGQAzqE+bPWdHzpbT7fmobIQTsH5IlA=
-github.com/submariner-io/submariner-operator v0.16.7 h1:reNbq+lDJwapMgQh8kHHVm7h9wgRiZcIN40v7CBH64Q=
-github.com/submariner-io/submariner-operator v0.16.7/go.mod h1:ejDiB05XW7R93sww9IGYQ3FQDg/bU3dcsz7ek05sQkg=
+github.com/submariner-io/submariner-operator v0.16.8-0.20240709144215-1b44b4f78f1f h1:BuoMWV356zbXNXdslC3tskhoUH2+Awwh9SsKKY5IdOM=
+github.com/submariner-io/submariner-operator v0.16.8-0.20240709144215-1b44b4f78f1f/go.mod h1:ejDiB05XW7R93sww9IGYQ3FQDg/bU3dcsz7ek05sQkg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -198,7 +198,7 @@ func populateBrokerSecret(brokerInfo *broker.Info) *v1.Secret {
 	// We need to copy the broker token secret as an opaque secret to store it in the connecting cluster
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "broker-secret-",
+			Name: "submariner-broker-secret",
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: brokerInfo.ClientToken.Data,

--- a/pkg/serviceaccount/ensure.go
+++ b/pkg/serviceaccount/ensure.go
@@ -32,7 +32,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -44,11 +43,7 @@ const (
 )
 
 func ensure(ctx context.Context, kubeClient kubernetes.Interface, namespace string, sa *corev1.ServiceAccount) (bool, error) {
-	result, err := util.CreateOrUpdate(ctx, resource.ForServiceAccount(kubeClient, namespace), sa,
-		func(existing runtime.Object) (runtime.Object, error) {
-			existing.(*corev1.ServiceAccount).Secrets = nil
-			return existing, nil
-		})
+	result, err := util.CreateOrUpdate(ctx, resource.ForServiceAccount(kubeClient, namespace), sa, util.Replace(sa))
 
 	return result == util.OperationResultCreated, errors.Wrapf(err, "error creating or updating ServiceAccount %q", sa.Name)
 }


### PR DESCRIPTION
Backport of #1128 on release-0.16.

#1128: Set the operator up with enforced secrets

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on https://github.com/submariner-io/submariner-operator/pull/3144