### PR TITLE
Avoid formatting functions with pre-calculated messages

### DIFF
--- a/internal/pods/schedule.go
+++ b/internal/pods/schedule.go
@@ -248,7 +248,7 @@ func (np *Scheduled) AwaitCompletion() error {
 			}
 		})
 	if err != nil {
-		return errors.Wrapf(err, errorMsg)
+		return errors.Wrap(err, errorMsg)
 	}
 
 	finished := np.Pod.Status.Phase == v1.PodSucceeded || np.Pod.Status.Phase == v1.PodFailed


### PR DESCRIPTION
This was caught by golangci-lint 1.60.1.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
