### PR TITLE
Automated backport of #1204: Add iptables mangle table to subctl gather

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -49,8 +49,9 @@ var ipGatewayCmds = map[string]string{
 }
 
 var ipTablesCmds = map[string]string{
-	"iptables":     "iptables -L -n -v --line-numbers",
-	"iptables-nat": "iptables -L -n -v --line-numbers -t nat",
+	"iptables":        "iptables -L -n -v --line-numbers",
+	"iptables-nat":    "iptables -L -n -v --line-numbers -t nat",
+	"iptables-mangle": "iptables -L -n -v --line-numbers -t mangle",
 }
 
 var libreswanCmds = map[string]string{


### PR DESCRIPTION
Backport of #1204 on release-0.17.

#1204: Add iptables mangle table to subctl gather

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.