### PR TITLE
Automated backport of #1230: Add custom vpc support in AWS cloud prepare

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -73,6 +73,15 @@ func init() {
 			"OCP metadata.json file (or directory containing it) to read AWS infra ID and region from (Takes precedence over the flags)")
 		command.Flags().StringVar(&awsConfig.Profile, "profile", cpaws.DefaultProfile(), "AWS profile to use for credentials")
 		command.Flags().StringVar(&awsConfig.CredentialsFile, "credentials", cpaws.DefaultCredentialsFile(), "AWS credentials configuration file")
+
+		command.Flags().StringVar(&awsConfig.ControlPlaneSecurityGroup, "control-plane-security-group", "",
+			"Custom AWS control plane security group name if the default is not used while provisioning")
+		command.Flags().StringVar(&awsConfig.WorkerSecurityGroup, "worker-security-group", "",
+			"Custom AWS worker security group name if the default is not used while provisioning")
+		command.Flags().StringVar(&awsConfig.VpcName, "vpc-name", "",
+			"Custom AWS VPC name if the default is not used while provisioning")
+		command.Flags().StringSliceVar(&awsConfig.SubnetNames, "subnet-names", nil,
+			"Custom AWS subnet names if the default is not used while provisioning (comma-separated list)")
 	}
 
 	addGeneralAWSFlags(awsPrepareCmd)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/admiral v0.16.7
-	github.com/submariner-io/cloud-prepare v0.16.7
+	github.com/submariner-io/cloud-prepare v0.16.8-0.20240926143602-f935ffc6c0e6
 	github.com/submariner-io/lighthouse v0.16.7
 	github.com/submariner-io/shipyard v0.16.7
 	github.com/submariner-io/submariner v0.16.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/submariner-io/admiral v0.16.7 h1:0eHCL+JG9fEo1RF++rBvyEuK2ysqIxOwZe92TxO5J+M=
 github.com/submariner-io/admiral v0.16.7/go.mod h1:sM2hFFQGX6cxWSVYbobTUAAfd+FrTUrqTQhPger/FxA=
-github.com/submariner-io/cloud-prepare v0.16.7 h1:so7Wv3mj+cOHaEup+Y+/HPuxWsbPa5v5soKOLC3X3Xc=
-github.com/submariner-io/cloud-prepare v0.16.7/go.mod h1:l7DesWX73bkDmQG0rb1HhkwQP9d716EeKazJaZvLDhc=
+github.com/submariner-io/cloud-prepare v0.16.8-0.20240926143602-f935ffc6c0e6 h1:jZdt3ypJBLZQObYAi+Nr6+CavROCLOUTSH9OhsxGH4g=
+github.com/submariner-io/cloud-prepare v0.16.8-0.20240926143602-f935ffc6c0e6/go.mod h1:l7DesWX73bkDmQG0rb1HhkwQP9d716EeKazJaZvLDhc=
 github.com/submariner-io/lighthouse v0.16.7 h1:3p66P9n+d7n7jUNxuy5cyjBsjLdVs8JIvsQ5vL/7B3I=
 github.com/submariner-io/lighthouse v0.16.7/go.mod h1:Ck3/wmD+2Xgqa1SptAhlM0YVyxhbKqCu0S5Skye3MFY=
 github.com/submariner-io/shipyard v0.16.7 h1:lqUHMS8TW9rNMC1I982imguPpiZnaA/89OYbGntskYo=


### PR DESCRIPTION
Backport of #1230 on release-0.16.

#1230: Add custom vpc support in AWS cloud prepare

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.