### PR TITLE
Use global clusterset IP enabled flag on join

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.19.0-m3.0.20240925124717-3989a7b0bc55
 	github.com/submariner-io/shipyard v0.19.0-m3
 	github.com/submariner-io/submariner v0.19.0-m3.0.20240917155703-5a6c358065a2
-	github.com/submariner-io/submariner-operator v0.19.0-m3.0.20240923150922-268a9960c6b7
+	github.com/submariner-io/submariner-operator v0.19.0-m3.0.20240930101644-70b24123471c
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.29.0
 	golang.org/x/oauth2 v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -524,8 +524,8 @@ github.com/submariner-io/shipyard v0.19.0-m3 h1:NliwAktRPF4OsLj1TDgpaOJD/bmmZW/F
 github.com/submariner-io/shipyard v0.19.0-m3/go.mod h1:BY1ceSnPz1/hN5F9uljcSzy5n5qgAOENsIvZpJ+XPOU=
 github.com/submariner-io/submariner v0.19.0-m3.0.20240917155703-5a6c358065a2 h1:SffTAy7zUR6fOr41EIGccVZHRNuExA78b7lLr84qizg=
 github.com/submariner-io/submariner v0.19.0-m3.0.20240917155703-5a6c358065a2/go.mod h1:hKbs5L9QPDslJ6n4k3fsPRbr7JbpT5AVr58YgWQQCKQ=
-github.com/submariner-io/submariner-operator v0.19.0-m3.0.20240923150922-268a9960c6b7 h1:grcgOt7T/fStYdOOK/E+cmAm/dm59KNxOm5kc0fpYrQ=
-github.com/submariner-io/submariner-operator v0.19.0-m3.0.20240923150922-268a9960c6b7/go.mod h1:OAbOn8vkkVtrGKTQ92aT7HNtAxCH5wHhPjb2t/8qKVM=
+github.com/submariner-io/submariner-operator v0.19.0-m3.0.20240930101644-70b24123471c h1:KDAbom91VmgVKYJM8OiTl9aKXxaDFqx5SkPIkZUZ3VI=
+github.com/submariner-io/submariner-operator v0.19.0-m3.0.20240930101644-70b24123471c/go.mod h1:OAbOn8vkkVtrGKTQ92aT7HNtAxCH5wHhPjb2t/8qKVM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -105,10 +105,14 @@ func ClusterToBroker(ctx context.Context, brokerInfo *broker.Info, options *Opti
 	}
 
 	if brokerInfo.IsServiceDiscoveryEnabled() {
-		err = clustersetip.AllocateCIDRFromConfigMap(ctx, brokerClientProducer.ForGeneral(), brokerNamespace,
+		enabled, err := clustersetip.AllocateCIDRFromConfigMap(ctx, brokerClientProducer.ForGeneral(), brokerNamespace,
 			&clustersetConfig, status)
 		if err != nil {
 			return errors.Wrap(err, "unable to determine the clusterset IP CIDR")
+		}
+
+		if enabled {
+			options.EnableClustersetIP = enabled
 		}
 	}
 


### PR DESCRIPTION
Use the enabled flag return from `clustersetip.AllocateCIDRFromConfigMap` to set the `Submariner.ClustersetIPEnabled` flag.

Depends on https://github.com/submariner-io/submariner-operator/pull/3234
