### PR TITLE
Enable errchkjson checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,13 @@ linters:
           deny:
             - pkg: github.com/mcuadros/go-version
               desc: Use coreos/go-semver instead
+    errcheck:
+      exclude-functions:
+        - encoding/json.Marshal
+        - encoding/json.MarshalIndent
+    errchkjson:
+      check-error-free-encoding: true
+      report-no-exported: true
     gocritic:
       disabled-checks:
         - ifElseChain


### PR DESCRIPTION
These are disabled by default, even when the linter itself is enabled. This enables them and configures errcheck appropriately (json.Marshal and json.MarshalIndent are checked by errchkjson and shouldn't be checked by errcheck).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
