### PR TITLE
Handle multiple discovered network CIDRs in subctl join

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -29,6 +29,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/admiral/pkg/slices"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/exit"
@@ -101,8 +102,8 @@ func init() {
 
 func addJoinFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&joinFlags.ClusterID, "clusterid", "", "cluster ID used to identify the tunnels")
-	cmd.Flags().StringVar(&joinFlags.ServiceCIDR, "servicecidr", "", "service CIDR")
-	cmd.Flags().StringVar(&joinFlags.ClusterCIDR, "clustercidr", "", "cluster CIDR")
+	cmd.Flags().StringVar(&joinFlags.ServiceCIDR, "servicecidr", "", "comma-separated service CIDRs")
+	cmd.Flags().StringVar(&joinFlags.ClusterCIDR, "clustercidr", "", "comma-separated cluster CIDRs")
 	cmd.Flags().StringVar(&joinFlags.Repository, "repository", "", "image repository")
 	cmd.Flags().StringVar(&joinFlags.ImageVersion, "version", "", "image version")
 	cmd.Flags().IntVar(&joinFlags.NATTPort, "nattport", 4500, "IPsec NATT port")
@@ -161,8 +162,8 @@ func joinInContext(brokerInfo *broker.Info, clusterInfo *cluster.Info, status re
 
 	ctx := context.TODO()
 	networkDetails := getNetworkDetails(ctx, clusterInfo.ClientProducer, status)
-	determinePodCIDR(networkDetails, status)
-	determineServiceCIDR(networkDetails, status)
+	joinFlags.ClusterCIDR = determineCIDR("Pod", joinFlags.ClusterCIDR, networkDetails.PodCIDRs, status)
+	joinFlags.ServiceCIDR = determineCIDR("Service", joinFlags.ServiceCIDR, networkDetails.ServiceCIDRs, status)
 
 	if brokerInfo.IsConnectivityEnabled() && labelGateway {
 		possiblyLabelGateway(clusterInfo.ClientProducer.ForKubernetes(), status)
@@ -276,7 +277,7 @@ func askForClusterID() (string, error) {
 func askForCIDR(name string) (string, error) {
 	qs := []*survey.Question{{
 		Name:     "cidr",
-		Prompt:   &survey.Input{Message: fmt.Sprintf("What's the %s CIDR for your cluster?", name)},
+		Prompt:   &survey.Input{Message: fmt.Sprintf("What's the %s CIDR for your cluster (comma-separated for multiple)?", name)},
 		Validate: survey.Required,
 	}}
 
@@ -331,33 +332,25 @@ func getNetworkDetails(ctx context.Context, clientProducer client.Producer, stat
 
 	if networkDetails != nil {
 		networkDetails.Show()
+	} else {
+		networkDetails = &network.ClusterNetwork{}
 	}
 
 	return networkDetails
 }
 
-func determinePodCIDR(nd *network.ClusterNetwork, status reporter.Interface) {
-	if joinFlags.ClusterCIDR != "" {
-		if nd != nil && len(nd.PodCIDRs) > 0 && nd.PodCIDRs[0] != joinFlags.ClusterCIDR {
-			status.Warning("The provided pod CIDR for the cluster (%s) does not match the discovered CIDR (%s)",
-				joinFlags.ClusterCIDR, nd.PodCIDRs[0])
+func determineCIDR(name, reqCIDR string, detectedCIDRs []string, status reporter.Interface) string {
+	if reqCIDR != "" {
+		reqCIDRs := strings.Split(reqCIDR, ",")
+		if len(detectedCIDRs) > 0 && !slices.Equivalent(detectedCIDRs, reqCIDRs, slices.Key[string]) {
+			status.Warning("The provided %s CIDR for the cluster (%s) does not match the discovered CIDR (%s)",
+				name, reqCIDR, strings.Join(detectedCIDRs, ","))
 		}
-	} else if nd == nil || len(nd.PodCIDRs) == 0 {
+	} else if len(detectedCIDRs) == 0 {
 		var err error
-		joinFlags.ClusterCIDR, err = askForCIDR("Pod")
+		reqCIDR, err = askForCIDR(name)
 		exit.OnError(status.Error(err, "Error collecting CIDR"))
 	}
-}
 
-func determineServiceCIDR(nd *network.ClusterNetwork, status reporter.Interface) {
-	if joinFlags.ServiceCIDR != "" {
-		if nd != nil && len(nd.ServiceCIDRs) > 0 && nd.ServiceCIDRs[0] != joinFlags.ServiceCIDR {
-			status.Warning("The provided service CIDR for the cluster (%s) does not match the discovered CIDR (%s)",
-				joinFlags.ServiceCIDR, nd.ServiceCIDRs[0])
-		}
-	} else if nd == nil || len(nd.ServiceCIDRs) == 0 {
-		var err error
-		joinFlags.ServiceCIDR, err = askForCIDR("Service")
-		exit.OnError(status.Error(err, "Error collecting CIDR"))
-	}
+	return reqCIDR
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.21.0-m3
 	github.com/submariner-io/shipyard v0.21.0-m3
 	github.com/submariner-io/submariner v0.21.0-m3
-	github.com/submariner-io/submariner-operator v0.21.0-m3
+	github.com/submariner-io/submariner-operator v0.21.0-m3.0.20250702134822-a20ac182d5e7
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.41.0
 	golang.org/x/oauth2 v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/submariner-io/shipyard v0.21.0-m3 h1:K0xxT34mIVwUh/9E5zqYRrapROianMKV
 github.com/submariner-io/shipyard v0.21.0-m3/go.mod h1:2nVGAqq4cw4TVGcW4qoOx2m67CmqIWW91DxkPqakiQQ=
 github.com/submariner-io/submariner v0.21.0-m3 h1:bszCAwW96bS2o2Zyqo4c4sQsSfyPn73CRfQ7I+1gWRU=
 github.com/submariner-io/submariner v0.21.0-m3/go.mod h1:P46FL1BlLP5q9xQH9m+qTD9axNI9grJ7pU8SlnShq1E=
-github.com/submariner-io/submariner-operator v0.21.0-m3 h1:5k3WYiMVq+EWtgmLXo0qSlkfEeDSmbBkUtMcqt9LJsk=
-github.com/submariner-io/submariner-operator v0.21.0-m3/go.mod h1:Z9q2cpNFFFnOKsE8jQDD5GM9OnpJb9ZOrmvaWypGxaE=
+github.com/submariner-io/submariner-operator v0.21.0-m3.0.20250702134822-a20ac182d5e7 h1:nX/8bWn3Vsc918EjIjBLjR3viCEH5dVxyZkSHWuYH5Y=
+github.com/submariner-io/submariner-operator v0.21.0-m3.0.20250702134822-a20ac182d5e7/go.mod h1:Z9q2cpNFFFnOKsE8jQDD5GM9OnpJb9ZOrmvaWypGxaE=
 github.com/urfave/cli/v2 v2.4.0 h1:m2pxjjDFgDxSPtO8WSdbndj17Wu2y8vOT86wE/tjr+I=
 github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=
 github.com/uw-labs/lichen v0.1.7 h1:SDNE3kThhhtP70XfLN/C2bqaT9Epefg1i10lhWYIG4g=


### PR DESCRIPTION
...for dual-stack. `network.Discover` now always returns multiple CIDRs as separate array entries instead of as a single comma-separate string entry.
