### PR TITLE
Prefixed kube context not properly handled when no context is specified for verify

### DIFF
--- a/cmd/subctl/benchmark.go
+++ b/cmd/subctl/benchmark.go
@@ -119,14 +119,12 @@ func runBenchmark(
 		intraCluster = true
 	}
 
-	framework.TestContext.OperationTimeout = verifyFlags.OperationTimeout
-	framework.TestContext.ConnectionTimeout = verifyFlags.ConnectionTimeout
-	framework.TestContext.ConnectionAttempts = verifyFlags.ConnectionAttempts
+	framework.TestContext.OperationTimeout = DefaultOperationTimeout
+	framework.TestContext.ConnectionTimeout = DefaultConnectionTimeout
+	framework.TestContext.ConnectionAttempts = DefaultConnectionAttempts
 	framework.TestContext.SubmarinerNamespace = constants.OperatorNamespace
 
 	_, reporterConfig := ginkgo.GinkgoConfiguration()
-	reporterConfig.Verbose = verifyFlags.VerboseConnectivityVerification
-	reporterConfig.JUnitReport = verifyFlags.JunitReport
 	framework.TestContext.ReporterConfig = &reporterConfig
 
 	return run(intraCluster, verbose)

--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -44,6 +44,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	DefaultOperationTimeout   uint = 240
+	DefaultConnectionTimeout  uint = 60
+	DefaultConnectionAttempts uint = 2
+)
+
 type suppressWarnings struct{}
 
 func (suppressWarnings) HandleWarningHeader(code int, agent, message string) {

--- a/cmd/subctl/subctl_suite_test.go
+++ b/cmd/subctl/subctl_suite_test.go
@@ -46,8 +46,10 @@ import (
 )
 
 const (
-	clusterName = "east"
-	brokerURL   = "https://broker-api-server"
+	clusterName    = "east"
+	remoteCluster  = "west"
+	remoteCluster2 = "north"
+	brokerURL      = "https://broker-api-server"
 )
 
 var (
@@ -101,6 +103,16 @@ var _ = BeforeSuite(func() {
 	}
 	clientConfig.CurrentContext = clusterName
 
+	clientConfig.Clusters[remoteCluster] = &api.Cluster{}
+	clientConfig.Contexts[remoteCluster] = &api.Context{
+		Cluster: remoteCluster,
+	}
+
+	clientConfig.Clusters[remoteCluster2] = &api.Cluster{}
+	clientConfig.Contexts[remoteCluster2] = &api.Context{
+		Cluster: remoteCluster2,
+	}
+
 	kubeConfigFileName = clientfake.CreateKubeConfigFile(clientConfig)
 })
 
@@ -133,6 +145,8 @@ func setupPrompts(respValues map[string]any) {
 		case *survey.Input:
 			msg = p.Message
 		case *survey.Select:
+			msg = p.Message
+		case *survey.Confirm:
 			msg = p.Message
 		}
 

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -56,17 +56,24 @@ type VerifyOptions struct {
 var RunVerify func(options VerifyOptions, fromClusterInfo, toClusterInfo, extraClusterInfo *cluster.Info,
 	namespace string, specLabels []string) error
 
-var verifyFlags VerifyOptions
+type verifyCommand struct {
+	cmd                *cobra.Command
+	flags              VerifyOptions
+	restConfigProducer *restconfig.Producer
+}
 
-var verifyRestConfigProducer = restconfig.NewProducer().
-	WithPrefixedContext("to").
-	WithPrefixedContext("extra").
-	WithDefaultNamespace(constants.OperatorNamespace)
+func NewVerifyCmd() *cobra.Command {
+	verifyCmd := &verifyCommand{
+		restConfigProducer: restconfig.NewProducer().
+			WithPrefixedContext("to").
+			WithPrefixedContext("extra").
+			WithDefaultNamespace(constants.OperatorNamespace),
+	}
 
-var verifyCmd = &cobra.Command{
-	Use:   "verify --context <kubeContext1> --tocontext <kubeContext2> [--extracontext <kubeContext3>]",
-	Short: "Run verifications between two clusters",
-	Long: `This command performs various tests to verify that a Submariner deployment between two clusters,
+	verifyCmd.cmd = &cobra.Command{
+		Use:   "verify --context <kubeContext1> --tocontext <kubeContext2> [--extracontext <kubeContext3>]",
+		Short: "Run verifications between two clusters",
+		Long: `This command performs various tests to verify that a Submariner deployment between two clusters,
 specified via the --context and --tocontext args, is functioning properly. Some Service Discovery tests require a third cluster,
 specified via the --extracontext arg, to verify additional functionality. If the third cluster is not specified,
 those tests are skipped. The verifications performed are controlled by the --only and --enable-disruptive flags.
@@ -79,61 +86,69 @@ disruptive verifications are skipped.
 The following verifications are deemed disruptive:
 
     ` + strings.Join(disruptiveVerificationNames(), "\n    "),
-	Args: checkVerifyArguments,
-	Run: func(cmd *cobra.Command, _ []string) {
-		exit.OnError(verifyRestConfigProducer.RunOnSelectedContext(
-			func(fromClusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
-				// Try to run using the "to" context
-				toContextPresent, err := verifyRestConfigProducer.RunOnSelectedPrefixedContext(
-					"to",
-					func(toClusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-						extraContextPresent, err := verifyRestConfigProducer.RunOnSelectedPrefixedContext(
-							"extra",
-							func(extraClusterInfo *cluster.Info, _ string, _ reporter.Interface) error {
-								return RunVerify(verifyFlags, fromClusterInfo, toClusterInfo, extraClusterInfo, namespace,
-									determineSpecLabelsToVerify())
-							}, status)
-						if extraContextPresent {
-							return err //nolint:wrapcheck // No need to wrap errors here.
-						}
+		Args: verifyCmd.checkVerifyArguments,
+		Run: func(cmd *cobra.Command, _ []string) {
+			exit.OnError(verifyCmd.restConfigProducer.RunOnSelectedContext(
+				func(fromClusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
+					// Try to run using the "to" context
+					toContextPresent, err := verifyCmd.restConfigProducer.RunOnSelectedPrefixedContext(
+						"to",
+						func(toClusterInfo *cluster.Info, _ string, status reporter.Interface) error {
+							extraContextPresent, err := verifyCmd.restConfigProducer.RunOnSelectedPrefixedContext(
+								"extra",
+								func(extraClusterInfo *cluster.Info, _ string, _ reporter.Interface) error {
+									return RunVerify(verifyCmd.flags, fromClusterInfo, toClusterInfo, extraClusterInfo, namespace,
+										verifyCmd.determineSpecLabelsToVerify())
+								}, status)
+							if extraContextPresent {
+								return err //nolint:wrapcheck // No need to wrap errors here.
+							}
 
-						return RunVerify(verifyFlags, fromClusterInfo, toClusterInfo, nil, namespace, determineSpecLabelsToVerify())
-					}, status)
+							return RunVerify(verifyCmd.flags, fromClusterInfo, toClusterInfo, nil, namespace,
+								verifyCmd.determineSpecLabelsToVerify())
+						}, status)
 
-				if toContextPresent {
-					return err //nolint:wrapcheck // No need to wrap errors here.
-				}
+					if toContextPresent {
+						return err //nolint:wrapcheck // No need to wrap errors here.
+					}
 
-				exit.WithMessage("This command requires two kube contexts corresponding to the two clusters to verify.\n" +
-					cmd.UsageString())
-				return nil
-			}, cli.NewReporter()))
-	},
+					exit.WithMessage("This command requires two kube contexts corresponding to the two clusters to verify.\n" +
+						cmd.UsageString())
+
+					return nil
+				}, cli.NewReporter()))
+		},
+	}
+
+	verifyCmd.restConfigProducer.SetupFlags(verifyCmd.cmd.Flags())
+	verifyCmd.addFlags()
+	addImageOverrideFlag(verifyCmd.cmd.PersistentFlags(), &imageOverrides)
+
+	return verifyCmd.cmd
 }
 
 func init() {
-	verifyRestConfigProducer.SetupFlags(verifyCmd.Flags())
-	addVerifyFlags(verifyCmd)
-	rootCmd.AddCommand(verifyCmd)
-
-	addImageOverrideFlag(verifyCmd.PersistentFlags(), &imageOverrides)
+	rootCmd.AddCommand(NewVerifyCmd())
 	framework.AddBeforeSuite(setupTestFrameworkBeforeSuite)
 }
 
-func addVerifyFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&verifyFlags.VerboseConnectivityVerification, "verbose", false,
+func (c *verifyCommand) addFlags() {
+	c.cmd.Flags().BoolVar(&c.flags.VerboseConnectivityVerification, "verbose", false,
 		"produce verbose logs during connectivity verification")
-	cmd.Flags().UintVar(&verifyFlags.OperationTimeout, "operation-timeout", 240, "operation timeout for K8s API calls")
-	cmd.Flags().UintVar(&verifyFlags.ConnectionTimeout, "connection-timeout", 60, "timeout in seconds per connection attempt")
-	cmd.Flags().UintVar(&verifyFlags.ConnectionAttempts, "connection-attempts", 2, "maximum number of connection attempts")
-	cmd.Flags().StringVar(&verifyFlags.JunitReport, "junit-report", "", "XML report path and report name")
-	cmd.Flags().StringVar(&verifyFlags.VerifyOnly, "only", strings.Join(getAllVerifyKeys(), ","),
+	c.cmd.Flags().UintVar(&c.flags.OperationTimeout, "operation-timeout", DefaultOperationTimeout,
+		"operation timeout for K8s API calls")
+	c.cmd.Flags().UintVar(&c.flags.ConnectionTimeout, "connection-timeout", DefaultConnectionTimeout,
+		"timeout in seconds per connection attempt")
+	c.cmd.Flags().UintVar(&c.flags.ConnectionAttempts, "connection-attempts", DefaultConnectionAttempts,
+		"maximum number of connection attempts")
+	c.cmd.Flags().StringVar(&c.flags.JunitReport, "junit-report", "", "XML report path and report name")
+	c.cmd.Flags().StringVar(&c.flags.VerifyOnly, "only", strings.Join(getAllVerifyKeys(), ","),
 		"comma separated verifications to be performed")
-	cmd.Flags().BoolVar(&verifyFlags.DisruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
-	cmd.Flags().UintVar(&verifyFlags.PacketSize, "packet-size", 3000, "set packet size used in TCP connectivity tests")
-	cmd.Flags().BoolVar(&verifyFlags.SkipConnectorSrcIPCheck, "skip-src-ip-check", false,
+	c.cmd.Flags().BoolVar(&c.flags.DisruptiveTests, "disruptive-tests", false, "enable disruptive verifications like gateway-failover")
+	c.cmd.Flags().UintVar(&c.flags.PacketSize, "packet-size", 3000, "set packet size used in TCP connectivity tests")
+	c.cmd.Flags().BoolVar(&c.flags.SkipConnectorSrcIPCheck, "skip-src-ip-check", false,
 		"skip source IP verification for connector pod traffic")
-	cmd.Flags().BoolVar(&verifyFlags.SkipIntraClusterConnectivityTests,
+	c.cmd.Flags().BoolVar(&c.flags.SkipIntraClusterConnectivityTests,
 		"skip-intra-cluster-connectivity-tests", false,
 		"skip tests that verify intra-cluster connectivity")
 }
@@ -156,16 +171,16 @@ func isNonInteractive(err error) bool {
 	return false
 }
 
-func checkVerifyArguments(cmd *cobra.Command, args []string) error {
-	if verifyFlags.ConnectionAttempts < 1 {
+func (c *verifyCommand) checkVerifyArguments(cmd *cobra.Command, args []string) error {
+	if c.flags.ConnectionAttempts < 1 {
 		return errors.New("--connection-attempts must be >=1")
 	}
 
-	if verifyFlags.ConnectionTimeout < 20 {
+	if c.flags.ConnectionTimeout < 20 {
 		return errors.New("--connection-timeout must be >=20")
 	}
 
-	if _, _, err := getVerifySpecLabels(verifyFlags.VerifyOnly, true); err != nil {
+	if _, _, err := getVerifySpecLabels(c.flags.VerifyOnly, true); err != nil {
 		return err
 	}
 
@@ -274,13 +289,13 @@ func getVerifySpecLabels(csv string, includeDisruptive bool) ([]string, []string
 	return outputLabels, outputVerifications, nil
 }
 
-func determineSpecLabelsToVerify() []string {
-	disruptive := extractDisruptiveVerifications(verifyFlags.VerifyOnly)
-	if !verifyFlags.DisruptiveTests && len(disruptive) > 0 {
-		err := survey.AskOne(&survey.Confirm{
+func (c *verifyCommand) determineSpecLabelsToVerify() []string {
+	disruptive := extractDisruptiveVerifications(c.flags.VerifyOnly)
+	if !c.flags.DisruptiveTests && len(disruptive) > 0 {
+		err := survey.AskOne(NewInputPrompt(&survey.Confirm{
 			Message: fmt.Sprintf("You have specified disruptive verifications (%s). Are you sure you want to run them?",
 				strings.Join(disruptive, ",")),
-		}, &verifyFlags.DisruptiveTests)
+		}), &c.flags.DisruptiveTests)
 		if err != nil {
 			if isNonInteractive(err) {
 				fmt.Printf(`
@@ -292,7 +307,7 @@ prompt for confirmation therefore you must specify --enable-disruptive to run th
 		}
 	}
 
-	labels, verifications, err := getVerifySpecLabels(verifyFlags.VerifyOnly, verifyFlags.DisruptiveTests)
+	labels, verifications, err := getVerifySpecLabels(c.flags.VerifyOnly, c.flags.DisruptiveTests)
 	if err != nil {
 		exit.WithMessage(err.Error())
 	}

--- a/cmd/subctl/verify_test.go
+++ b/cmd/subctl/verify_test.go
@@ -1,0 +1,241 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subctl_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	lhlabels "github.com/submariner-io/lighthouse/test/e2e/labels"
+	"github.com/submariner-io/subctl/cmd/subctl"
+	"github.com/submariner-io/subctl/pkg/cluster"
+	submlabels "github.com/submariner-io/submariner/test/e2e/labels"
+)
+
+var _ = Describe("Verify", func() {
+	Context("with no arguments", func() {
+		t := newVerifyTestDriver()
+
+		Context("and the disruptive verification prompt is confirmed", func() {
+			BeforeEach(func() {
+				setupPrompts(map[string]any{
+					"disruptive verifications": true,
+				})
+			})
+
+			It("should invoke verify with all defaults", func() {
+				t.assertCmdSuccess()
+				Expect(t.runVerifyCalled).To(BeTrue())
+				Expect(t.verifyOptions.OperationTimeout).To(Equal(subctl.DefaultOperationTimeout))
+				Expect(t.verifyOptions.ConnectionTimeout).To(Equal(subctl.DefaultConnectionTimeout))
+				Expect(t.verifyOptions.ConnectionAttempts).To(Equal(subctl.DefaultConnectionAttempts))
+				Expect(t.fromClusterName).To(Equal(clusterName))
+				Expect(t.toClusterName).To(Equal(remoteCluster))
+				Expect(t.specLabels).To(ContainElements(lhlabels.ServiceDiscovery, submlabels.Compliance, submlabels.Redundancy,
+					ContainSubstring(submlabels.Dataplane)))
+				Expect(t.extraClusterName).To(BeEmpty())
+			})
+		})
+
+		Context("and the disruptive verification prompt is not confirmed", func() {
+			BeforeEach(func() {
+				setupPrompts(map[string]any{
+					"disruptive verifications": false,
+				})
+			})
+
+			It("should invoke verify with only non-disruptive spec labels", func() {
+				t.assertCmdSuccess()
+				Expect(t.runVerifyCalled).To(BeTrue())
+				Expect(t.specLabels).To(ContainElements(lhlabels.ServiceDiscovery, submlabels.Compliance,
+					ContainSubstring(submlabels.Dataplane)))
+				Expect(t.specLabels).NotTo(ContainElements(submlabels.Redundancy))
+			})
+		})
+	})
+
+	Context("with --extracontext specified", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--extracontext="+remoteCluster2, "--only=connectivity")
+		})
+
+		It("should invoke verify with three clusters", func() {
+			t.assertCmdSuccess()
+			Expect(t.runVerifyCalled).To(BeTrue())
+			Expect(t.fromClusterName).To(Equal(clusterName))
+			Expect(t.toClusterName).To(Equal(remoteCluster))
+			Expect(t.extraClusterName).To(Equal(remoteCluster2))
+		})
+	})
+
+	Context("with various flags specified", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--only=connectivity", "--verbose", "--operation-timeout=300", "--connection-timeout=90",
+				"--connection-attempts=5", "--packet-size=1500", "--junit-report=/tmp/report.xml", "--skip-src-ip-check",
+				"--skip-intra-cluster-connectivity-tests")
+		})
+
+		It("should invoke verify with the specified values", func() {
+			t.assertCmdSuccess()
+			Expect(t.runVerifyCalled).To(BeTrue())
+			Expect(t.specLabels).To(ContainElements(ContainSubstring(submlabels.Dataplane)))
+			Expect(t.verifyOptions.VerboseConnectivityVerification).To(BeTrue())
+			Expect(t.verifyOptions.OperationTimeout).To(Equal(uint(300)))
+			Expect(t.verifyOptions.ConnectionTimeout).To(Equal(uint(90)))
+			Expect(t.verifyOptions.ConnectionAttempts).To(Equal(uint(5)))
+			Expect(t.verifyOptions.PacketSize).To(Equal(uint(1500)))
+			Expect(t.verifyOptions.JunitReport).To(Equal("/tmp/report.xml"))
+			Expect(t.verifyOptions.SkipConnectorSrcIPCheck).To(BeTrue())
+			Expect(t.verifyOptions.SkipIntraClusterConnectivityTests).To(BeTrue())
+		})
+	})
+
+	Context("with --disruptive-tests specified", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--disruptive-tests", "--only=gateway-failover")
+		})
+
+		It("should invoke verify without prompting", func() {
+			t.assertCmdSuccess()
+			Expect(t.verifyOptions.DisruptiveTests).To(BeTrue())
+			Expect(t.specLabels).To(Equal([]string{submlabels.Redundancy}))
+		})
+	})
+
+	Context("with --only specified with multiple verifications", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--only=connectivity,service-discovery")
+		})
+
+		It("should invoke verify with the correct spec labels", func() {
+			t.assertCmdSuccess()
+			Expect(t.specLabels).To(ConsistOf(ContainSubstring(submlabels.Dataplane), lhlabels.ServiceDiscovery))
+		})
+	})
+
+	Context("without --tocontext specified", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = []string{}
+		})
+
+		It("should exit with an error message", func() {
+			Expect(t.cmd.Execute()).To(Succeed())
+			Expect(t.exited).To(BeTrue())
+		})
+	})
+
+	Context("with invalid connection-attempts", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--connection-attempts=0")
+		})
+
+		It("should fail argument validation", func() {
+			Expect(t.cmd.Execute()).NotTo(Succeed())
+		})
+	})
+
+	Context("with invalid connection-timeout", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--connection-timeout=10")
+		})
+
+		It("should fail argument validation", func() {
+			Expect(t.cmd.Execute()).NotTo(Succeed())
+		})
+	})
+
+	Context("with invalid verification name", func() {
+		t := newVerifyTestDriver()
+
+		BeforeEach(func() {
+			t.args = append(t.args, "--only=invalid-verification")
+		})
+
+		It("should fail argument validation", func() {
+			Expect(t.cmd.Execute()).NotTo(Succeed())
+		})
+	})
+})
+
+type verifyTestDriver struct {
+	*testDriver
+	runVerifyCalled  bool
+	fromClusterName  string
+	toClusterName    string
+	extraClusterName string
+	verifyOptions    subctl.VerifyOptions
+	specLabels       []string
+}
+
+func newVerifyTestDriver() *verifyTestDriver {
+	t := &verifyTestDriver{testDriver: newTestDriver()}
+
+	BeforeEach(func() {
+		t.cmd = subctl.NewVerifyCmd()
+		t.runVerifyCalled = false
+		t.fromClusterName = ""
+		t.toClusterName = ""
+		t.extraClusterName = ""
+		t.verifyOptions = subctl.VerifyOptions{}
+		t.specLabels = nil
+
+		subctl.RunVerify = func(options subctl.VerifyOptions, fromClusterInfo, toClusterInfo, extraClusterInfo *cluster.Info,
+			namespace string, specLabels []string,
+		) error {
+			t.runVerifyCalled = true
+			t.verifyOptions = options
+			t.fromClusterName = ""
+			t.toClusterName = ""
+			t.extraClusterName = ""
+
+			if fromClusterInfo != nil {
+				t.fromClusterName = fromClusterInfo.Name
+			}
+
+			if toClusterInfo != nil {
+				t.toClusterName = toClusterInfo.Name
+			}
+
+			if extraClusterInfo != nil {
+				t.extraClusterName = extraClusterInfo.Name
+			}
+
+			t.specLabels = specLabels
+
+			return nil
+		}
+
+		t.args = append(t.args, "--tocontext="+remoteCluster)
+	})
+
+	return t
+}

