### PR TITLE
Automated backport of #1150: Migrate the broker secret on upgrade to 0.18

### DIFF
--- a/pkg/broker/rbac.go
+++ b/pkg/broker/rbac.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	LocalClientBrokerSecretName = "submariner-broker-secret"
 	submarinerBrokerClusterRole = "submariner-k8s-broker-cluster"
 )
 

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -198,7 +198,7 @@ func populateBrokerSecret(brokerInfo *broker.Info) *v1.Secret {
 	// We need to copy the broker token secret as an opaque secret to store it in the connecting cluster
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "submariner-broker-secret",
+			Name: broker.LocalClientBrokerSecretName,
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: brokerInfo.ClientToken.Data,


### PR DESCRIPTION
Backport of #1150 on release-0.16.

#1150: Migrate the broker secret on upgrade to 0.18

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.