### PR TITLE
Adjust to golangci-lint v2.7.2

### DIFF
--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -326,6 +326,7 @@ func getTargetPort(submariner *v1alpha1.Submariner, endpoint *subv1.Endpoint, tg
 	switch endpoint.Spec.Backend {
 	case Libreswan, Wireguard, VxLAN:
 		if tgtport == TunnelPort {
+			//nolint:gosec // Tgnore integer overflow conversion int -> int32
 			targetPort, err = endpoint.Spec.GetBackendPort(subv1.UDPPortConfig, int32(submariner.Spec.CeIPSecNATTPort))
 			if err != nil {
 				return 0, fmt.Errorf("error reading tunnel port: %w", err)


### PR DESCRIPTION
Revert the prior `nolint:gosec` removals due to v2.7.1.

Depends on https://github.com/submariner-io/shipyard/pull/2231