### PR TITLE
Add iptables mangle table to subctl gather

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -49,8 +49,9 @@ var ipGatewayCmds = map[string]string{
 }
 
 var ipTablesCmds = map[string]string{
-	"iptables":     "iptables -L -n -v --line-numbers",
-	"iptables-nat": "iptables -L -n -v --line-numbers -t nat",
+	"iptables":        "iptables -L -n -v --line-numbers",
+	"iptables-nat":    "iptables -L -n -v --line-numbers -t nat",
+	"iptables-mangle": "iptables -L -n -v --line-numbers -t mangle",
 }
 
 var libreswanCmds = map[string]string{


### PR DESCRIPTION
Submariner adds rules to the mangle iptables table for clamping TCP MSS on all nodes.

Fixes: https://github.com/submariner-io/subctl/issues/36

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
