### PR TITLE
Support  custom subnets in RHOS cloud prepare

### DIFF
--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -79,6 +79,8 @@ func init() {
 		"Number of gateways to deploy")
 	rhosPrepareCmd.Flags().StringVar(&rhosConfig.GWInstanceType, "gateway-instance", "PnTAE.CPU_4_Memory_8192_Disk_50",
 		"Type of gateway instance machine")
+	rhosPrepareCmd.Flags().StringSliceVar(&rhosConfig.SubnetNames, "subnet-names", []string{},
+		"Custom subnet names (comma-separated) for dual-stack or custom network configurations")
 
 	cloudPrepareCmd.AddCommand(rhosPrepareCmd)
 

--- a/pkg/cloud/rhos/rhos.go
+++ b/pkg/cloud/rhos/rhos.go
@@ -42,6 +42,7 @@ type Config struct {
 	OcpMetadataFile string
 	CloudEntry      string
 	GWInstanceType  string
+	SubnetNames     []string
 }
 
 // RunOn runs the given function on RHOS, supplying it with a cloud instance connected to RHOS and a reporter that writes to CLI.
@@ -94,10 +95,11 @@ func RunOn(ctx context.Context, clusterInfo *cluster.Info, config *Config, statu
 	dynamicClient := clusterInfo.ClientProducer.ForDynamic()
 
 	cloudInfo := rhos.CloudInfo{
-		Client:    providerClient,
-		InfraID:   config.InfraID,
-		Region:    config.Region,
-		K8sClient: k8sClientSet,
+		Client:      providerClient,
+		InfraID:     config.InfraID,
+		Region:      config.Region,
+		SubnetNames: config.SubnetNames,
+		K8sClient:   k8sClientSet,
 	}
 	rhosCloud := rhos.NewCloud(cloudInfo)
 	msDeployer := ocp.NewK8sMachinesetDeployer(restMapper, dynamicClient)


### PR DESCRIPTION
This commit updates subctl to support multiple subnets for RHOS gateway deployment.

Usage:
  subctl cloud prepare rhos --subnet-names subnet1,subnet2 ...

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now specify custom subnet names via a new CLI flag to support dual-stack and custom network configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->