### PR TITLE
Automated backport of #1267: Output init containers in subctl gather

### DIFF
--- a/internal/gather/connectivity.go
+++ b/internal/gather/connectivity.go
@@ -40,10 +40,10 @@ func gatherGatewayPodLogs(info *Info) {
 }
 
 func gatherMetricsProxyPodLogs(info *Info) {
-	gatherPodLogsByContainer(metricsProxyPodLabel, "gateway-metrics-proxy", info)
+	gatherPodLogs(metricsProxyPodLabel, info, "gateway-metrics-proxy")
 
 	if info.Submariner.Spec.GlobalCIDR != "" {
-		gatherPodLogsByContainer(metricsProxyPodLabel, "globalnet-metrics-proxy", info)
+		gatherPodLogs(metricsProxyPodLabel, info, "globalnet-metrics-proxy")
 	}
 }
 

--- a/internal/gather/resource.go
+++ b/internal/gather/resource.go
@@ -97,11 +97,13 @@ func ResourcesToYAMLFile(info *Info, ofType schema.GroupVersionResource, namespa
 //nolint:gocritic // hugeParam: listOptions - match K8s API.
 func gatherDaemonSet(info *Info, namespace string, listOptions metav1.ListOptions) {
 	ResourcesToYAMLFile(info, appsv1.SchemeGroupVersion.WithResource("daemonsets"), namespace, listOptions)
+	ResourcesToYAMLFile(info, corev1.SchemeGroupVersion.WithResource("pods"), namespace, listOptions)
 }
 
 //nolint:gocritic // hugeParam: listOptions - match K8s API.
 func gatherDeployment(info *Info, namespace string, listOptions metav1.ListOptions) {
 	ResourcesToYAMLFile(info, appsv1.SchemeGroupVersion.WithResource("deployments"), namespace, listOptions)
+	ResourcesToYAMLFile(info, corev1.SchemeGroupVersion.WithResource("pods"), namespace, listOptions)
 }
 
 //nolint:gocritic // hugeParam: listOptions - match K8s API.

--- a/internal/gather/servicediscovery.go
+++ b/internal/gather/servicediscovery.go
@@ -42,7 +42,7 @@ func gatherServiceDiscoveryPodLogs(info *Info) {
 
 func gatherCoreDNSPodLogs(info *Info) {
 	if isCoreDNSTypeOcp(info) {
-		gatherPodLogsByContainer(ocpCoreDNSPodLabel, "dns", info)
+		gatherPodLogs(ocpCoreDNSPodLabel, info, "dns")
 	} else {
 		gatherPodLogs(k8sCoreDNSPodLabel, info)
 	}

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -44,7 +44,7 @@ function test_subctl_gather() {
     _subctl gather --dir "$gather_out_dir"
 
     echo "::group::Validating 'subctl gather'"
-    ls $gather_out_dir
+    ls -R $gather_out_dir
 
     for cluster in "${clusters[@]}"; do
         with_context "${cluster}" validate_gathered_files


### PR DESCRIPTION
Backport of #1267 on release-0.19.

#1267: Output init containers in subctl gather

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.