### PR TITLE
Use non-root user in Konflux Dockerfile

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -31,6 +31,8 @@ ARG BASE_BRANCH
 ARG SOURCE
 ARG TARGETPLATFORM
 
+RUN adduser -r -l -u 1001010000 subctl
+
 WORKDIR /
 COPY --from=builder \
     ${SOURCE}/bin/${TARGETPLATFORM}/subctl \
@@ -40,6 +42,8 @@ RUN chown 0:0 /usr/local/bin/subctl && \
     chmod 500 /usr/local/bin/subctl
 
 COPY --from=builder ${SOURCE}/LICENSE /licenses/LICENSE
+
+USER 1001010000
 
 ENTRYPOINT ["/usr/local/bin/subctl"]
 


### PR DESCRIPTION
Fixes an openshift-preflight check.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
