### PR TITLE
Add bump-task-refs step to Konflux setup workflow

### DIFF
--- a/.agents/workflows/konflux-subctl-setup.md
+++ b/.agents/workflows/konflux-subctl-setup.md
@@ -52,7 +52,31 @@ git add .tekton/subctl-0-${TARGET_VERSION}-*.yaml package/Dockerfile.subctl.konf
 git commit -s -m "Add Konflux config for subctl"
 ```
 
-##### 5. Review and Push
+##### 5. Update Tekton Task References
+
+```bash
+bash << 'EOF'
+set -e
+
+PATCHER_SHA="b001763bb1cd0286a894cfb570fe12dd7f4504bd"
+EXPECTED_SHA256="080ad5d7cf7d0cee732a774b7e4dda0e2ccf26b58e08a8516a3b812bc73beb53"
+
+SCRIPT=$(curl -sL "https://raw.githubusercontent.com/simonbaird/konflux-pipeline-patcher/${PATCHER_SHA}/pipeline-patcher")
+ACTUAL_SHA256=$(echo "$SCRIPT" | sha256sum | cut -d' ' -f1)
+
+if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+  echo "ERROR: Script checksum mismatch!"
+  exit 1
+fi
+
+echo "$SCRIPT" | bash -s bump-task-refs
+EOF
+git diff --quiet .tekton/*.yaml || \
+  { git add .tekton/*.yaml && \
+    git commit -s -m "Update Tekton task references to latest versions"; }
+```
+
+##### 6. Review and Push
 
 ```bash
 git log origin/<target-branch>..HEAD
@@ -60,7 +84,7 @@ git status
 git push origin konflux-subctl-<X-Y> --force-with-lease
 ```
 
-Expected: 2 commits (bot's initial + your configuration), clean working tree.
+Expected: 3 commits (bot's initial + configuration + task refs update), clean working tree.
 
 **Troubleshooting:**
 


### PR DESCRIPTION
The workflow was missing the step to update Tekton task references to their latest trusted SHAs, causing EC violations after setup.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
