### PR TITLE
Use cobra's version flag support

### DIFF
--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/subctl/internal/exit"
 	"github.com/submariner-io/subctl/pkg/cluster"
+	"github.com/submariner-io/subctl/pkg/version"
 	submarineropv1a1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"golang.org/x/net/http/httpproxy"
@@ -64,8 +65,9 @@ func init() {
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:   filepath.Base(os.Args[0]),
-	Short: "Deploy, manage, verify and diagnose Submariner deployments",
+	Use:     filepath.Base(os.Args[0]),
+	Short:   "Deploy, manage, verify and diagnose Submariner deployments",
+	Version: version.Version,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Assigning a value to the Version field in the root cobra command automatically defines a --version flag which displays the command name and version, in much the same way as "subctl version" does already. This provides version information in a fashion aligned with common practice.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
