### PR TITLE
Enhance diagnose to verify the local ServiceImport for an imported service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
-	github.com/submariner-io/admiral v0.22.0-m0
+	github.com/submariner-io/admiral v0.22.0-m0.0.20250805185520-677f668b1864
 	github.com/submariner-io/cloud-prepare v0.22.0-m0
 	github.com/submariner-io/lighthouse v0.22.0-m0.0.20250804124049-c11c354a394c
 	github.com/submariner-io/shipyard v0.22.0-m0

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/submariner-io/admiral v0.22.0-m0 h1:Fu/ZS9/nZaPVtIjRwDSOwnDjTjn7z+ExlSiTCL44Eck=
-github.com/submariner-io/admiral v0.22.0-m0/go.mod h1:/TFjweSHJGNWguW7A6RtQSsN6ruckOyYIQ/FYHHoPI0=
+github.com/submariner-io/admiral v0.22.0-m0.0.20250805185520-677f668b1864 h1:hvPHPIZND6YtGcILWC6m/w3ViJzhYpELeNYefpUo2Hg=
+github.com/submariner-io/admiral v0.22.0-m0.0.20250805185520-677f668b1864/go.mod h1:zGujbtsSfIh+yPna+83GTsuRLY1F+zEBgUGqj7f07ig=
 github.com/submariner-io/cloud-prepare v0.22.0-m0 h1:2EWS/eQ0zLvJ8T4A5LVhDgz9RWEuGU9CCjEZUlyvsDU=
 github.com/submariner-io/cloud-prepare v0.22.0-m0/go.mod h1:oO3SUJcaKeL50f0ZxlzjKtnALrheFJkuFIlmV6kB9Wc=
 github.com/submariner-io/lighthouse v0.22.0-m0.0.20250804124049-c11c354a394c h1:kGg4B7A+dYt+2YbDw0Hezdq5yws7NKuYOCrAVR3hQMY=

--- a/pkg/diagnose/diagnose_suite_test.go
+++ b/pkg/diagnose/diagnose_suite_test.go
@@ -24,16 +24,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/client"
 	clientfake "github.com/submariner-io/subctl/pkg/client/fake"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	cntrollerclient "sigs.k8s.io/controller-runtime/pkg/client"
+	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -49,11 +56,33 @@ func TestDiagnose(t *testing.T) {
 }
 
 type testDriver struct {
-	fakeProducer *client.DefaultProducer
+	fakeProducer  *client.DefaultProducer
+	submariner    *v1alpha1.Submariner
+	statusTracker *StatusTracker
 }
 
