### PR TITLE
Use cmd.Context() over context.TODO() for Cobra handlers

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -22,8 +22,6 @@ limitations under the License.
 package subctl
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/cloud-prepare/pkg/aws/client"
@@ -43,11 +41,10 @@ var (
 		Short:   "Prepare an OpenShift AWS cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on AWS cloud for Submariner installation.",
 		PreRunE: checkAWSFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.AWS(
-						context.TODO(), clusterInfo, &cloudOptions.ports, &awsConfig, cloudOptions.useLoadBalancer, status)
+					return prepare.AWS(cmd.Context(), clusterInfo, &cloudOptions.ports, &awsConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}
@@ -58,10 +55,10 @@ var (
 		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on " +
 			"AWS-based cloud after Submariner uninstallation.",
 		PreRunE: checkAWSFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.AWS(context.TODO(), clusterInfo, &awsConfig, status)
+					return cleanup.AWS(cmd.Context(), clusterInfo, &awsConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/azure.go
+++ b/cmd/subctl/azure.go
@@ -22,8 +22,6 @@ limitations under the License.
 package subctl
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/cli"
@@ -42,11 +40,10 @@ var (
 		Short:   "Prepare an OpenShift Azure cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on Azure cloud for Submariner installation.",
 		PreRunE: checkAzureFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.Azure(
-						context.TODO(), clusterInfo, &cloudOptions.ports, &azureConfig, cloudOptions.useLoadBalancer, status)
+					return prepare.Azure(cmd.Context(), clusterInfo, &cloudOptions.ports, &azureConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}
@@ -57,10 +54,10 @@ var (
 		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on " +
 			"Azure-based cloud after Submariner uninstallation.",
 		PreRunE: checkAzureFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.Azure(context.TODO(), clusterInfo, &azureConfig, status)
+					return cleanup.Azure(cmd.Context(), clusterInfo, &azureConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/gcp.go
+++ b/cmd/subctl/gcp.go
@@ -21,7 +21,6 @@ limitations under the License.
 package subctl
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 
@@ -43,11 +42,10 @@ var (
 		Short:   "Prepare an OpenShift GCP cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on GCP cloud for Submariner installation.",
 		PreRunE: checkGCPFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.GCP(
-						context.TODO(), clusterInfo, &cloudOptions.ports, &gcpConfig, cloudOptions.useLoadBalancer, status)
+					return prepare.GCP(cmd.Context(), clusterInfo, &cloudOptions.ports, &gcpConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}
@@ -57,10 +55,10 @@ var (
 		Short:   "Clean up a GCP cloud",
 		Long:    "This command cleans up an installer-provisioned infrastructure (IPI) on GCP-based cloud after Submariner uninstallation.",
 		PreRunE: checkGCPFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.GCP(context.TODO(), clusterInfo, &gcpConfig, status)
+					return cleanup.GCP(cmd.Context(), clusterInfo, &gcpConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -67,7 +67,7 @@ func NewJoinCmd() *cobra.Command {
 		Args: func(cmd *cobra.Command, args []string) error {
 			return joinCmd.checkArguments(args)
 		},
-		Run: func(_ *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, args []string) {
 			status := NewReporter()
 
 			brokerInfo, err := broker.ReadInfoFromFile(args[0])
@@ -81,7 +81,7 @@ func NewJoinCmd() *cobra.Command {
 
 			exit.OnError(joinCmd.restConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return joinCmd.joinInContext(brokerInfo, clusterInfo, status)
+					return joinCmd.joinInContext(cmd.Context(), brokerInfo, clusterInfo, status)
 				}, status))
 		},
 	}
@@ -174,16 +174,16 @@ func (c *JoinCommand) addFlags() {
 	)
 }
 
-func (c *JoinCommand) joinInContext(brokerInfo *broker.Info, clusterInfo *cluster.Info, status reporter.Interface) error {
+func (c *JoinCommand) joinInContext(ctx context.Context, brokerInfo *broker.Info, clusterInfo *cluster.Info, status reporter.Interface,
+) error {
 	c.determineClusterID(clusterInfo.Name, status)
 
-	ctx := context.TODO()
 	networkDetails := getNetworkDetails(ctx, clusterInfo.ClientProducer, status)
 	c.flags.ClusterCIDR = determineCIDR("Pod", c.flags.ClusterCIDR, networkDetails.PodCIDRs, status)
 	c.flags.ServiceCIDR = determineCIDR("Service", c.flags.ServiceCIDR, networkDetails.ServiceCIDRs, status)
 
 	if brokerInfo.IsConnectivityEnabled() && c.labelGateway {
-		possiblyLabelGateway(clusterInfo.ClientProducer.ForKubernetes(), status)
+		possiblyLabelGateway(ctx, clusterInfo.ClientProducer.ForKubernetes(), status)
 	}
 
 	if c.flags.CustomDomains == nil && brokerInfo.CustomDomains != nil {
@@ -193,11 +193,11 @@ func (c *JoinCommand) joinInContext(brokerInfo *broker.Info, clusterInfo *cluste
 	return JoinClusterToBroker(ctx, brokerInfo, &c.flags, clusterInfo.ClientProducer, status)
 }
 
-func possiblyLabelGateway(kubeClient kubernetes.Interface, status reporter.Interface) {
+func possiblyLabelGateway(ctx context.Context, kubeClient kubernetes.Interface, status reporter.Interface) {
 	status.Start("Retrieving the gateway nodes")
 	defer status.End()
 
-	gatewayNodes, err := nodes.ListGateways(kubeClient)
+	gatewayNodes, err := nodes.ListGateways(ctx, kubeClient)
 	exit.OnError(status.Error(err, "Error retrieving the gateway nodes"))
 
 	if len(gatewayNodes) > 0 {
@@ -213,7 +213,7 @@ func possiblyLabelGateway(kubeClient kubernetes.Interface, status reporter.Inter
 	// No Gateway nodes are present, get all worker nodes and ask user to select one of them as gateway node
 	status.Start("Retrieving all worker nodes")
 
-	workerNodes, err := nodes.GetAllWorkerNames(kubeClient)
+	workerNodes, err := nodes.GetAllWorkerNames(ctx, kubeClient)
 	exit.OnError(status.Error(err, "Error listing the worker nodes"))
 
 	status.End()
@@ -233,7 +233,7 @@ func possiblyLabelGateway(kubeClient kubernetes.Interface, status reporter.Inter
 
 	status.Start("Labeling node %q as a gateway", nodeToLabel)
 
-	err = nodes.LabelAsGateway(kubeClient, nodeToLabel)
+	err = nodes.LabelAsGateway(ctx, kubeClient, nodeToLabel)
 	exit.OnError(status.Error(err, "Error labeling node %q as a gateway", nodeToLabel))
 }
 

--- a/cmd/subctl/recover_broker_info.go
+++ b/cmd/subctl/recover_broker_info.go
@@ -49,9 +49,11 @@ func NewRecoverBrokerInfoCmd() *cobra.Command {
 	recoverCmd.cmd = &cobra.Command{
 		Use:   "recover-broker-info",
 		Short: "Recovers the broker-info.subm file from the installed Broker",
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(recoverCmd.restConfigProducer.RunOnSelectedContext(restconfig.IfConnectivityInstalled(
-				recoverCmd.recoverBrokerInfo), NewReporter()))
+				func(clusterInfo *cluster.Info, namespace string, status reporter.Interface) error {
+					return recoverCmd.recoverBrokerInfo(cmd.Context(), clusterInfo, namespace, status)
+				}), NewReporter()))
 		},
 	}
 
@@ -69,14 +71,15 @@ func init() {
 	rootCmd.AddCommand(recoverBrokerInfo)
 }
 
-func (c *RecoverBrokerCommand) recoverBrokerInfo(submCluster *cluster.Info, _ string, status reporter.Interface) error {
+func (c *RecoverBrokerCommand) recoverBrokerInfo(ctx context.Context, submCluster *cluster.Info, _ string, status reporter.Interface,
+) error {
 	brokerNamespace := submCluster.Submariner.Spec.BrokerK8sRemoteNamespace
 	brokerRestConfig := submCluster.RestConfig
 
 	status.Start("Checking if the Broker is installed on the Submariner cluster %q in namespace %q", submCluster.Name, brokerNamespace)
 	defer status.End()
 
-	brokerObj, found, err := getBroker(context.TODO(), brokerRestConfig, brokerNamespace)
+	brokerObj, found, err := getBroker(ctx, brokerRestConfig, brokerNamespace)
 	if err != nil {
 		return status.Error(err, "Error getting Broker")
 	}
@@ -89,7 +92,7 @@ func (c *RecoverBrokerCommand) recoverBrokerInfo(submCluster *cluster.Info, _ st
 			return status.Error(err, "Error getting the Broker's REST config")
 		}
 
-		brokerObj, found, err = getBroker(context.TODO(), brokerRestConfig, brokerNamespace)
+		brokerObj, found, err = getBroker(ctx, brokerRestConfig, brokerNamespace)
 		if err != nil {
 			return status.Error(err, "")
 		}

--- a/cmd/subctl/rhos.go
+++ b/cmd/subctl/rhos.go
@@ -22,8 +22,6 @@ limitations under the License.
 package subctl
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/cli"
@@ -42,11 +40,10 @@ var (
 		Short:   "Prepare an OpenShift RHOS cloud",
 		Long:    "This command prepares an OpenShift installer-provisioned infrastructure (IPI) on RHOS cloud for Submariner installation.",
 		PreRunE: checkRHOSFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return prepare.RHOS(
-						context.TODO(), clusterInfo, &cloudOptions.ports, &rhosConfig, cloudOptions.useLoadBalancer, status)
+					return prepare.RHOS(cmd.Context(), clusterInfo, &cloudOptions.ports, &rhosConfig, cloudOptions.useLoadBalancer, status)
 				}, cli.NewReporter()))
 		},
 	}
@@ -57,10 +54,10 @@ var (
 		Long: "This command cleans up an OpenShift installer-provisioned infrastructure (IPI) on RHOS-based" +
 			" cloud after Submariner uninstallation.",
 		PreRunE: checkRHOSFlags,
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			exit.OnError(cloudRestConfigProducer.RunOnSelectedContext(
 				func(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-					return cleanup.RHOS(context.TODO(), clusterInfo, &rhosConfig, status)
+					return cleanup.RHOS(cmd.Context(), clusterInfo, &rhosConfig, status)
 				}, cli.NewReporter()))
 		},
 	}

--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -88,7 +88,7 @@ func init() {
 	rootCmd.AddCommand(NewUpgradeCmd())
 }
 
-func (c *upgradeCommand) upgrade(_ *cobra.Command, _ []string) {
+func (c *upgradeCommand) upgrade(cmd *cobra.Command, _ []string) {
 	status := NewReporter()
 
 	// Step 1: upgrade subctl to match the requested version
@@ -110,7 +110,9 @@ func (c *upgradeCommand) upgrade(_ *cobra.Command, _ []string) {
 		}
 	} else {
 		// Step 2b: this subctl is already the requested version, run it
-		exit.OnError(c.restConfigProducer.RunOnAllContexts(c.upgradeSubmariner, status))
+		exit.OnError(c.restConfigProducer.RunOnAllContexts(func(info *cluster.Info, namespace string, status reporter.Interface) error {
+			return c.upgradeSubmariner(cmd.Context(), info, namespace, status)
+		}, status))
 	}
 }
 
@@ -210,9 +212,7 @@ func retrieveLatestReleaseTag() (string, error) {
 	return "", goerrors.New("no tag name found in the latest release data")
 }
 
-func (c *upgradeCommand) upgradeSubmariner(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-	ctx := context.TODO()
-
+func (c *upgradeCommand) upgradeSubmariner(ctx context.Context, clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	// We only expect users to specify a subctl version, if any ("--to-version"). In such scenarios,
 	// the versions are expected to align, so subctl vX installs the operator image tagged with vX,
 	// and that operator defaults to the appropriate Submariner version.

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -36,13 +36,13 @@ import (
 )
 
 // LabelAsGateway labels the specified  node as a gateway.
-func LabelAsGateway(clientset kubernetes.Interface, nodeName string) error {
-	return addLabels(clientset, nodeName, map[string]string{constants.SubmarinerGatewayLabel: constants.TrueLabel})
+func LabelAsGateway(ctx context.Context, clientset kubernetes.Interface, nodeName string) error {
+	return addLabels(ctx, clientset, nodeName, map[string]string{constants.SubmarinerGatewayLabel: constants.TrueLabel})
 }
 
 // LabelAnyAsGateway labels any worker node as a gateway.
-func LabelAnyAsGateway(clientset kubernetes.Interface) (bool, error) {
-	workerNodes, err := GetAllWorkerNames(clientset)
+func LabelAnyAsGateway(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+	workerNodes, err := GetAllWorkerNames(ctx, clientset)
 	if err != nil {
 		return false, err
 	}
@@ -51,21 +51,19 @@ func LabelAnyAsGateway(clientset kubernetes.Interface) (bool, error) {
 		return false, nil
 	}
 
-	return true, LabelAsGateway(clientset, workerNodes[0])
+	return true, LabelAsGateway(ctx, clientset, workerNodes[0])
 }
 
 // GetAllWorkerNames returns all worker nodes.
-func GetAllWorkerNames(clientset kubernetes.Interface) ([]string, error) {
-	workerNodes, err := clientset.CoreV1().Nodes().List(
-		context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
+func GetAllWorkerNames(ctx context.Context, clientset kubernetes.Interface) ([]string, error) {
+	workerNodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing Nodes")
 	}
 
 	if len(workerNodes.Items) == 0 {
 		// In some deployments (like KIND), worker nodes are not explicitly labelled. So list non-master nodes.
-		workerNodes, err = clientset.CoreV1().Nodes().List(
-			context.TODO(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/master"})
+		workerNodes, err = clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/master"})
 		if err != nil {
 			return nil, errors.Wrap(err, "error listing Nodes")
 		}
@@ -84,10 +82,10 @@ func getNodeNames(nodes *corev1.NodeList) []string {
 }
 
 // ListGateways returns the names of all node labeled as a gateway.
-func ListGateways(clientset kubernetes.Interface) ([]string, error) {
+func ListGateways(ctx context.Context, clientset kubernetes.Interface) ([]string, error) {
 	selector := labels.SelectorFromSet(map[string]string{constants.SubmarinerGatewayLabel: constants.TrueLabel})
 
-	labeledNodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	labeledNodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing Nodes")
 	}
@@ -97,7 +95,7 @@ func ListGateways(clientset kubernetes.Interface) ([]string, error) {
 
 // this function was sourced from:
 // https://github.com/kubernetes/kubernetes/blob/a3ccea9d8743f2ff82e41b6c2af6dc2c41dc7b10/test/utils/density_utils.go#L36
-func addLabels(clientset kubernetes.Interface, nodeName string, labelsToAdd map[string]string) error {
+func addLabels(ctx context.Context, clientset kubernetes.Interface, nodeName string, labelsToAdd map[string]string) error {
 	tokens := make([]string, 0, len(labelsToAdd))
 	for k, v := range labelsToAdd {
 		tokens = append(tokens, fmt.Sprintf("%q:%q", k, v))
@@ -111,7 +109,7 @@ func addLabels(clientset kubernetes.Interface, nodeName string, labelsToAdd map[
 
 	var lastErr error
 	err := wait.ExponentialBackoff(nodeLabelBackoff, func() (bool, error) {
-		_, lastErr = clientset.CoreV1().Nodes().Patch(context.TODO(), nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+		_, lastErr = clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
 		if lastErr != nil {
 			if !k8serrors.IsConflict(lastErr) {
 				return false, lastErr //nolint:wrapcheck // No need to wrap here


### PR DESCRIPTION
This aligns with Cobra's idiomatic pattern for context handling and enables seamless integration with proper cancellation/timeout propagation if the main function is later updated to use `ExecuteContext` with signal handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal context propagation updates across cloud provider operations and cluster management workflows to improve operational control and handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->