--- a/internal/restconfig/producer_test.go
+++ b/internal/restconfig/producer_test.go
@@ -788,6 +788,19 @@ func testRunOnSelectedPrefixedContext() {
 			Expect(err).To(Succeed())
 			Expect(wasRun).To(BeFalse())
 		})
+
+		Context("and an explicit kubeconfig is specified", func() {
+			JustBeforeEach(func() {
+				Expect(t.flags.Set("kubeconfig", clientfake.CreateKubeConfigFile(t.clientConfig))).To(Succeed())
+			})
+
+			It("should return false", func() {
+				wasRun, err := t.producer.RunOnSelectedPrefixedContext(prefix, t.noopPerContext, reporter.Stdout())
+
+				Expect(err).To(Succeed())
+				Expect(wasRun).To(BeFalse())
+			})
+		})
 	})
 }
 

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -271,10 +271,7 @@ func (rcp *Producer) RunOnSelectedPrefixedContext(prefix string, function PerCon
 		contextKubeConfig, ok := rcp.prefixedKubeConfigs[prefix]
 		if ok && contextKubeConfig != nil && *contextKubeConfig != "" {
 			loadingRules.ExplicitPath = *contextKubeConfig
-		}
-
-		// Has the user actually specified a value for the prefixed context?
-		if loadingRules.ExplicitPath == "" && areOverridesEmpty(clientConfig.overrides) {
+		} else if areOverridesEmpty(clientConfig.overrides) { // Has the user actually specified a value for the prefixed context?
 			return false, nil
 		}
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -70,7 +70,7 @@ func runVerify(options subctl.VerifyOptions, fromClusterInfo, toClusterInfo, ext
 	suiteConfig.RandomSeed = 1
 	suiteConfig.LabelFilter = strings.Join(specLabels, "||")
 
-	if fromClusterInfo.Submariner.Spec.GlobalCIDR != "" {
+	if fromClusterInfo.Submariner != nil && fromClusterInfo.Submariner.Spec.GlobalCIDR != "" {
 		suiteConfig.LabelFilter = strings.ReplaceAll(suiteConfig.LabelFilter, "!"+submlabels.Globalnet, submlabels.Globalnet)
 	}
 


### PR DESCRIPTION
For the `verify` command, if `--kubeconfig` is explicitly specified, eg

  `subctl verify --kubeconfig some-kubeconfig-file --context cluster1 --tocontext cluster2`

without specifying `--extracontext`, the `extra` context will be set to the current context defined in the kubeconfig file and the tests will erroneously run with three clusters. A similar issue is seen if `--tocontext` isn't specified, ie it will use the  current context as the `to` context. In this case, the command should fail stating it requires two kube contexts, which it does if `--kubeconfig` isn't specified (in which case it uses a kubeconfig file found on the path). 

I narrowed the issue down to this code:

https://github.com/submariner-io/subctl/blob/5173f74a97d52cc18fb61ce1b787ad3f547749bf/internal/restconfig/restconfig.go#L270-L278

When `--kubeconfig` isn't specified, then `loadingRules.ExplicitPath` is empty and it returns false on L278. However, if `--kubeconfig` is specified, the prefixed context config inherits that and `loadingRules.ExplicitPath` is set so it doesn't reach L278 and uses the current context if the prefixed context isn't specified. If `--toconfig` is set, then `loadingRules.ExplicitPath` is set from from the `rcp.prefixedKubeConfigs` map on L273. In this case, it's proper to use the current context if the prefixed context isn't specified, otherwise require the prefixed context to be specified.

I also added unit tests for the `verify` command (and refactored the code to make it testable), one of which exposed the issue.

**Note**: The `benchmark` command was referencing the global `verifyFlags` to set `TestContext` fields. Even though the `benchmark` command does not provide them as CLI flags, they were implicitly getting initialized as a side effect of the `verify` command using them as flags. However, now that `verifyFlags` is no longer global, the `TestContext` fields are now explicitly set from global constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential crash in verify operations due to missing nil-check guard.

* **Tests**
  * Expanded test coverage for verify command scenarios and configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->