-func (t *testDriver) createResource(resource cntrollerclient.Object) {
+func (t *testDriver) createResource(resource controllerclient.Object) {
 	err := t.fakeProducer.GeneralClient.Create(context.TODO(), resource)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (t *testDriver) createServiceExport(se *mcsv1a1.ServiceExport) {
+	test.CreateResource(t.fakeProducer.DynamicClient.Resource(
+		gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceexports")).Namespace(se.Namespace), se)
+}
+
+func (t *testDriver) createServiceImport(si *mcsv1a1.ServiceImport) {
+	test.CreateResource(t.fakeProducer.DynamicClient.Resource(
+		gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceimports")).Namespace(si.Namespace), si)
+}
+
+func (t *testDriver) createService(svc *corev1.Service) {
+	_, err := t.fakeProducer.KubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (t *testDriver) creatEndpointSlice(eps *discoveryv1.EndpointSlice) {
+	_, err := t.fakeProducer.KubeClient.DiscoveryV1().EndpointSlices(eps.Namespace).Create(context.TODO(), eps, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -61,10 +90,52 @@ func newTestDriver() *testDriver {
 	t := &testDriver{}
 
 	BeforeEach(func() {
+		t.statusTracker = &StatusTracker{Interface: cli.NewReporter()}
 		t.fakeProducer = clientfake.New()
+		t.submariner = &v1alpha1.Submariner{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      names.SubmarinerCrName,
+				Namespace: constants.OperatorNamespace,
+			},
+			Spec: v1alpha1.SubmarinerSpec{
+				ClusterID: "east",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		t.createResource(t.submariner)
 	})
 
 	return t
+}
+
+type StatusTracker struct {
+	reporter.Interface
+	failures []string
+	warnings []string
+}
+
+func (t *StatusTracker) Warning(message string, args ...any) {
+	t.warnings = append(t.warnings, message)
+	t.Interface.Warning(message, args...)
+}
+
+func (t *StatusTracker) Failure(message string, args ...any) {
+	t.failures = append(t.failures, message)
+	t.Interface.Failure(message, args...)
+}
+
+func (t *StatusTracker) assertFailureCount(count int) {
+	Expect(t.failures).To(HaveLen(count))
+}
+
+func (t *StatusTracker) assertHasFailure() {
+	Expect(t.failures).NotTo(BeEmpty())
+}
+
+func (t *StatusTracker) assertWarningCount(count int) {
+	Expect(t.warnings).To(HaveLen(count))
 }
 
 func newClusterInfo() *cluster.Info {

--- a/pkg/diagnose/diagnose_suite_test.go
+++ b/pkg/diagnose/diagnose_suite_test.go
@@ -20,11 +20,13 @@ package diagnose_test
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/submariner-io/admiral/pkg/reporter"
+	reportertest "github.com/submariner-io/admiral/pkg/reporter/test"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/subctl/internal/cli"
 	"github.com/submariner-io/subctl/internal/constants"
@@ -38,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,11 +61,11 @@ func TestDiagnose(t *testing.T) {
 type testDriver struct {
 	fakeProducer  *client.DefaultProducer
 	submariner    *v1alpha1.Submariner
-	statusTracker *StatusTracker
+	statusTracker *reportertest.Tracker
 }
 
-func (t *testDriver) createResource(resource controllerclient.Object) {
-	err := t.fakeProducer.GeneralClient.Create(context.TODO(), resource)
+func (t *testDriver) createResource(obj controllerclient.Object) {
+	err := t.fakeProducer.GeneralClient.Create(context.TODO(), obj)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -86,11 +89,27 @@ func (t *testDriver) creatEndpointSlice(eps *discoveryv1.EndpointSlice) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func (t *testDriver) createNamespace(name string) {
+	_, err := t.fakeProducer.KubeClient.CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	test.CreateResource(t.fakeProducer.DynamicClient.Resource(corev1.SchemeGroupVersion.WithResource("namespaces")),
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		})
+}
+
 func newTestDriver() *testDriver {
 	t := &testDriver{}
 
 	BeforeEach(func() {
-		t.statusTracker = &StatusTracker{Interface: cli.NewReporter()}
+		t.statusTracker = &reportertest.Tracker{Interface: cli.NewReporter()}
 		t.fakeProducer = clientfake.New()
 		t.submariner = &v1alpha1.Submariner{
 			ObjectMeta: metav1.ObjectMeta{
@@ -98,8 +117,15 @@ func newTestDriver() *testDriver {
 				Namespace: constants.OperatorNamespace,
 			},
 			Spec: v1alpha1.SubmarinerSpec{
-				ClusterID: "east",
+				ClusterID:                "east",
+				BrokerK8sApiServer:       "api-server",
+				BrokerK8sApiServerToken:  base64.StdEncoding.EncodeToString([]byte("token")),
+				BrokerK8sRemoteNamespace: constants.DefaultBrokerNamespace,
 			},
+		}
+
+		resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
+			return t.fakeProducer.DynamicClient, nil
 		}
 	})
 
@@ -108,34 +134,6 @@ func newTestDriver() *testDriver {
 	})
 
 	return t
-}
-
-type StatusTracker struct {
-	reporter.Interface
-	failures []string
-	warnings []string
-}
-
-func (t *StatusTracker) Warning(message string, args ...any) {
-	t.warnings = append(t.warnings, message)
-	t.Interface.Warning(message, args...)
-}
-
-func (t *StatusTracker) Failure(message string, args ...any) {
-	t.failures = append(t.failures, message)
-	t.Interface.Failure(message, args...)
-}
-
-func (t *StatusTracker) assertFailureCount(count int) {
-	Expect(t.failures).To(HaveLen(count))
-}
-
-func (t *StatusTracker) assertHasFailure() {
-	Expect(t.failures).NotTo(BeEmpty())
-}
-
-func (t *StatusTracker) assertWarningCount(count int) {
-	Expect(t.warnings).To(HaveLen(count))
 }
 
 func newClusterInfo() *cluster.Info {

--- a/pkg/diagnose/servicediscovery.go
+++ b/pkg/diagnose/servicediscovery.go
@@ -20,7 +20,6 @@ package diagnose
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -34,17 +33,20 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 func ServiceDiscovery(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
+	ctx := context.TODO()
+
 	status.Start("Checking that services have been exported properly")
 	defer status.End()
 
 	tracker := reporter.NewTracker(status)
 
-	checkServiceExport(clusterInfo, tracker)
+	checkServiceExports(ctx, clusterInfo, tracker)
 
 	if tracker.HasFailures() {
 		return errors.New("failures while diagnosing service discovery")
@@ -54,9 +56,7 @@ func ServiceDiscovery(clusterInfo *cluster.Info, _ string, status reporter.Inter
 }
 
 // This function checks if all ServiceExports have a matching ServiceImport and if an EndpointSlice has been created for the service.
-func checkServiceExport(clusterInfo *cluster.Info, status reporter.Interface) {
-	ctx := context.TODO()
-
+func checkServiceExports(ctx context.Context, clusterInfo *cluster.Info, status reporter.Interface) {
 	serviceExportGVR := gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceexports")
 
 	serviceExports, err := clusterInfo.ClientProducer.ForDynamic().Resource(serviceExportGVR).Namespace(corev1.NamespaceAll).
@@ -66,33 +66,43 @@ func checkServiceExport(clusterInfo *cluster.Info, status reporter.Interface) {
 		return
 	}
 
-	serviceImportsGVR := gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceimports")
-
 	for i := range serviceExports.Items {
-		se := &mcsv1a1.ServiceExport{}
-
-		err = runtime.DefaultUnstructuredConverter.FromUnstructured(serviceExports.Items[i].Object, se)
-		if err != nil {
-			status.Failure("Error converting ServiceExport: %v", err)
-			continue
-		}
+		se := resource.MustFromUnstructured(&serviceExports.Items[i], &mcsv1a1.ServiceExport{})
 
 		_, err := clusterInfo.ClientProducer.ForKubernetes().CoreV1().Services(se.Namespace).Get(ctx, se.Name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			status.Warning("Exported Service %s/%s not found", se.Namespace, se.Name)
+			status.Warning("Exported Service \"%s/%s\" not found", se.Namespace, se.Name)
 			verifyStatusCondition(se, mcsv1a1.ServiceExportValid, metav1.ConditionFalse, status)
 
 			continue
 		}
 
 		if err != nil {
-			status.Failure("Error retrieving Service %s/%s: %v", se.Namespace, se.Name, err)
+			status.Failure("Error retrieving Service \"%s/%s\": %v", se.Namespace, se.Name, err)
+			return
+		}
+
+		if !verifyStatusCondition(se, mcsv1a1.ServiceExportValid, metav1.ConditionTrue, status) {
 			continue
 		}
 
-		verifyStatusCondition(se, mcsv1a1.ServiceExportValid, metav1.ConditionTrue, status)
 		verifyStatusCondition(se, lhconstants.ServiceExportReady, metav1.ConditionTrue, status)
 		verifyStatusCondition(se, mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, status)
+
+		serviceImportClient := clusterInfo.ClientProducer.ForDynamic().Resource(serviceImportGVR())
+
+		if !localServiceImportExists(ctx, serviceImportClient, se.Name, se.Namespace, status) {
+			continue
+		}
+
+		_, err = serviceImportClient.Namespace(se.Namespace).Get(ctx, se.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				status.Failure("No ServiceImport found for exported service \"%s/%s\"", se.Namespace, se.Name)
+			} else {
+				status.Failure("Error retrieving ServiceImport for exported service \"%s/%s\": %v", se.Namespace, se.Name, err)
+			}
+		}
 
 		ep := clusterInfo.ClientProducer.ForKubernetes().DiscoveryV1().EndpointSlices(se.Namespace)
 
@@ -104,59 +114,67 @@ func checkServiceExport(clusterInfo *cluster.Info, status reporter.Interface) {
 			}).String(),
 		})
 		if err != nil {
-			status.Failure("Error retrieving EndPointSlice for exported service %s/%s: %v", se.Namespace, se.Name, err)
+			status.Failure("Error retrieving EndpointSlices for exported service \"%s/%s\": %v", se.Namespace, se.Name, err)
 			return
 		}
 
 		if len(epsList.Items) == 0 {
-			status.Failure("No EndpointSlice found for exported service %s/%s", se.Namespace, se.Name)
-		}
-
-		checkForAggregateSI := false
-
-		serviceImportClient := clusterInfo.ClientProducer.ForDynamic().Resource(serviceImportsGVR)
-
-		localSI, err := serviceImportClient.Namespace(constants.OperatorNamespace).Get(ctx,
-			fmt.Sprintf("%s-%s-%s", se.Name, se.Namespace, clusterInfo.Submariner.Spec.ClusterID), metav1.GetOptions{})
-		if err == nil {
-			_, checkForAggregateSI = localSI.GetLabels()[mcsv1a1.LabelServiceName]
-		} else if apierrors.IsNotFound(err) {
-			status.Failure("No local ServiceImport in %q found for exported service %s/%s", constants.OperatorNamespace,
-				se.Namespace, se.Name)
-		} else {
-			status.Failure("Error retrieving ServiceImport for exported service %s/%s: %v", se.Namespace, se.Name, err)
-		}
-
-		if checkForAggregateSI {
-			_, err = serviceImportClient.Namespace(se.Namespace).Get(ctx, se.Name, metav1.GetOptions{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					status.Failure("No ServiceImport found for exported service %s/%s", se.Namespace, se.Name)
-				} else {
-					status.Failure("Error retrieving ServiceImport for exported service %s/%s: %v", se.Namespace, se.Name, err)
-				}
-			}
+			status.Failure("No EndpointSlice found for exported service \"%s/%s\"", se.Namespace, se.Name)
 		}
 	}
 }
 
+func localServiceImportExists(ctx context.Context, siClient dynamic.NamespaceableResourceInterface, serviceName, serviceNamespace string,
+	status reporter.Interface,
+) bool {
+	list, err := siClient.Namespace(constants.OperatorNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			mcsv1a1.LabelServiceName:         serviceName,
+			lhconstants.LabelSourceNamespace: serviceNamespace,
+		}).String(),
+	})
+	if err != nil {
+		status.Failure("Error retrieving ServiceImport for exported service \"%s/%s\": %v", serviceNamespace, serviceName, err)
+
+		return false
+	}
+
+	if len(list.Items) > 0 {
+		return true
+	}
+
+	status.Failure("No local ServiceImport in %q found for exported service \"%s/%s\"", constants.OperatorNamespace,
+		serviceNamespace, serviceName)
+
+	return false
+}
+
 func verifyStatusCondition(se *mcsv1a1.ServiceExport, condType string, condStatus metav1.ConditionStatus,
 	status reporter.Interface,
-) {
+) bool {
 	for i := range se.Status.Conditions {
 		condition := &se.Status.Conditions[i]
 		if condition.Type == condType || (condType == lhconstants.ServiceExportReady && condition.Type == "Synced") {
 			if condition.Status != condStatus {
 				status.Failure(
-					"The ServiceExport %q status condition type for %s/%s is not satisfied. Expected condition status %q. Actual:\n%s",
+					"The ServiceExport %q status condition type for \"%s/%s\" is not satisfied. Expected condition status %q. Actual:\n%s",
 					condition.Type, se.Namespace, se.Name, condStatus, resource.ToJSON(condition))
+
+				return false
 			}
 
-			return
+			return true
 		}
 	}
 
 	if condStatus == metav1.ConditionTrue {
-		status.Failure("The ServiceExport for %s/%s is missing the %q status condition type", se.Namespace, se.Name, condType)
+		status.Failure("The ServiceExport for \"%s/%s\" is missing the %q status condition type", se.Namespace, se.Name, condType)
+		return false
 	}
+
+	return true
+}
+
+func serviceImportGVR() schema.GroupVersionResource {
+	return gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceimports")
 }

--- a/pkg/diagnose/servicediscovery.go
+++ b/pkg/diagnose/servicediscovery.go
@@ -27,6 +27,8 @@ import (
 	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/gvr"
+	"github.com/submariner-io/subctl/internal/restconfig"
+	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -41,12 +43,13 @@ import (
 func ServiceDiscovery(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	ctx := context.TODO()
 
-	status.Start("Checking that services have been exported properly")
+	status.Start("Checking that services have been exported/imported properly")
 	defer status.End()
 
 	tracker := reporter.NewTracker(status)
 
 	checkServiceExports(ctx, clusterInfo, tracker)
+	checkServiceImports(ctx, clusterInfo, tracker)
 
 	if tracker.HasFailures() {
 		return errors.New("failures while diagnosing service discovery")
@@ -173,6 +176,48 @@ func verifyStatusCondition(se *mcsv1a1.ServiceExport, condType string, condStatu
 	}
 
 	return true
+}
+
+func checkServiceImports(ctx context.Context, clusterInfo *cluster.Info, status reporter.Interface) {
+	brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(clusterInfo.Submariner, nil)
+	if err != nil {
+		status.Failure("Error getting the Broker's REST config: %v", err)
+		return
+	}
+
+	clientProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	if err != nil {
+		status.Failure("Error creating broker client Producer: %v", err)
+		return
+	}
+
+	serviceImports, err := clientProducer.ForDynamic().Resource(serviceImportGVR()).Namespace(brokerNamespace).List(
+		ctx, metav1.ListOptions{})
+	if err != nil {
+		status.Failure("Error listing ServiceImports on the broker: %v", err)
+		return
+	}
+
+	for i := range serviceImports.Items {
+		if _, ok := serviceImports.Items[i].GetAnnotations()[mcsv1a1.LabelServiceName]; !ok {
+			continue
+		}
+
+		// This is an aggregated ServiceImport on the broker - check for the local copy.
+		serviceName := serviceImports.Items[i].GetAnnotations()[mcsv1a1.LabelServiceName]
+		serviceNamespace := serviceImports.Items[i].GetAnnotations()[lhconstants.LabelSourceNamespace]
+
+		_, err = clusterInfo.ClientProducer.ForDynamic().Resource(serviceImportGVR()).Namespace(serviceNamespace).Get(
+			ctx, serviceName, metav1.GetOptions{})
+		if resource.IsMissingNamespaceErr(err) {
+			status.Warning("The namespace %q for imported service %q does not exist therefore the service will "+
+				"not be accessible via DNS on this cluster. This may be intentional.", serviceNamespace, serviceName)
+		} else if apierrors.IsNotFound(err) {
+			status.Failure("No ServiceImport found for imported service \"%s/%s\"", serviceNamespace, serviceName)
+		} else if err != nil {
+			status.Failure("Error retrieving ServiceImport for imported service \"%s/%s\": %v", serviceNamespace, serviceName, err)
+		}
+	}
 }
 
 func serviceImportGVR() schema.GroupVersionResource {

--- a/pkg/diagnose/servicediscovery_test.go
+++ b/pkg/diagnose/servicediscovery_test.go
@@ -43,6 +43,7 @@ const (
 
 var _ = Describe("ServiceDiscovery", func() {
 	Describe("Exported Services", testExportedServices)
+	Describe("Imported Services", testImportedServices)
 })
 
 func testExportedServices() {
@@ -125,8 +126,8 @@ func testExportedServices() {
 
 		It("should succeed", func() {
 			Expect(t.runServiceDiscovery()).To(Succeed())
-			t.statusTracker.assertFailureCount(0)
-			t.statusTracker.assertWarningCount(0)
+			t.statusTracker.AssertFailureCount(0)
+			t.statusTracker.AssertWarningCount(0)
 		})
 	})
 
@@ -144,7 +145,7 @@ func testExportedServices() {
 
 			It("should fail", func() {
 				Expect(t.runServiceDiscovery()).NotTo(Succeed())
-				t.statusTracker.assertFailureCount(1)
+				t.statusTracker.AssertFailureCount(1)
 			})
 		})
 
@@ -156,7 +157,7 @@ func testExportedServices() {
 
 			It("should fail", func() {
 				Expect(t.runServiceDiscovery()).NotTo(Succeed())
-				t.statusTracker.assertFailureCount(1)
+				t.statusTracker.AssertFailureCount(1)
 			})
 		})
 
@@ -167,7 +168,7 @@ func testExportedServices() {
 
 			It("should fail", func() {
 				Expect(t.runServiceDiscovery()).NotTo(Succeed())
-				t.statusTracker.assertHasFailure()
+				t.statusTracker.AssertHasFailure()
 			})
 		})
 
@@ -179,14 +180,14 @@ func testExportedServices() {
 
 			It("should fail", func() {
 				Expect(t.runServiceDiscovery()).NotTo(Succeed())
-				t.statusTracker.assertFailureCount(1)
+				t.statusTracker.AssertFailureCount(1)
 			})
 		})
 
 		Context("but no local ServiceImport exists", func() {
 			It("should fail", func() {
 				Expect(t.runServiceDiscovery()).NotTo(Succeed())
-				t.statusTracker.assertFailureCount(1)
+				t.statusTracker.AssertFailureCount(1)
 			})
 		})
 
@@ -198,7 +199,7 @@ func testExportedServices() {
 
 			It("should fail", func() {
 				Expect(t.runServiceDiscovery()).NotTo(Succeed())
-				t.statusTracker.assertFailureCount(1)
+				t.statusTracker.AssertFailureCount(1)
 			})
 		})
 	})
@@ -211,16 +212,16 @@ func testExportedServices() {
 
 		It("should succeed but emit a warning", func() {
 			Expect(t.runServiceDiscovery()).To(Succeed())
-			t.statusTracker.assertFailureCount(0)
-			t.statusTracker.assertWarningCount(1)
+			t.statusTracker.AssertFailureCount(0)
+			t.statusTracker.AssertWarningCount(1)
 		})
 	})
 
 	When("no services are exported", func() {
 		It("should succeed", func() {
 			Expect(t.runServiceDiscovery()).To(Succeed())
-			t.statusTracker.assertFailureCount(0)
-			t.statusTracker.assertWarningCount(0)
+			t.statusTracker.AssertFailureCount(0)
+			t.statusTracker.AssertWarningCount(0)
 		})
 	})
 
@@ -232,7 +233,7 @@ func testExportedServices() {
 
 		It("should fail", func() {
 			Expect(t.runServiceDiscovery()).NotTo(Succeed())
-			t.statusTracker.assertFailureCount(1)
+			t.statusTracker.AssertFailureCount(1)
 		})
 	})
 
@@ -245,7 +246,7 @@ func testExportedServices() {
 
 		It("should fail", func() {
 			Expect(t.runServiceDiscovery()).NotTo(Succeed())
-			t.statusTracker.assertFailureCount(1)
+			t.statusTracker.AssertFailureCount(1)
 		})
 	})
 
@@ -254,12 +255,12 @@ func testExportedServices() {
 			t.createService(service)
 			t.createServiceExport(serviceExport)
 			t.createServiceImport(localServiceImport)
-			fake.FailOnAction(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceimports", "list", nil, false)
+			fake.FailOnAction(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceimports", "list", nil, true)
 		})
 
 		It("should fail", func() {
 			Expect(t.runServiceDiscovery()).NotTo(Succeed())
-			t.statusTracker.assertFailureCount(1)
+			t.statusTracker.AssertFailureCount(1)
 		})
 	})
 
@@ -275,7 +276,106 @@ func testExportedServices() {
 
 		It("should fail", func() {
 			Expect(t.runServiceDiscovery()).NotTo(Succeed())
-			t.statusTracker.assertFailureCount(1)
+			t.statusTracker.AssertFailureCount(1)
+		})
+	})
+}
+
+func testImportedServices() {
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		fake.AddVerifyNamespaceReactor(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceimports")
+	})
+
+	JustBeforeEach(func() {
+		t.createNamespace(t.submariner.Spec.BrokerK8sRemoteNamespace)
+
+		// Aggregated ServiceImport on the broker
+		t.createServiceImport(&mcsv1a1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName + "-" + serviceNamespace,
+				Namespace: t.submariner.Spec.BrokerK8sRemoteNamespace,
+				Annotations: map[string]string{
+					mcsv1a1.LabelServiceName:         serviceName,
+					lhconstants.LabelSourceNamespace: serviceNamespace,
+				},
+			},
+		})
+
+		// Some cluster-local ServiceImport on the broker
+		t.createServiceImport(&mcsv1a1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName + "-wdglkj",
+				Namespace: t.submariner.Spec.BrokerK8sRemoteNamespace,
+				Labels: map[string]string{
+					mcsv1a1.LabelServiceName:         serviceName,
+					lhconstants.LabelSourceNamespace: serviceNamespace,
+					mcsv1a1.LabelSourceCluster:       "west",
+				},
+			},
+		})
+	})
+
+	When("an imported service's local ServiceImport exists", func() {
+		JustBeforeEach(func() {
+			t.createNamespace(serviceNamespace)
+
+			// Local aggregated ServiceImport
+			t.createServiceImport(&mcsv1a1.ServiceImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: serviceNamespace,
+				},
+			})
+		})
+
+		It("should succeed", func() {
+			Expect(t.runServiceDiscovery()).To(Succeed())
+			t.statusTracker.AssertFailureCount(0)
+			t.statusTracker.AssertWarningCount(0)
+		})
+	})
+
+	When("an imported service's namespace doesn't exist locally", func() {
+		It("should succeed but emit a warning", func() {
+			Expect(t.runServiceDiscovery()).To(Succeed())
+			t.statusTracker.AssertFailureCount(0)
+			t.statusTracker.AssertWarningCount(1)
+		})
+	})
+
+	When("an imported service's local ServiceImport doesn't exist", func() {
+		JustBeforeEach(func() {
+			t.createNamespace(serviceNamespace)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.AssertFailureCount(1)
+			t.statusTracker.AssertWarningCount(0)
+		})
+	})
+
+	When("broker ServiceImport retrieval fails", func() {
+		BeforeEach(func() {
+			fake.FailOnAction(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceimports", "list", nil, true)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.AssertFailureCount(1)
+		})
+	})
+
+	When("local ServiceImport retrieval fails", func() {
+		BeforeEach(func() {
+			fake.FailOnAction(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceimports", "get", nil, true)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.AssertFailureCount(1)
 		})
 	})
 }

--- a/pkg/diagnose/servicediscovery_test.go
+++ b/pkg/diagnose/servicediscovery_test.go
@@ -1,0 +1,285 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnose_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
+	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/pkg/diagnose"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+const (
+	serviceName      = "nginx"
+	serviceNamespace = "service-ns"
+)
+
+var _ = Describe("ServiceDiscovery", func() {
+	Describe("Exported Services", testExportedServices)
+})
+
+func testExportedServices() {
+	var (
+		service                 *corev1.Service
+		serviceExport           *mcsv1a1.ServiceExport
+		localServiceImport      *mcsv1a1.ServiceImport
+		aggregatedServiceImport *mcsv1a1.ServiceImport
+		endpointSlice           *discoveryv1.EndpointSlice
+	)
+
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		service = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: serviceNamespace,
+			},
+		}
+
+		serviceExport = &mcsv1a1.ServiceExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: serviceNamespace,
+			},
+			Status: mcsv1a1.ServiceExportStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   mcsv1a1.ServiceExportValid,
+						Status: metav1.ConditionTrue,
+					},
+					{
+						Type:   lhconstants.ServiceExportReady,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		endpointSlice = &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eps",
+				Namespace: serviceNamespace,
+				Labels: map[string]string{
+					discoveryv1.LabelManagedBy: lhconstants.LabelValueManagedBy,
+					mcsv1a1.LabelServiceName:   serviceName,
+					mcsv1a1.LabelSourceCluster: t.submariner.Spec.ClusterID,
+				},
+			},
+		}
+
+		localServiceImport = &mcsv1a1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s-%s", serviceName, serviceNamespace, t.submariner.Spec.ClusterID),
+				Namespace: constants.OperatorNamespace,
+				Labels: map[string]string{
+					mcsv1a1.LabelServiceName:         serviceName,
+					lhconstants.LabelSourceNamespace: serviceNamespace,
+				},
+			},
+		}
+
+		aggregatedServiceImport = &mcsv1a1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: serviceNamespace,
+			},
+		}
+	})
+
+	When("a service is exported properly", func() {
+		JustBeforeEach(func() {
+			t.createService(service)
+			t.createServiceExport(serviceExport)
+			t.createServiceImport(localServiceImport)
+			t.createServiceImport(aggregatedServiceImport)
+			t.creatEndpointSlice(endpointSlice)
+		})
+
+		It("should succeed", func() {
+			Expect(t.runServiceDiscovery()).To(Succeed())
+			t.statusTracker.assertFailureCount(0)
+			t.statusTracker.assertWarningCount(0)
+		})
+	})
+
+	When("a service is exported", func() {
+		JustBeforeEach(func() {
+			t.createServiceExport(serviceExport)
+			t.createService(service)
+		})
+
+		Context("but the ServiceExport Valid condition isn't present", func() {
+			BeforeEach(func() {
+				meta.RemoveStatusCondition(&serviceExport.Status.Conditions, mcsv1a1.ServiceExportValid)
+				meta.RemoveStatusCondition(&serviceExport.Status.Conditions, lhconstants.ServiceExportReady)
+			})
+
+			It("should fail", func() {
+				Expect(t.runServiceDiscovery()).NotTo(Succeed())
+				t.statusTracker.assertFailureCount(1)
+			})
+		})
+
+		Context("but the ServiceExport Valid condition status is False", func() {
+			BeforeEach(func() {
+				meta.FindStatusCondition(serviceExport.Status.Conditions, mcsv1a1.ServiceExportValid).Status = metav1.ConditionFalse
+				meta.RemoveStatusCondition(&serviceExport.Status.Conditions, lhconstants.ServiceExportReady)
+			})
+
+			It("should fail", func() {
+				Expect(t.runServiceDiscovery()).NotTo(Succeed())
+				t.statusTracker.assertFailureCount(1)
+			})
+		})
+
+		Context("but the ServiceExport Ready condition status is False", func() {
+			BeforeEach(func() {
+				meta.FindStatusCondition(serviceExport.Status.Conditions, lhconstants.ServiceExportReady).Status = metav1.ConditionFalse
+			})
+
+			It("should fail", func() {
+				Expect(t.runServiceDiscovery()).NotTo(Succeed())
+				t.statusTracker.assertHasFailure()
+			})
+		})
+
+		Context("but no EndpointSlice exists", func() {
+			BeforeEach(func() {
+				t.createServiceImport(localServiceImport)
+				t.createServiceImport(aggregatedServiceImport)
+			})
+
+			It("should fail", func() {
+				Expect(t.runServiceDiscovery()).NotTo(Succeed())
+				t.statusTracker.assertFailureCount(1)
+			})
+		})
+
+		Context("but no local ServiceImport exists", func() {
+			It("should fail", func() {
+				Expect(t.runServiceDiscovery()).NotTo(Succeed())
+				t.statusTracker.assertFailureCount(1)
+			})
+		})
+
+		Context("but no aggregate ServiceImport exists", func() {
+			BeforeEach(func() {
+				t.createServiceImport(localServiceImport)
+				t.creatEndpointSlice(endpointSlice)
+			})
+
+			It("should fail", func() {
+				Expect(t.runServiceDiscovery()).NotTo(Succeed())
+				t.statusTracker.assertFailureCount(1)
+			})
+		})
+	})
+
+	When("a ServiceExport exists but the Service resource is missing", func() {
+		JustBeforeEach(func() {
+			meta.FindStatusCondition(serviceExport.Status.Conditions, mcsv1a1.ServiceExportValid).Status = metav1.ConditionFalse
+			t.createServiceExport(serviceExport)
+		})
+
+		It("should succeed but emit a warning", func() {
+			Expect(t.runServiceDiscovery()).To(Succeed())
+			t.statusTracker.assertFailureCount(0)
+			t.statusTracker.assertWarningCount(1)
+		})
+	})
+
+	When("no services are exported", func() {
+		It("should succeed", func() {
+			Expect(t.runServiceDiscovery()).To(Succeed())
+			t.statusTracker.assertFailureCount(0)
+			t.statusTracker.assertWarningCount(0)
+		})
+	})
+
+	When("ServiceExports retrieval fails", func() {
+		BeforeEach(func() {
+			t.createServiceExport(serviceExport)
+			fake.FailOnAction(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceexports", "list", nil, false)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.assertFailureCount(1)
+		})
+	})
+
+	When("Service retrieval fails", func() {
+		BeforeEach(func() {
+			t.createService(service)
+			t.createServiceExport(serviceExport)
+			fake.FailOnAction(&t.fakeProducer.KubeClient.(*k8sfake.Clientset).Fake, "services", "get", nil, false)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.assertFailureCount(1)
+		})
+	})
+
+	When("ServiceImport retrieval fails", func() {
+		BeforeEach(func() {
+			t.createService(service)
+			t.createServiceExport(serviceExport)
+			t.createServiceImport(localServiceImport)
+			fake.FailOnAction(&t.fakeProducer.DynamicClient.(*dynamicfake.FakeDynamicClient).Fake, "serviceimports", "list", nil, false)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.assertFailureCount(1)
+		})
+	})
+
+	When("EndpointSlice retrieval fails", func() {
+		BeforeEach(func() {
+			t.createService(service)
+			t.createServiceExport(serviceExport)
+			t.createServiceImport(localServiceImport)
+			t.createServiceImport(aggregatedServiceImport)
+			t.creatEndpointSlice(endpointSlice)
+			fake.FailOnAction(&t.fakeProducer.KubeClient.(*k8sfake.Clientset).Fake, "endpointslices", "list", nil, false)
+		})
+
+		It("should fail", func() {
+			Expect(t.runServiceDiscovery()).NotTo(Succeed())
+			t.statusTracker.assertFailureCount(1)
+		})
+	})
+}
+
+func (t *testDriver) runServiceDiscovery() error {
+	return diagnose.ServiceDiscovery(newClusterInfo(), "", t.statusTracker)
+}


### PR DESCRIPTION
For each aggregated `ServiceImport` on the broker, check if the local `ServiceImport` exists. If it doesn't, emit a failure. If the service namespace doesn't exist, emit a warning as it may be intentional.
    
A preliminary commit adds unit tests for the existing service export diagnosis code and makes some adjustments/improvements.

Fixes https://github.com/submariner-io/subctl/issues/1462
