### PR TITLE
Automated backport of #1230: Add custom vpc support in AWS cloud prepare

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -73,6 +73,15 @@ func init() {
 			"OCP metadata.json file (or directory containing it) to read AWS infra ID and region from (Takes precedence over the flags)")
 		command.Flags().StringVar(&awsConfig.Profile, "profile", cpaws.DefaultProfile(), "AWS profile to use for credentials")
 		command.Flags().StringVar(&awsConfig.CredentialsFile, "credentials", cpaws.DefaultCredentialsFile(), "AWS credentials configuration file")
+
+		command.Flags().StringVar(&awsConfig.ControlPlaneSecurityGroup, "control-plane-security-group", "",
+			"Custom AWS control plane security group name if the default is not used while provisioning")
+		command.Flags().StringVar(&awsConfig.WorkerSecurityGroup, "worker-security-group", "",
+			"Custom AWS worker security group name if the default is not used while provisioning")
+		command.Flags().StringVar(&awsConfig.VpcName, "vpc-name", "",
+			"Custom AWS VPC name if the default is not used while provisioning")
+		command.Flags().StringSliceVar(&awsConfig.SubnetNames, "subnet-names", nil,
+			"Custom AWS subnet names if the default is not used while provisioning (comma-separated list)")
 	}
 
 	addGeneralAWSFlags(awsPrepareCmd)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/submariner-io/admiral v0.18.0
-	github.com/submariner-io/cloud-prepare v0.18.0
+	github.com/submariner-io/cloud-prepare v0.18.1-0.20240926141430-b73b84732e47
 	github.com/submariner-io/lighthouse v0.18.0
 	github.com/submariner-io/shipyard v0.18.0
 	github.com/submariner-io/submariner v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ github.com/submariner-io/admiral v0.18.0 h1:f8+owedukeKjwNazwmQScJjP3wXkEB+FqEJQ
 github.com/submariner-io/admiral v0.18.0/go.mod h1:Xy24HCHRsq+LUSyuQh0pLgKFpAFyPhuzcPRUyUlL30s=
 github.com/submariner-io/cloud-prepare v0.18.0 h1:o9w6xKwzU0mhZrVGoaw0GXsvr/5f6P6c14DnNVLspJI=
 github.com/submariner-io/cloud-prepare v0.18.0/go.mod h1:zxzSHoJpLH5C0rZV8tqxAIyJ27iS21VMJvc06RBzzVw=
+github.com/submariner-io/cloud-prepare v0.18.1-0.20240926141430-b73b84732e47 h1:H+zFPcfvihetBc00wWCsNSi9MAXDfZxCZJ0ajUnnCF0=
+github.com/submariner-io/cloud-prepare v0.18.1-0.20240926141430-b73b84732e47/go.mod h1:zxzSHoJpLH5C0rZV8tqxAIyJ27iS21VMJvc06RBzzVw=
 github.com/submariner-io/lighthouse v0.18.0 h1:5hWXQBDduJqY+reheP24Ue7HPedVoWaIJjVn5OMEXkU=
 github.com/submariner-io/lighthouse v0.18.0/go.mod h1:xkvjJT46XvR77HMw2srnytWJEMGyfP4lDPC5oNtuqho=
 github.com/submariner-io/shipyard v0.18.0 h1:bBvqho5UtEplMhyxX2YhEC4DzjrfWTqF8KOGblaDJJw=


### PR DESCRIPTION
Backport of #1230 on release-0.18.

#1230: Add custom vpc support in AWS cloud prepare

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on https://github.com/submariner-io/cloud-prepare/pull/1010