### PR TITLE
Migrate to golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,63 +1,86 @@
 ---
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: github.com/mcuadros/go-version
-            desc: Use coreos/go-semver instead
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - ifElseChain
-      - unnamedResult
-  gocyclo:
-    min-complexity: 15
-  godot:
-    exclude:
-      - ^\s*\+
-  goheader:
-    template: |-
-      SPDX-License-Identifier: Apache-2.0
-
-      Copyright Contributors to the Submariner project.
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-  govet:
-    enable:
-      - fieldalignment
-  lll:
-    line-length: 140
-  wrapcheck:
-    ignoreSigs:
-      - .Error(
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
-  wsl:
-    # Separating explicit var declarations by blank lines seems excessive.
-    allow-cuddle-declarations: true
+version: "2"
 linters:
-  disable-all: true
+  default: none
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/mcuadros/go-version
+              desc: Use coreos/go-semver instead
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - unnamedResult
+      enabled-tags:
+        - diagnostic
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    godot:
+      exclude:
+        - ^\s*\+
+    goheader:
+      template: |-
+        SPDX-License-Identifier: Apache-2.0
+
+        Copyright Contributors to the Submariner project.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    govet:
+      enable:
+        - fieldalignment
+    lll:
+      line-length: 140
+    revive:
+      rules:
+        - name: dot-imports
+          arguments:
+            - allowed-packages: ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"]
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+      checks:
+        # Defaults
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        # Allow if/else constructs that could be switches
+        - -QF1003
+        # Allow unnecessary embedded field selectors
+        - -QF1008
+    wrapcheck:
+      ignore-sigs:
+        - .Error(
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+    wsl:
+      # Separating explicit var declarations by blank lines seems excessive.
+      allow-cuddle-declarations: true
   enable:
     - asasalint
     - asciicheck
@@ -77,18 +100,18 @@ linters:
     - err113
     - errcheck
     - errchkjson
-    - errorlint
     - errname
+    - errorlint
     - exhaustive
-    - exptostd
     # - exhaustruct # This is too cumbersome as it requires all string, int, pointer et al fields to be initialized even when the
     #   type's default suffices, which is most of the time
+    - exptostd
     - fatcontext
     # - forbidigo # We don't forbid any statements
     # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
+    # - funcorder # TODO Evaluate whether this is worth it
     # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
-    - gci
     - ginkgolinter
     - gocheckcompilerdirectives
     # - gochecknoglobals # We don't want to forbid global variable constants
@@ -100,20 +123,17 @@ linters:
     - gocyclo
     - godot
     # - godox #  Let's not forbid inline TODOs, FIXMEs et al
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     # - gomoddirectives # We don't want to forbid the 'replace' directive
     # - gomodguard # We don't block any modules
     # - goprintffuncname # This doesn't seem useful at all
-    # - gosmopolitan # This is related to internationalization which is not a concern for us
     - gosec
-    - gosimple
+    # - gosmopolitan # This is related to internationalization which is not a concern for us
     - govet
     - grouper
     - iface
     - importas
+    - inamedparam
     - ineffassign
     # - interfacebloat # We track complexity elsewhere
     - intrange
@@ -126,6 +146,7 @@ linters:
     - mirror
     - misspell
     # - mnd # It doesn't seem useful in general to enforce constants for all numeric values
+    # - musttag # TODO Our JSON structs should be tagged
     - nakedret
     # - nestif # This calculates cognitive complexity but we're doing that elsewhere
     - nilerr
@@ -150,7 +171,6 @@ linters:
     # - spancheck # We don't use OpenTelemetry/OpenCensus
     # - sqlclosecheck # We don't use SQL
     - staticcheck
-    - stylecheck
     - tagalign
     # - tagliatelle # Inconsistent with stylecheck and not as good
     # - testableexamples # We don't need this
@@ -158,7 +178,6 @@ linters:
     - testpackage
     # - thelper # Not relevant for our Ginkgo UTs
     # - tparallel # Not relevant for our Ginkgo UTs
-    - typecheck
     - unconvert
     - unparam
     - unused
@@ -170,64 +189,66 @@ linters:
     - wrapcheck
     - wsl
     # - zerologlint # We use zerolog indirectly so this isn't needed
-issues:
-  exclude-rules:
-    # Allow dot-imports for Gomega BDD directives per idiomatic Gomega
-    - linters:
-        - revive
-        - stylecheck
-      text: "dot imports"
-      source: "gomega"
-
-    # Allow dot-imports for Ginkgo BDD directives per idiomatic Ginkgo
-    - linters:
-        - revive
-        - stylecheck
-      text: "dot imports"
-      source: "ginkgo"
-
-    # Ignore long line and variable name non-compliance warnings in auto-generated file
-    - linters:
-        - lll
-        - stylecheck
-        - revive
-      path: "pkg/embeddedyamls/yamls.go"
-
-    # BrokerK8sApiServer parameter is used by other projects, like ACM,
-    # so not changing it to BrokerK8sAPIServer as suggested by stylecheck
-    - linters:
-        - revive
-        - stylecheck
-      text: "struct field BrokerK8sApiServer"
-
-    # Ignore pointer bytes in struct alignment tests (this is a very
-    # minor optimisation)
-    - linters:
-        - govet
-      text: "pointer bytes could be"
-
-    # Full text of the error is "do not define dynamic errors, use wrapped static errors instead". See
-    # https://github.com/Djarvur/go-err113/issues/10 for an interesting discussion of this error. While there are cases
-    # where wrapped sentinel errors are useful, it seems a bit pedantic to force that pattern in all cases.
-    - linters:
-        - err113
-      text: "do not define dynamic errors"
-
-    # Ignore certain linters for test files
-    - path: _test\.go|test/|fake/
-      linters:
-        - errname
-        - gochecknoinits
-        - err113
-        - wrapcheck
-
-    # Ignore header linting for internal files copied from Kubernetes
-    - path: internal/(cli|env|log)/.*\.go
-      linters:
-        - goheader
-
-    # Ignore header linting for build constraint
-    # See https://github.com/denis-tingaikin/go-header/issues/18
-    - path: cmd/subctl/.*\.go
-      linters:
-        - goheader
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Ignore long line and variable name non-compliance warnings in auto-generated file
+      - linters:
+          - lll
+          - revive
+          - staticcheck
+        path: pkg/embeddedyamls/yamls.go
+      # BrokerK8sApiServer parameter is used by other projects, like ACM,
+      # so not changing it to BrokerK8sAPIServer as suggested by stylecheck
+      - linters:
+          - revive
+          - staticcheck
+        text: struct field BrokerK8sApiServer
+      # Ignore pointer bytes in struct alignment tests (this is a very
+      # minor optimisation)
+      - linters:
+          - govet
+        text: pointer bytes could be
+      # Full text of the error is "do not define dynamic errors, use wrapped static errors instead". See
+      # https://github.com/Djarvur/go-err113/issues/10 for an interesting discussion of this error. While there are cases
+      # where wrapped sentinel errors are useful, it seems a bit pedantic to force that pattern in all cases.
+      - linters:
+          - err113
+        text: do not define dynamic errors
+      # Ignore certain linters for test files
+      - linters:
+          - err113
+          - errname
+          - gochecknoinits
+          - wrapcheck
+        path: _test\.go|test/|fake/
+      # Ignore header linting for internal files copied from Kubernetes
+      - linters:
+          - goheader
+        path: internal/(cli|env|log)/.*\.go
+      # Ignore header linting for build constraint
+      # See https://github.com/denis-tingaikin/go-header/issues/18
+      - linters:
+          - goheader
+        path: cmd/subctl/.*\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -18,7 +18,6 @@ limitations under the License.
 
 package subctl
 
-//nolint:revive // Blank imports below are intentional.
 import (
 	"errors"
 	"fmt"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/submariner-io/admiral v0.21.0-m2
 	github.com/submariner-io/cloud-prepare v0.21.0-m2
-	github.com/submariner-io/lighthouse v0.21.0-m2
+	github.com/submariner-io/lighthouse v0.21.0-m2.0.20250519102227-c28e43bf734f
 	github.com/submariner-io/shipyard v0.21.0-m2
 	github.com/submariner-io/submariner v0.21.0-m2
 	github.com/submariner-io/submariner-operator v0.21.0-m2

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/submariner-io/admiral v0.21.0-m2 h1:SoDFEfd651Ql4BjN29J2AA86AycjvSjvi
 github.com/submariner-io/admiral v0.21.0-m2/go.mod h1:bVLQLEKc8ioOQPg8DpplPhgmrmhF+FufKj/CUgQtMPw=
 github.com/submariner-io/cloud-prepare v0.21.0-m2 h1:jJ3zylNQmLb1u9ivAFTaaq62iExx4F1XfKdiBN98BLg=
 github.com/submariner-io/cloud-prepare v0.21.0-m2/go.mod h1:pI+q3v5Yk28WqSMaVriKo5lT+y2SZNmLDKA5YXDn91M=
-github.com/submariner-io/lighthouse v0.21.0-m2 h1:5zktV+h+E0I+7Qkd0xoeBItR62EJQBqY+J2mklYWfAM=
-github.com/submariner-io/lighthouse v0.21.0-m2/go.mod h1:MKYKOM+P3FO7b91v5uxzyOVZAGEVSMcwclL636vY3Z0=
+github.com/submariner-io/lighthouse v0.21.0-m2.0.20250519102227-c28e43bf734f h1:lN1y3ykMInDerH6DWyJTy7/tpR7q63HO2NBrQaOPU8s=
+github.com/submariner-io/lighthouse v0.21.0-m2.0.20250519102227-c28e43bf734f/go.mod h1:MKYKOM+P3FO7b91v5uxzyOVZAGEVSMcwclL636vY3Z0=
 github.com/submariner-io/shipyard v0.21.0-m2 h1:tkPO6fMi2C8HKgoiNLMDWb6LBXpIl7QIEzdvdTS5Vnc=
 github.com/submariner-io/shipyard v0.21.0-m2/go.mod h1:J8Qk9Mf40Uj+9g44TkVJtf0fif/62IQ/MqS7feyjp5E=
 github.com/submariner-io/submariner v0.21.0-m2 h1:5FxUvbH4HZw1QvVkUk0ju0dT00nz+g8fRC/eHsRNpsc=

--- a/internal/log/types.go
+++ b/internal/log/types.go
@@ -46,7 +46,7 @@ type Logger interface {
 	//
 	// It is expected that the returned InfoLogger will be extremely cheap
 	// to interact with for a Level greater than the enabled level.
-	V(Level) InfoLogger
+	V(level Level) InfoLogger
 }
 
 // InfoLogger defines the info logging interface kind uses.

--- a/pkg/broker/info.go
+++ b/pkg/broker/info.go
@@ -36,11 +36,11 @@ import (
 
 type Info struct {
 	BrokerURL        string         `json:"brokerURL"`
-	ClientToken      *corev1.Secret `omitempty,json:"clientToken"`
-	IPSecPSK         *corev1.Secret `omitempty,json:"ipsecPSK"`
-	ServiceDiscovery bool           `omitempty,json:"serviceDiscovery"`
+	ClientToken      *corev1.Secret `json:"clientToken,omitempty"`
+	IPSecPSK         *corev1.Secret `json:"ipsecPSK,omitempty"`
+	ServiceDiscovery bool           `json:"serviceDiscovery,omitempty"`
 	Components       []string       `json:",omitempty"`
-	CustomDomains    *[]string      `omitempty,json:"customDomains"`
+	CustomDomains    *[]string      `json:"customDomains,omitempty"`
 }
 
 func (d *Info) writeToFile(filename string) error {

--- a/pkg/diagnose/kubeproxy.go
+++ b/pkg/diagnose/kubeproxy.go
@@ -61,7 +61,7 @@ func KubeProxyMode(clusterInfo *cluster.Info, namespace string, imageOverrides [
 		return status.Error(err, "Error spawning the network pod")
 	}
 
-	if !(strings.Contains(podOutput, missingInterface) || strings.Contains(podOutput, notEnabled)) {
+	if !strings.Contains(podOutput, missingInterface) && !strings.Contains(podOutput, notEnabled) {
 		status.Failure("The cluster is deployed with kube-proxy ipvs mode which Submariner does not support")
 		return nil
 	}


### PR DESCRIPTION
This also fixes a few issues:
* simplify kubeproxy diagnose using De Morgan's laws
* fix broker Info JSON tags
* name the Logger V() argument

musttag is left disabled because it requires fixes in Azure auth which must match the current file format.

Depends on https://github.com/submariner-io/shipyard/pull/1963