### PR TITLE
Use Ginkgo context instead of global variables

### DIFF
--- a/cmd/subctl/join_test.go
+++ b/cmd/subctl/join_test.go
@@ -59,9 +59,9 @@ func testRunJoinCommand() {
 	})
 
 	When("with no user input", func() {
-		BeforeEach(func() {
-			t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
-			t.createGatewayNode()
+		BeforeEach(func(ctx SpecContext) {
+			t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
+			t.createGatewayNode(ctx)
 		})
 
 		It("should invoke join with the defaults", func() {
@@ -113,9 +113,9 @@ func testRunJoinCommand() {
 	When("various flags are specified on the command line", func() {
 		otherBrokerURL := "http://other-broker"
 
-		BeforeEach(func() {
-			t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
-			t.createGatewayNode()
+		BeforeEach(func(ctx SpecContext) {
+			t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
+			t.createGatewayNode(ctx)
 
 			t.args = append(t.args, "--preferred-server", "--force-udp-encaps", "--natt=false",
 				"--ignore-requirements", "--globalnet=false", "--ipsec-debug", "--pod-debug", "--operator-debug",
@@ -180,8 +180,8 @@ func testRunJoinCommand() {
 	})
 
 	When("the network details aren't discovered", func() {
-		BeforeEach(func() {
-			t.createGatewayNode()
+		BeforeEach(func(ctx SpecContext) {
+			t.createGatewayNode(ctx)
 			setupPrompts(map[string]any{"Pod CIDR": clusterCIDR, "Service CIDR": serviceCIDR})
 		})
 
@@ -201,8 +201,8 @@ func testRunJoinCommand() {
 	})
 
 	When("the cluster and service CIDRs are specified on the command line", func() {
-		BeforeEach(func() {
-			t.createGatewayNode()
+		BeforeEach(func(ctx SpecContext) {
+			t.createGatewayNode(ctx)
 
 			t.args = append(t.args, "--clustercidr="+clusterCIDR, "--servicecidr="+serviceCIDR)
 
@@ -223,8 +223,8 @@ func testRunJoinCommand() {
 		})
 
 		Context("and they match the discovered network details", func() {
-			BeforeEach(func() {
-				t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
+			BeforeEach(func(ctx SpecContext) {
+				t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
 			})
 
 			It("should invoke join with the specified values", func() {
@@ -233,8 +233,8 @@ func testRunJoinCommand() {
 		})
 
 		Context("and they don't match the discovered network details", func() {
-			BeforeEach(func() {
-				t.setupNetworkDiscovery("10.20.30.40/32", "11.20.30.40/32")
+			BeforeEach(func(ctx SpecContext) {
+				t.setupNetworkDiscovery(ctx, "10.20.30.40/32", "11.20.30.40/32")
 			})
 
 			It("should emit a warning and invoke join with the specified values", func() {
@@ -249,9 +249,9 @@ func testRunJoinCommand() {
 	When("the cluster ID is specified on the command line", func() {
 		var clusterID string
 
-		BeforeEach(func() {
-			t.createGatewayNode()
-			t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
+		BeforeEach(func(ctx SpecContext) {
+			t.createGatewayNode(ctx)
+			t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
 
 			clusterID = "north-america"
 			t.args = append(t.args, "--clusterid="+clusterID)
@@ -287,14 +287,14 @@ func testRunJoinCommand() {
 	})
 
 	When("there's one worker node", func() {
-		BeforeEach(func() {
-			t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
-			t.createNodes("worker1")
+		BeforeEach(func(ctx SpecContext) {
+			t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
+			t.createNodes(ctx, "worker1")
 		})
 
-		It("should label it as a gateway", func() {
+		It("should label it as a gateway", func(ctx SpecContext) {
 			t.assertCmdSuccess()
-			Expect(t.getNode("worker1").Labels).To(HaveKeyWithValue(constants.SubmarinerGatewayLabel, constants.TrueLabel))
+			Expect(t.getNode(ctx, "worker1").Labels).To(HaveKeyWithValue(constants.SubmarinerGatewayLabel, constants.TrueLabel))
 		})
 
 		Context("and the label-gateway flag is specified as false on the command line", func() {
@@ -302,9 +302,9 @@ func testRunJoinCommand() {
 				t.args = append(t.args, "--label-gateway=false")
 			})
 
-			It("should not label it as a gateway", func() {
+			It("should not label it as a gateway", func(ctx SpecContext) {
 				t.assertCmdSuccess()
-				Expect(t.getNode("worker1").Labels).NotTo(HaveKeyWithValue(constants.SubmarinerGatewayLabel, constants.TrueLabel))
+				Expect(t.getNode(ctx, "worker1").Labels).NotTo(HaveKeyWithValue(constants.SubmarinerGatewayLabel, constants.TrueLabel))
 			})
 		})
 	})
@@ -312,21 +312,21 @@ func testRunJoinCommand() {
 	When("there's multiple worker nodes", func() {
 		selectedNode := "worker2"
 
-		BeforeEach(func() {
-			t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
-			t.createNodes("worker1", selectedNode)
+		BeforeEach(func(ctx SpecContext) {
+			t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
+			t.createNodes(ctx, "worker1", selectedNode)
 			setupPrompts(map[string]any{"gateway": selectedNode})
 		})
 
-		It("should prompt for which node to label as a gateway", func() {
+		It("should prompt for which node to label as a gateway", func(ctx SpecContext) {
 			t.assertCmdSuccess()
-			Expect(t.getNode(selectedNode).Labels).To(HaveKeyWithValue(constants.SubmarinerGatewayLabel, constants.TrueLabel))
+			Expect(t.getNode(ctx, selectedNode).Labels).To(HaveKeyWithValue(constants.SubmarinerGatewayLabel, constants.TrueLabel))
 		})
 	})
 
 	When("there's no worker nodes", func() {
-		BeforeEach(func() {
-			t.setupNetworkDiscovery(clusterCIDR, serviceCIDR)
+		BeforeEach(func(ctx SpecContext) {
+			t.setupNetworkDiscovery(ctx, clusterCIDR, serviceCIDR)
 		})
 
 		It("should emit a warning", func() {

--- a/cmd/subctl/recover_broker_info_test.go
+++ b/cmd/subctl/recover_broker_info_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Recover Broker Info", func() {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		Expect(t.fakeProducer.GeneralClient.Create(ctx, submarinerObj)).To(Succeed())
 		Expect(t.fakeProducer.GeneralClient.Create(ctx, brokerObj.DeepCopy())).To(Succeed())
 	})
@@ -140,7 +140,7 @@ var _ = Describe("Recover Broker Info", func() {
 	})
 
 	When("the Broker is not found on the same cluster as Submariner", func() {
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx SpecContext) {
 			Expect(t.fakeProducer.GeneralClient.Delete(ctx, brokerObj)).To(Succeed())
 			Expect(brokerProducer.GeneralClient.Create(ctx, brokerObj.DeepCopy())).To(Succeed())
 		})
@@ -163,7 +163,7 @@ var _ = Describe("Recover Broker Info", func() {
 		})
 
 		When("and is not found on the remote cluster", func() {
-			JustBeforeEach(func() {
+			JustBeforeEach(func(ctx SpecContext) {
 				Expect(brokerProducer.GeneralClient.Delete(ctx, brokerObj)).To(Succeed())
 			})
 

--- a/cmd/subctl/root.go
+++ b/cmd/subctl/root.go
@@ -19,6 +19,7 @@ limitations under the License.
 package subctl
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -118,7 +119,7 @@ func addHTTPProxyFlags(flags *pflag.FlagSet, config *httpproxy.Config) {
 }
 
 func setupTestFrameworkBeforeSuite() {
-	clusterInfo, err := cluster.NewInfo(framework.TestContext.ClusterIDs[framework.ClusterA],
+	clusterInfo, err := cluster.NewInfo(context.TODO(), framework.TestContext.ClusterIDs[framework.ClusterA],
 		framework.RestConfigs[framework.ClusterA])
 	exit.OnErrorWithMessage(err, "Error initializing the cluster information")
 

--- a/cmd/subctl/subctl_suite_test.go
+++ b/cmd/subctl/subctl_suite_test.go
@@ -59,7 +59,6 @@ const (
 )
 
 var (
-	ctx                = context.TODO()
 	brokerInfoFileName string
 	kubeConfigFileName string
 	brokerInfo         broker.Info
@@ -216,7 +215,7 @@ func newTestDriver() *testDriver {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if t.submarinerSpec != nil {
 			t.submariner = &v1alpha1.Submariner{
 				ObjectMeta: metav1.ObjectMeta{
@@ -261,7 +260,7 @@ func newTestDriver() *testDriver {
 	return t
 }
 
-func (t *testDriver) setupNetworkDiscovery(clusterCIDR, serviceCIDR string) {
+func (t *testDriver) setupNetworkDiscovery(ctx context.Context, clusterCIDR, serviceCIDR string) {
 	name := "kube-controller-manager"
 
 	err := t.fakeProducer.GeneralClient.Create(ctx, &corev1.Pod{
@@ -285,7 +284,7 @@ func (t *testDriver) setupNetworkDiscovery(clusterCIDR, serviceCIDR string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func (t *testDriver) createGatewayNode() {
+func (t *testDriver) createGatewayNode(ctx context.Context) {
 	_, err := t.fakeProducer.KubeClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "worker1",
@@ -295,7 +294,7 @@ func (t *testDriver) createGatewayNode() {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func (t *testDriver) createNodes(nodeNames ...string) {
+func (t *testDriver) createNodes(ctx context.Context, nodeNames ...string) {
 	for _, name := range nodeNames {
 		_, err := t.fakeProducer.KubeClient.CoreV1().Nodes().Create(ctx, &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -306,14 +305,14 @@ func (t *testDriver) createNodes(nodeNames ...string) {
 	}
 }
 
-func (t *testDriver) getNode(name string) *corev1.Node {
+func (t *testDriver) getNode(ctx context.Context, name string) *corev1.Node {
 	node, err := t.fakeProducer.KubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	return node
 }
 
-func (t *testDriver) getSubmariner() *v1alpha1.Submariner {
+func (t *testDriver) getSubmariner(ctx context.Context) *v1alpha1.Submariner {
 	submariner := &v1alpha1.Submariner{}
 	Expect(t.fakeProducer.GeneralClient.Get(ctx, controllerClient.ObjectKey{
 		Namespace: constants.OperatorNamespace,
@@ -323,7 +322,7 @@ func (t *testDriver) getSubmariner() *v1alpha1.Submariner {
 	return submariner
 }
 
-func (t *testDriver) getServiceDiscovery() *v1alpha1.ServiceDiscovery {
+func (t *testDriver) getServiceDiscovery(ctx context.Context) *v1alpha1.ServiceDiscovery {
 	sd := &v1alpha1.ServiceDiscovery{}
 	Expect(t.fakeProducer.GeneralClient.Get(ctx, controllerClient.ObjectKey{
 		Namespace: constants.OperatorNamespace,
@@ -333,7 +332,7 @@ func (t *testDriver) getServiceDiscovery() *v1alpha1.ServiceDiscovery {
 	return sd
 }
 
-func (t *testDriver) getBroker() *v1alpha1.Broker {
+func (t *testDriver) getBroker(ctx context.Context) *v1alpha1.Broker {
 	b := &v1alpha1.Broker{}
 	Expect(t.fakeProducer.GeneralClient.Get(ctx, controllerClient.ObjectKey{
 		Namespace: constants.DefaultBrokerNamespace,

--- a/cmd/subctl/upgrade_test.go
+++ b/cmd/subctl/upgrade_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package subctl_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -47,16 +48,16 @@ import (
 var _ = Describe("Upgrade", func() {
 	t := newUpgradeTestDriver()
 
-	It("should upgrade installed components", func() {
+	It("should upgrade installed components", func(ctx SpecContext) {
 		t.assertCmdSuccess()
-		Expect(t.getSubmariner().UID).NotTo(Equal(t.submariner.UID))
-		t.assertOperatorDeploymentUpgraded(version.Version)
+		Expect(t.getSubmariner(ctx).UID).NotTo(Equal(t.submariner.UID))
+		t.assertOperatorDeploymentUpgraded(ctx, version.Version)
 	})
 
 	When("the broker secret is stale", func() {
 		var staleSecret *corev1.Secret
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			secretName := "broker-secret-stale"
 
 			var err error
@@ -77,7 +78,7 @@ var _ = Describe("Upgrade", func() {
 			t.submarinerSpec.BrokerK8sSecret = staleSecret.Name
 		})
 
-		It("should migrate it", func() {
+		It("should migrate it", func(ctx SpecContext) {
 			t.assertCmdSuccess()
 
 			migrated, err := t.fakeProducer.ForKubernetes().CoreV1().Secrets(constants.OperatorNamespace).Get(
@@ -105,10 +106,10 @@ var _ = Describe("Upgrade", func() {
 			t.serviceDiscoverySpec = &v1alpha1.ServiceDiscoverySpec{}
 		})
 
-		It("should upgrade it", func() {
+		It("should upgrade it", func(ctx SpecContext) {
 			t.assertCmdSuccess()
-			Expect(t.getServiceDiscovery().UID).NotTo(Equal(t.serviceDiscovery.UID))
-			t.assertOperatorDeploymentUpgraded(version.Version)
+			Expect(t.getServiceDiscovery(ctx).UID).NotTo(Equal(t.serviceDiscovery.UID))
+			t.assertOperatorDeploymentUpgraded(ctx, version.Version)
 		})
 	})
 
@@ -117,10 +118,10 @@ var _ = Describe("Upgrade", func() {
 			t.brokerSpec = &v1alpha1.BrokerSpec{}
 		})
 
-		It("should upgrade it", func() {
+		It("should upgrade it", func(ctx SpecContext) {
 			t.assertCmdSuccess()
-			Expect(t.getBroker().UID).NotTo(Equal(t.broker.UID))
-			t.assertOperatorDeploymentUpgraded(version.Version)
+			Expect(t.getBroker(ctx).UID).NotTo(Equal(t.broker.UID))
+			t.assertOperatorDeploymentUpgraded(ctx, version.Version)
 		})
 	})
 
@@ -156,10 +157,10 @@ var _ = Describe("Upgrade", func() {
 				t.args = []string{"--to-version=" + toVersion}
 			})
 
-			It("should upgrade installed components but not subctl", func() {
+			It("should upgrade installed components but not subctl", func(ctx SpecContext) {
 				t.assertCmdSuccess()
 				t.cmdExecutor.EnsureNoCommand(nil)
-				t.assertOperatorDeploymentUpgraded(toVersion)
+				t.assertOperatorDeploymentUpgraded(ctx, toVersion)
 			})
 		})
 	})
@@ -236,7 +237,7 @@ func newUpgradeTestDriver() *upgradeTestDriver {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		server := httptest.NewServer(t.httpHandler)
 
 		DeferCleanup(func() {
@@ -255,7 +256,7 @@ func newUpgradeTestDriver() *upgradeTestDriver {
 	return t
 }
 
-func (t *upgradeTestDriver) assertOperatorDeploymentUpgraded(toVersion string) {
+func (t *upgradeTestDriver) assertOperatorDeploymentUpgraded(ctx context.Context, toVersion string) {
 	deployment, err := t.fakeProducer.ForKubernetes().AppsV1().Deployments(constants.OperatorNamespace).Get(
 		ctx, names.OperatorComponent, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())

--- a/internal/pods/exec_test.go
+++ b/internal/pods/exec_test.go
@@ -86,7 +86,7 @@ var _ = Describe("ExecWithOptions", func() {
 	})
 
 	Context("with defaults", func() {
-		It("should return stdout and stderr with whitespace trimmed", func() {
+		It("should return stdout and stderr with whitespace trimmed", func(ctx SpecContext) {
 			stdout, stderr, err := pods.ExecWithOptions(ctx, config, &execOptions)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -101,7 +101,7 @@ var _ = Describe("ExecWithOptions", func() {
 			execOptions.PreserveWhitespace = true
 		})
 
-		It("should preserve whitespace in stdout and stderr", func() {
+		It("should preserve whitespace in stdout and stderr", func(ctx SpecContext) {
 			stdout, stderr, err := pods.ExecWithOptions(ctx, config, &execOptions)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = Describe("ExecWithOptions", func() {
 			execOptions.CaptureStderr = false
 		})
 
-		It("should set the request query parameters appropriately", func() {
+		It("should set the request query parameters appropriately", func(ctx SpecContext) {
 			_, _, err := pods.ExecWithOptions(ctx, config, &execOptions)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -130,7 +130,7 @@ var _ = Describe("ExecWithOptions", func() {
 			fake.SetSPDYExecutor("", "", errors.New("executor error"))
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, _, err := pods.ExecWithOptions(ctx, config, &execOptions)
 			Expect(err).To(HaveOccurred())
 		})

--- a/internal/pods/pods_suite_test.go
+++ b/internal/pods/pods_suite_test.go
@@ -19,15 +19,12 @@ limitations under the License.
 package pods_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 )
-
-var ctx = context.TODO()
 
 var _ = BeforeSuite(func() {
 	framework.TestContext.OperationTimeout = 1

--- a/internal/pods/schedule_test.go
+++ b/internal/pods/schedule_test.go
@@ -49,7 +49,7 @@ func testSchedule() {
 	t := newScheduleTestDriver()
 
 	Context("with defaults", func() {
-		It("should create a pod to be scheduled on a gateway node", func() {
+		It("should create a pod to be scheduled on a gateway node", func(ctx SpecContext) {
 			scheduled, err := pods.Schedule(t.config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(scheduled).NotTo(BeNil())
@@ -115,7 +115,7 @@ func testSchedule() {
 	})
 
 	Context("with a custom namespace", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "custom-namespace",
@@ -130,7 +130,7 @@ func testSchedule() {
 			t.config.Namespace = ns.Name
 		})
 
-		It("should create the pod in the namespace", func() {
+		It("should create the pod in the namespace", func(ctx SpecContext) {
 			scheduled, err := pods.Schedule(t.config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(scheduled).NotTo(BeNil())
@@ -168,7 +168,7 @@ func testSchedule() {
 			t.podPhase = corev1.PodPending
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := pods.Schedule(t.config)
 			Expect(err).To(HaveOccurred())
 
@@ -233,7 +233,7 @@ func testAwaitCompletion() {
 func testDelete() {
 	t := newScheduledTestDriver()
 
-	It("should delete the pod", func() {
+	It("should delete the pod", func(ctx SpecContext) {
 		t.scheduled.Delete()
 
 		_, err := t.k8sClient.CoreV1().Pods(t.scheduled.Pod.Namespace).Get(ctx, t.scheduled.Pod.Name, metav1.GetOptions{})
@@ -302,7 +302,7 @@ func newScheduledTestDriver() *scheduledTestDriver {
 		t.podPhase = corev1.PodSucceeded
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		t.scheduled = &pods.Scheduled{
 			Config: t.config,
 			Pod: &corev1.Pod{

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -19,6 +19,7 @@ limitations under the License.
 package restconfig
 
 import (
+	"context"
 	goerrors "errors"
 	"fmt"
 	"strings"
@@ -236,7 +237,7 @@ func createClusterInfo(clientConfig clientcmd.ClientConfig, overrides *clientcmd
 		return nil, err
 	}
 
-	return cluster.NewInfo(restConfig.ClusterName, restConfig.Config) //nolint:wrapcheck // No need to wrap
+	return cluster.NewInfo(context.TODO(), restConfig.ClusterName, restConfig.Config) //nolint:wrapcheck // No need to wrap
 }
 
 func (rcp *Producer) runInCluster(function PerContextFn, status reporter.Interface) error {
@@ -246,7 +247,7 @@ func (rcp *Producer) runInCluster(function PerContextFn, status reporter.Interfa
 	}
 
 	// In-cluster configurations don't give a cluster name, use "in-cluster"
-	clusterInfo, err := cluster.NewInfo(InCluster, restConfig)
+	clusterInfo, err := cluster.NewInfo(context.TODO(), InCluster, restConfig)
 	if err != nil {
 		return status.Error(err, "error building the cluster.Info for the in-cluster configuration")
 	}

--- a/internal/show/connections.go
+++ b/internal/show/connections.go
@@ -19,6 +19,7 @@ limitations under the License.
 package show
 
 import (
+	"context"
 	"errors"
 	"net"
 
@@ -32,7 +33,7 @@ import (
 func Connections(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	status.Start("Showing Connections")
 
-	gateways, err := clusterInfo.GetGateways()
+	gateways, err := clusterInfo.GetGateways(context.TODO())
 	if err != nil {
 		return status.Error(err, "Error retrieving gateways")
 	}

--- a/internal/show/endpoints.go
+++ b/internal/show/endpoints.go
@@ -19,6 +19,7 @@ limitations under the License.
 package show
 
 import (
+	"context"
 	"errors"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -30,7 +31,7 @@ import (
 func Endpoints(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	status.Start("Showing Endpoints")
 
-	gateways, err := clusterInfo.GetGateways()
+	gateways, err := clusterInfo.GetGateways(context.TODO())
 	if err != nil {
 		return status.Error(err, "Error retrieving gateways")
 	}

--- a/internal/show/gateways.go
+++ b/internal/show/gateways.go
@@ -19,6 +19,7 @@ limitations under the License.
 package show
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -31,7 +32,7 @@ import (
 func Gateways(clusterInfo *cluster.Info, _ string, status reporter.Interface) error {
 	status.Start("Showing Gateways")
 
-	gateways, err := clusterInfo.GetGateways()
+	gateways, err := clusterInfo.GetGateways(context.TODO())
 	if err != nil {
 		return status.Error(err, "Error retrieving gateways")
 	}

--- a/pkg/apply/embedded_yamls_test.go
+++ b/pkg/apply/embedded_yamls_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package apply_test
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -36,8 +35,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
-
-var ctx = context.TODO()
 
 const (
 	saTemplate = `apiVersion: v1
@@ -106,7 +103,7 @@ var _ = Describe("EmbeddedYAMLs", func() {
 	})
 
 	When("no resources exist", func() {
-		It("should create them and return true", func() {
+		It("should create them and return true", func(ctx SpecContext) {
 			created, err := apply.EmbeddedYAMLs(ctx, client, constants.OperatorNamespace, embeddedYAMLs)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeTrue())
@@ -125,7 +122,7 @@ var _ = Describe("EmbeddedYAMLs", func() {
 	})
 
 	When("some resources already exist", func() {
-		It("should aggregate the returned flag correctly", func() {
+		It("should aggregate the returned flag correctly", func(ctx SpecContext) {
 			createdCount := 0
 
 			client.PrependReactor("create", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -142,12 +139,12 @@ var _ = Describe("EmbeddedYAMLs", func() {
 	})
 
 	When("the resources already exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			_, err := apply.EmbeddedYAMLs(ctx, client, constants.OperatorNamespace, embeddedYAMLs)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should succeed and return false", func() {
+		It("should succeed and return false", func(ctx SpecContext) {
 			created, err := apply.EmbeddedYAMLs(ctx, client, constants.OperatorNamespace, embeddedYAMLs)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeFalse())
@@ -160,7 +157,7 @@ var _ = Describe("EmbeddedYAMLs", func() {
 				fake.FailOnAction(&client.Fake, strings.ToLower(resource)+"s", "create", nil, false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				_, err := apply.EmbeddedYAMLs(ctx, client, constants.OperatorNamespace, embeddedYAMLs)
 				Expect(err).To(HaveOccurred())
 			})

--- a/pkg/broker/broker_suite_test.go
+++ b/pkg/broker/broker_suite_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package broker_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -37,8 +36,6 @@ import (
 	"k8s.io/client-go/rest"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-var ctx = context.TODO()
 
 var _ = BeforeSuite(func() {
 	Expect(apiextensions.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/pkg/broker/ensure_test.go
+++ b/pkg/broker/ensure_test.go
@@ -53,7 +53,7 @@ var _ = Describe("", func() {
 func testEnsure() {
 	t := newTestDriver()
 
-	It("should create the broker resources", func() {
+	It("should create the broker resources", func(ctx SpecContext) {
 		Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient, []string{}, false, testBrokerNamespace)).To(Succeed())
 
 		_, err := t.kubeClient.CoreV1().Namespaces().Get(ctx, testBrokerNamespace, metav1.GetOptions{})
@@ -86,7 +86,7 @@ func testEnsure() {
 	})
 
 	Context("with CRD creation requested", func() {
-		It("should create the CRDs", func() {
+		It("should create the CRDs", func(ctx SpecContext) {
 			Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient,
 				[]string{component.Connectivity, component.ServiceDiscovery, component.Globalnet}, true, testBrokerNamespace)).To(Succeed())
 
@@ -98,7 +98,7 @@ func testEnsure() {
 		})
 
 		Context("and Globalnet component is specified without ServiceDiscovery", func() {
-			It("should create the Globalnet and ServiceDiscovery CRDs", func() {
+			It("should create the Globalnet and ServiceDiscovery CRDs", func(ctx SpecContext) {
 				Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient,
 					[]string{component.Connectivity, component.Globalnet}, true, testBrokerNamespace)).To(Succeed())
 
@@ -116,7 +116,7 @@ func testEnsure() {
 			fake.FailOnAction(&t.kubeClient.(*k8sfake.Clientset).Fake, "namespaces", "create", nil, false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient, []string{component.Connectivity}, false, testBrokerNamespace)).
 				NotTo(Succeed())
 		})
@@ -135,7 +135,7 @@ func testEnsure() {
 					}).Build())
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient, []string{comp}, true, testBrokerNamespace)).NotTo(Succeed())
 			})
 		},
@@ -150,7 +150,7 @@ func testEnsure() {
 				errors.New("mock SA creation error"), false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient, []string{component.Connectivity}, false, testBrokerNamespace)).
 				NotTo(Succeed())
 		})
@@ -162,7 +162,7 @@ func testEnsure() {
 				errors.New("mock role creation error"), false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(broker.Ensure(ctx, t.crdUpdater, t.kubeClient, []string{component.Connectivity}, false, testBrokerNamespace)).
 				NotTo(Succeed())
 		})
@@ -172,7 +172,7 @@ func testEnsure() {
 func testCreateSAForCluster() {
 	t := newTestDriver()
 
-	It("should create the ServiceAccount and RoleBinding", func() {
+	It("should create the ServiceAccount and RoleBinding", func(ctx SpecContext) {
 		secret, err := broker.CreateSAForCluster(ctx, t.kubeClient, testClusterID, testBrokerNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(secret).NotTo(BeNil())
@@ -191,7 +191,7 @@ func testCreateSAForCluster() {
 	})
 
 	When("the ServiceAccount already exists", func() {
-		It("should succeed", func() {
+		It("should succeed", func(ctx SpecContext) {
 			_, err := broker.CreateSAForCluster(ctx, t.kubeClient, testClusterID, testBrokerNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -206,7 +206,7 @@ func testCreateSAForCluster() {
 				errors.New("mock SA creation error"), false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := broker.CreateSAForCluster(ctx, t.kubeClient, testClusterID, testBrokerNamespace)
 			Expect(err).To(HaveOccurred())
 		})
@@ -218,7 +218,7 @@ func testCreateSAForCluster() {
 				errors.New("mock role binding creation error"), false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := broker.CreateSAForCluster(ctx, t.kubeClient, testClusterID, testBrokerNamespace)
 			Expect(err).To(HaveOccurred())
 		})
@@ -230,7 +230,7 @@ func testCreateSAForCluster() {
 				errors.New("mock secret creation error"), false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := broker.CreateSAForCluster(ctx, t.kubeClient, testClusterID, testBrokerNamespace)
 			Expect(err).To(HaveOccurred())
 		})

--- a/pkg/broker/file_test.go
+++ b/pkg/broker/file_test.go
@@ -56,7 +56,7 @@ func testWriteInfoToFile() {
 		tokenSecret = newTokenSecret()
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if tokenSecret != nil {
 			_, err := t.kubeClient.CoreV1().Secrets(testBrokerNamespace).Create(ctx, tokenSecret, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/broker/info_test.go
+++ b/pkg/broker/info_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package broker_test
 
 import (
+	"context"
 	"crypto/x509"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -70,7 +71,7 @@ func testGetBrokerAdministratorConfig() {
 		}
 	})
 
-	assertGetBrokerAdministratorConfigSuccess := func(insecure bool) *rest.Config {
+	assertGetBrokerAdministratorConfigSuccess := func(ctx context.Context, insecure bool) *rest.Config {
 		config, err := info.GetBrokerAdministratorConfig(ctx, insecure)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(config).NotTo(BeNil())
@@ -82,16 +83,16 @@ func testGetBrokerAdministratorConfig() {
 	}
 
 	When("insecure is true", func() {
-		It("should return a config with insecure TLS", func() {
-			config := assertGetBrokerAdministratorConfigSuccess(true)
+		It("should return a config with insecure TLS", func(ctx SpecContext) {
+			config := assertGetBrokerAdministratorConfigSuccess(ctx, true)
 			Expect(config.TLSClientConfig.CAData).To(BeNil())
 		})
 	})
 
 	When("insecure is false", func() {
 		Context("and the connection succeeds without CA data", func() {
-			It("should return a config without CA data", func() {
-				config := assertGetBrokerAdministratorConfigSuccess(false)
+			It("should return a config without CA data", func(ctx SpecContext) {
+				config := assertGetBrokerAdministratorConfigSuccess(ctx, false)
 				Expect(config.TLSClientConfig.CAData).To(BeNil())
 			})
 		})
@@ -109,8 +110,8 @@ func testGetBrokerAdministratorConfig() {
 				}
 			})
 
-			It("should retry with CA data", func() {
-				config := assertGetBrokerAdministratorConfigSuccess(false)
+			It("should retry with CA data", func(ctx SpecContext) {
+				config := assertGetBrokerAdministratorConfigSuccess(ctx, false)
 				Expect(config.TLSClientConfig.CAData).To(Equal(caCert))
 			})
 		})
@@ -124,8 +125,8 @@ func testGetBrokerAdministratorConfig() {
 			}, ""), false)
 		})
 
-		It("should treat it as success", func() {
-			assertGetBrokerAdministratorConfigSuccess(false)
+		It("should treat it as success", func(ctx SpecContext) {
+			assertGetBrokerAdministratorConfigSuccess(ctx, false)
 		})
 	})
 
@@ -134,7 +135,7 @@ func testGetBrokerAdministratorConfig() {
 			fake.FailOnAction(&submarinerClient.Fake, "clusters", "list", nil, false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := info.GetBrokerAdministratorConfig(ctx, false)
 			Expect(err).To(HaveOccurred())
 		})

--- a/pkg/broker/recover_broker_info_test.go
+++ b/pkg/broker/recover_broker_info_test.go
@@ -79,7 +79,7 @@ var _ = Describe("RecoverData", func() {
 		brokerRestConfig = &rest.Config{}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		_, err := t.kubeClient.CoreV1().Secrets(testBrokerNamespace).Create(ctx, newTokenSecret(), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/pkg/brokercr/ensure_test.go
+++ b/pkg/brokercr/ensure_test.go
@@ -39,8 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-var ctx = context.TODO()
-
 var _ = BeforeSuite(func() {
 	Expect(submariner.AddToScheme(scheme.Scheme)).To(Succeed())
 })
@@ -73,7 +71,7 @@ var _ = Describe("Ensure", func() {
 	})
 
 	When("the Broker doesn't exist", func() {
-		It("should create it", func() {
+		It("should create it", func(ctx SpecContext) {
 			Expect(brokercr.Ensure(ctx, client, constants.DefaultBrokerNamespace, brokerSpec)).To(Succeed())
 
 			broker := &submariner.Broker{}
@@ -97,7 +95,7 @@ var _ = Describe("Ensure", func() {
 			})
 		})
 
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx SpecContext) {
 			existingBroker := &submariner.Broker{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      brokerKey.Name,
@@ -114,7 +112,7 @@ var _ = Describe("Ensure", func() {
 			existingUID = existingBroker.UID
 		})
 
-		It("should replace it with a new resource", func() {
+		It("should replace it with a new resource", func(ctx SpecContext) {
 			Expect(brokercr.Ensure(ctx, client, constants.DefaultBrokerNamespace, brokerSpec)).To(Succeed())
 
 			broker := &submariner.Broker{}
@@ -133,7 +131,7 @@ var _ = Describe("Ensure", func() {
 			})
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			Expect(brokercr.Ensure(ctx, client, constants.DefaultBrokerNamespace, brokerSpec)).NotTo(Succeed())
 		})
 	})

--- a/pkg/cluster/cluster_suite_test.go
+++ b/pkg/cluster/cluster_suite_test.go
@@ -42,8 +42,6 @@ const (
 	remoteCluster = "remote-cluster"
 )
 
-var ctx = context.TODO()
-
 var _ = BeforeSuite(func() {
 	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(apiextensionsv1.AddToScheme(scheme.Scheme)).To(Succeed())
@@ -92,7 +90,7 @@ func newTestDriver() *testDriver {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if t.submariner != nil {
 			Expect(t.clients.ForGeneral().Create(ctx, t.submariner)).To(Succeed())
 		}
@@ -105,15 +103,15 @@ func newTestDriver() *testDriver {
 	return t
 }
 
-func (t *testDriver) newInfo() *cluster.Info {
-	info, err := cluster.NewInfo(localCluster, nil)
+func (t *testDriver) newInfo(ctx context.Context) *cluster.Info {
+	info, err := cluster.NewInfo(ctx, localCluster, nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	return info
 }
 
-func (t *testDriver) createNode(name string) {
-	_, err := t.newInfo().ClientProducer.ForKubernetes().CoreV1().Nodes().Create(ctx, &corev1.Node{
+func (t *testDriver) createNode(ctx context.Context, name string) {
+	_, err := t.newInfo(ctx).ClientProducer.ForKubernetes().CoreV1().Nodes().Create(ctx, &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -121,7 +119,7 @@ func (t *testDriver) createNode(name string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func (t *testDriver) createEndpoint(clusterID string) {
+func (t *testDriver) createEndpoint(ctx context.Context, clusterID string) {
 	Expect(t.clients.ForGeneral().Create(ctx, &submarinerv1.Endpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterID,

--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -49,7 +49,7 @@ type Info struct {
 	nodeCount        int
 }
 
-func NewInfo(clusterName string, config *rest.Config) (*Info, error) {
+func NewInfo(ctx context.Context, clusterName string, config *rest.Config) (*Info, error) {
 	info := &Info{
 		Name:       clusterName,
 		RestConfig: config,
@@ -65,7 +65,7 @@ func NewInfo(clusterName string, config *rest.Config) (*Info, error) {
 
 	submariner := &v1alpha1.Submariner{}
 
-	err = info.ClientProducer.ForGeneral().Get(context.TODO(), controllerClient.ObjectKey{
+	err = info.ClientProducer.ForGeneral().Get(ctx, controllerClient.ObjectKey{
 		Namespace: constants.OperatorNamespace,
 		Name:      opnames.SubmarinerCrName,
 	}, submariner)
@@ -77,7 +77,7 @@ func NewInfo(clusterName string, config *rest.Config) (*Info, error) {
 
 	serviceDiscovery := &v1alpha1.ServiceDiscovery{}
 
-	err = info.ClientProducer.ForGeneral().Get(context.TODO(), controllerClient.ObjectKey{
+	err = info.ClientProducer.ForGeneral().Get(ctx, controllerClient.ObjectKey{
 		Namespace: constants.OperatorNamespace,
 		Name:      opnames.ServiceDiscoveryCrName,
 	}, serviceDiscovery)
@@ -87,7 +87,7 @@ func NewInfo(clusterName string, config *rest.Config) (*Info, error) {
 		return nil, errors.Wrap(err, "error retrieving ServiceDiscovery")
 	}
 
-	_, err = info.GetGateways()
+	_, err = info.GetGateways(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving Gateways")
 	}
@@ -95,10 +95,10 @@ func NewInfo(clusterName string, config *rest.Config) (*Info, error) {
 	return info, nil
 }
 
-func (c *Info) GetGateways() ([]submarinerv1.Gateway, error) {
+func (c *Info) GetGateways(ctx context.Context) ([]submarinerv1.Gateway, error) {
 	gateways := &submarinerv1.GatewayList{}
 
-	err := c.ClientProducer.ForGeneral().List(context.TODO(), gateways, controllerClient.InNamespace(constants.OperatorNamespace))
+	err := c.ClientProducer.ForGeneral().List(ctx, gateways, controllerClient.InNamespace(constants.OperatorNamespace))
 	if err != nil {
 		if resource.IsNotFoundErr(err) {
 			return []submarinerv1.Gateway{}, nil

--- a/pkg/cluster/info_test.go
+++ b/pkg/cluster/info_test.go
@@ -51,8 +51,8 @@ func testNewInfo() {
 	t := newTestDriver()
 
 	When("the Submariner and ServiceDiscovery resources exist", func() {
-		It("should succeed", func() {
-			info, err := cluster.NewInfo(localCluster, nil)
+		It("should succeed", func(ctx SpecContext) {
+			info, err := cluster.NewInfo(ctx, localCluster, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info).NotTo(BeNil())
 			Expect(info.Submariner).To(Equal(t.submariner))
@@ -66,8 +66,8 @@ func testNewInfo() {
 			t.serviceDisc = nil
 		})
 
-		It("should succeed", func() {
-			info, err := cluster.NewInfo(localCluster, nil)
+		It("should succeed", func(ctx SpecContext) {
+			info, err := cluster.NewInfo(ctx, localCluster, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info).NotTo(BeNil())
 			Expect(info.Submariner).To(BeNil())
@@ -81,8 +81,8 @@ func testNewInfo() {
 				fake.FailingGetInterceptor[*v1alpha1.Submariner]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := cluster.NewInfo(localCluster, nil)
+		It("should return an error", func(ctx SpecContext) {
+			_, err := cluster.NewInfo(ctx, localCluster, nil)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -93,8 +93,8 @@ func testNewInfo() {
 				fake.FailingGetInterceptor[*v1alpha1.ServiceDiscovery]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := cluster.NewInfo(localCluster, nil)
+		It("should return an error", func(ctx SpecContext) {
+			_, err := cluster.NewInfo(ctx, localCluster, nil)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -105,8 +105,8 @@ func testNewInfo() {
 				fake.FailingListInterceptor[*submarinerv1.GatewayList]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := cluster.NewInfo(localCluster, nil)
+		It("should return an error", func(ctx SpecContext) {
+			_, err := cluster.NewInfo(ctx, localCluster, nil)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -116,7 +116,7 @@ func testGetGateways() {
 	t := newTestDriver()
 
 	When("gateways exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			Expect(t.clients.ForGeneral().Create(ctx, &submarinerv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gateway1",
@@ -132,16 +132,16 @@ func testGetGateways() {
 			})).To(Succeed())
 		})
 
-		It("should return all gateways", func() {
-			gateways, err := t.newInfo().GetGateways()
+		It("should return all gateways", func(ctx SpecContext) {
+			gateways, err := t.newInfo(ctx).GetGateways(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gateways).To(HaveLen(2))
 		})
 	})
 
 	When("no gateways exist", func() {
-		It("should return an empty list", func() {
-			gateways, err := t.newInfo().GetGateways()
+		It("should return an empty list", func(ctx SpecContext) {
+			gateways, err := t.newInfo(ctx).GetGateways(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gateways).To(BeEmpty())
 		})
@@ -152,7 +152,7 @@ func testGetRouteAgents() {
 	t := newTestDriver()
 
 	When("route agents exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			Expect(t.clients.ForGeneral().Create(ctx, &submarinerv1.RouteAgent{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "node1",
@@ -168,16 +168,16 @@ func testGetRouteAgents() {
 			})).To(Succeed())
 		})
 
-		It("should return all route agents", func() {
-			routeAgents, err := t.newInfo().GetRouteAgents()
+		It("should return all route agents", func(ctx SpecContext) {
+			routeAgents, err := t.newInfo(ctx).GetRouteAgents()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routeAgents).To(HaveLen(2))
 		})
 	})
 
 	When("no route agents exist", func() {
-		It("should return empty list", func() {
-			routeAgents, err := t.newInfo().GetRouteAgents()
+		It("should return empty list", func(ctx SpecContext) {
+			routeAgents, err := t.newInfo(ctx).GetRouteAgents()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(routeAgents).To(BeEmpty())
 		})
@@ -189,8 +189,8 @@ func testGetRouteAgents() {
 				fake.FailingListInterceptor[*submarinerv1.RouteAgentList]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := t.newInfo().GetRouteAgents()
+		It("should return an error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetRouteAgents()
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -200,33 +200,33 @@ func testHasSingleNode() {
 	t := newTestDriver()
 
 	When("the cluster has a single node", func() {
-		BeforeEach(func() {
-			t.createNode("node1")
+		BeforeEach(func(ctx SpecContext) {
+			t.createNode(ctx, "node1")
 		})
 
-		It("should return true", func() {
-			hasSingleNode, err := t.newInfo().HasSingleNode()
+		It("should return true", func(ctx SpecContext) {
+			hasSingleNode, err := t.newInfo(ctx).HasSingleNode()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasSingleNode).To(BeTrue())
 		})
 	})
 
 	When("cluster has multiple nodes", func() {
-		BeforeEach(func() {
-			t.createNode("node1")
-			t.createNode("node2")
+		BeforeEach(func(ctx SpecContext) {
+			t.createNode(ctx, "node1")
+			t.createNode(ctx, "node2")
 		})
 
-		It("should return false", func() {
-			hasSingleNode, err := t.newInfo().HasSingleNode()
+		It("should return false", func(ctx SpecContext) {
+			hasSingleNode, err := t.newInfo(ctx).HasSingleNode()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasSingleNode).To(BeFalse())
 		})
 	})
 
 	When("cluster has no nodes", func() {
-		It("should return false", func() {
-			hasSingleNode, err := t.newInfo().HasSingleNode()
+		It("should return false", func(ctx SpecContext) {
+			hasSingleNode, err := t.newInfo(ctx).HasSingleNode()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasSingleNode).To(BeFalse())
 		})
@@ -237,8 +237,8 @@ func testHasSingleNode() {
 			fake.FailOnAction(&t.clients.ForKubernetes().(*k8sfake.Clientset).Fake, "nodes", "list", nil, false)
 		})
 
-		It("should return an error", func() {
-			_, err := t.newInfo().HasSingleNode()
+		It("should return an error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).HasSingleNode()
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -248,13 +248,13 @@ func testGetLocalEndpoint() {
 	t := newTestDriver()
 
 	When("a local endpoint exists", func() {
-		BeforeEach(func() {
-			t.createEndpoint(localCluster)
-			t.createEndpoint(remoteCluster)
+		BeforeEach(func(ctx SpecContext) {
+			t.createEndpoint(ctx, localCluster)
+			t.createEndpoint(ctx, remoteCluster)
 		})
 
-		It("should return the local endpoint", func() {
-			endpoint, err := t.newInfo().GetLocalEndpoint()
+		It("should return the local endpoint", func(ctx SpecContext) {
+			endpoint, err := t.newInfo(ctx).GetLocalEndpoint()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(endpoint).NotTo(BeNil())
 			Expect(endpoint.Spec.ClusterID).To(Equal(localCluster))
@@ -262,19 +262,19 @@ func testGetLocalEndpoint() {
 	})
 
 	When("a local endpoint does not exist", func() {
-		BeforeEach(func() {
-			t.createEndpoint(remoteCluster)
+		BeforeEach(func(ctx SpecContext) {
+			t.createEndpoint(ctx, remoteCluster)
 		})
 
-		It("should return not found error", func() {
-			_, err := t.newInfo().GetLocalEndpoint()
+		It("should return not found error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetLocalEndpoint()
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
 
 	When("no endpoints exist", func() {
-		It("should return not found error", func() {
-			_, err := t.newInfo().GetLocalEndpoint()
+		It("should return not found error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetLocalEndpoint()
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
@@ -285,8 +285,8 @@ func testGetLocalEndpoint() {
 				fake.FailingListInterceptor[*submarinerv1.EndpointList]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := t.newInfo().GetLocalEndpoint()
+		It("should return an error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetLocalEndpoint()
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -296,25 +296,25 @@ func testGetAnyRemoteEndpoint() {
 	t := newTestDriver()
 
 	When("remote endpoints exist", func() {
-		BeforeEach(func() {
-			t.createEndpoint(localCluster)
-			t.createEndpoint(remoteCluster)
+		BeforeEach(func(ctx SpecContext) {
+			t.createEndpoint(ctx, localCluster)
+			t.createEndpoint(ctx, remoteCluster)
 		})
 
-		It("should return a remote endpoint", func() {
-			endpoint, err := t.newInfo().GetAnyRemoteEndpoint()
+		It("should return a remote endpoint", func(ctx SpecContext) {
+			endpoint, err := t.newInfo(ctx).GetAnyRemoteEndpoint()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(endpoint.Spec.ClusterID).To(Equal(remoteCluster))
 		})
 	})
 
 	When("no remote endpoints exist", func() {
-		BeforeEach(func() {
-			t.createEndpoint(localCluster)
+		BeforeEach(func(ctx SpecContext) {
+			t.createEndpoint(ctx, localCluster)
 		})
 
-		It("should return not found error", func() {
-			_, err := t.newInfo().GetAnyRemoteEndpoint()
+		It("should return not found error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetAnyRemoteEndpoint()
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
@@ -325,8 +325,8 @@ func testGetAnyRemoteEndpoint() {
 				fake.FailingListInterceptor[*submarinerv1.EndpointList]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := t.newInfo().GetAnyRemoteEndpoint()
+		It("should return an error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetAnyRemoteEndpoint()
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -343,8 +343,8 @@ func testGetImageRepositoryInfo() {
 			}
 		})
 
-		It("should return repository info from the Submariner spec", func() {
-			repoInfo, err := t.newInfo().GetImageRepositoryInfo()
+		It("should return repository info from the Submariner spec", func(ctx SpecContext) {
+			repoInfo, err := t.newInfo(ctx).GetImageRepositoryInfo()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(repoInfo).NotTo(BeNil())
 			Expect(repoInfo.Name).To(Equal(t.submariner.Spec.Repository))
@@ -352,9 +352,9 @@ func testGetImageRepositoryInfo() {
 			Expect(repoInfo.Overrides).To(Equal(t.submariner.Spec.ImageOverrides))
 		})
 
-		It("should merge local overrides with the Submariner spec overrides", func() {
+		It("should merge local overrides with the Submariner spec overrides", func(ctx SpecContext) {
 			overrideImage := "custom-routeagent:2.0.0"
-			repoInfo, err := t.newInfo().GetImageRepositoryInfo(names.RouteAgentComponent + "=" + overrideImage)
+			repoInfo, err := t.newInfo(ctx).GetImageRepositoryInfo(names.RouteAgentComponent + "=" + overrideImage)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(repoInfo).NotTo(BeNil())
 			Expect(repoInfo.Overrides).To(HaveKeyWithValue(names.GatewayComponent,
@@ -362,8 +362,8 @@ func testGetImageRepositoryInfo() {
 			Expect(repoInfo.Overrides).To(HaveKeyWithValue(names.RouteAgentComponent, overrideImage))
 		})
 
-		It("should return an error for an invalid local override format", func() {
-			_, err := t.newInfo().GetImageRepositoryInfo("invalid-format")
+		It("should return an error for an invalid local override format", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetImageRepositoryInfo("invalid-format")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -373,8 +373,8 @@ func testGetImageRepositoryInfo() {
 			t.submariner = nil
 		})
 
-		It("should return default repository info", func() {
-			repoInfo, err := t.newInfo().GetImageRepositoryInfo()
+		It("should return default repository info", func(ctx SpecContext) {
+			repoInfo, err := t.newInfo(ctx).GetImageRepositoryInfo()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(repoInfo).NotTo(BeNil())
 			Expect(repoInfo.Name).To(Equal(v1alpha1.DefaultRepo))
@@ -382,9 +382,9 @@ func testGetImageRepositoryInfo() {
 			Expect(repoInfo.Overrides).To(BeEmpty())
 		})
 
-		It("should return local overrides", func() {
+		It("should return local overrides", func(ctx SpecContext) {
 			overrideImage := "custom-gateway:latest"
-			repoInfo, err := t.newInfo().GetImageRepositoryInfo(names.GatewayComponent + "=" + overrideImage)
+			repoInfo, err := t.newInfo(ctx).GetImageRepositoryInfo(names.GatewayComponent + "=" + overrideImage)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(repoInfo).NotTo(BeNil())
 			Expect(repoInfo.Name).To(Equal(v1alpha1.DefaultRepo))
@@ -392,8 +392,8 @@ func testGetImageRepositoryInfo() {
 			Expect(repoInfo.Overrides).To(HaveKeyWithValue(names.GatewayComponent, overrideImage))
 		})
 
-		It("should return an error for invalid local override format", func() {
-			_, err := t.newInfo().GetImageRepositoryInfo("invalid-format")
+		It("should return an error for invalid local override format", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetImageRepositoryInfo("invalid-format")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -403,8 +403,8 @@ func testOperatorNamespace() {
 	t := newTestDriver()
 
 	When("the Submariner resource exists", func() {
-		It("should return its namespace", func() {
-			Expect(t.newInfo().OperatorNamespace()).To(Equal(t.submariner.Namespace))
+		It("should return its namespace", func(ctx SpecContext) {
+			Expect(t.newInfo(ctx).OperatorNamespace()).To(Equal(t.submariner.Namespace))
 		})
 	})
 
@@ -413,8 +413,8 @@ func testOperatorNamespace() {
 			t.submariner = nil
 		})
 
-		It("should return its namespace", func() {
-			Expect(t.newInfo().OperatorNamespace()).To(Equal(t.serviceDisc.Namespace))
+		It("should return its namespace", func(ctx SpecContext) {
+			Expect(t.newInfo(ctx).OperatorNamespace()).To(Equal(t.serviceDisc.Namespace))
 		})
 	})
 
@@ -424,8 +424,8 @@ func testOperatorNamespace() {
 			t.serviceDisc = nil
 		})
 
-		It("should return default operator namespace", func() {
-			Expect(t.newInfo().OperatorNamespace()).To(Equal(constants.OperatorNamespace))
+		It("should return default operator namespace", func(ctx SpecContext) {
+			Expect(t.newInfo(ctx).OperatorNamespace()).To(Equal(constants.OperatorNamespace))
 		})
 	})
 }
@@ -434,7 +434,7 @@ func testGetClusters() {
 	t := newTestDriver()
 
 	When("clusters exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			Expect(t.clients.ForGeneral().Create(ctx, &submarinerv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cluster1",
@@ -450,16 +450,16 @@ func testGetClusters() {
 			})).To(Succeed())
 		})
 
-		It("should return all clusters", func() {
-			clusters, err := t.newInfo().GetClusters(constants.OperatorNamespace)
+		It("should return all clusters", func(ctx SpecContext) {
+			clusters, err := t.newInfo(ctx).GetClusters(constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(clusters).To(HaveLen(2))
 		})
 	})
 
 	When("no clusters exist", func() {
-		It("should return an empty list", func() {
-			clusters, err := t.newInfo().GetClusters(constants.OperatorNamespace)
+		It("should return an empty list", func(ctx SpecContext) {
+			clusters, err := t.newInfo(ctx).GetClusters(constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(clusters).To(BeEmpty())
 		})
@@ -471,8 +471,8 @@ func testGetClusters() {
 				fake.FailingListInterceptor[*submarinerv1.ClusterList]()).Build()
 		})
 
-		It("should return an error", func() {
-			_, err := t.newInfo().GetClusters(constants.OperatorNamespace)
+		It("should return an error", func(ctx SpecContext) {
+			_, err := t.newInfo(ctx).GetClusters(constants.OperatorNamespace)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/deploy/broker_test.go
+++ b/pkg/deploy/broker_test.go
@@ -53,7 +53,7 @@ const (
 var _ = Describe("Broker", func() {
 	t := newBrokerTestDriver()
 
-	It("should successfully deploy the operator and the Broker resource", func() {
+	It("should successfully deploy the operator and the Broker resource", func(ctx SpecContext) {
 		t.assertSuccess()
 
 		deployment, err := t.fakeProducer.KubeClient.AppsV1().Deployments(constants.OperatorNamespace).Get(
@@ -71,7 +71,7 @@ var _ = Describe("Broker", func() {
 		_, err = t.fakeProducer.KubeClient.CoreV1().Namespaces().Get(ctx, testBrokerNamespace, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		t.assertBrokerResource()
+		t.assertBrokerResource(ctx)
 
 		ginfo, _, err := globalnet.GetGlobalNetworks(ctx, t.fakeProducer.ForGeneral(), testBrokerNamespace)
 		Expect(err).NotTo(HaveOccurred())
@@ -87,9 +87,9 @@ var _ = Describe("Broker", func() {
 			t.options.BrokerSpec.Components = []string{component.Connectivity}
 		})
 
-		It("should deploy the Broker resource correctly", func() {
+		It("should deploy the Broker resource correctly", func(ctx SpecContext) {
 			t.assertSuccess()
-			t.assertBrokerResource()
+			t.assertBrokerResource(ctx)
 		})
 	})
 
@@ -117,7 +117,7 @@ var _ = Describe("Broker", func() {
 		})
 
 		Context("with a valid globalnet configuration", func() {
-			It("should create the globalnet ConfigMap correctly", func() {
+			It("should create the globalnet ConfigMap correctly", func(ctx SpecContext) {
 				t.assertSuccess()
 
 				info, _, err := globalnet.GetGlobalNetworks(ctx, t.fakeProducer.ForGeneral(), testBrokerNamespace)
@@ -169,7 +169,7 @@ var _ = Describe("Broker", func() {
 		})
 
 		Context("with a valid clusterset IP configuration", func() {
-			It("should create the clusterset IP ConfigMap correctly", func() {
+			It("should create the clusterset IP ConfigMap correctly", func(ctx SpecContext) {
 				t.assertSuccess()
 
 				info, _, err := clustersetip.GetClustersetIPNetworks(ctx, t.fakeProducer.ForGeneral(), testBrokerNamespace)
@@ -261,7 +261,7 @@ func (t *brokerTestDriver) testFailure(msgs ...string) {
 	})
 }
 
-func (t *brokerTestDriver) assertBrokerResource() {
+func (t *brokerTestDriver) assertBrokerResource(ctx context.Context) {
 	broker := &v1alpha1.Broker{}
 	Expect(t.fakeProducer.ForGeneral().Get(ctx, ctrlClient.ObjectKey{
 		Name:      brokercr.Name,

--- a/pkg/deploy/deploy_suite_test.go
+++ b/pkg/deploy/deploy_suite_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package deploy_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -44,8 +43,6 @@ const (
 	testRepository      = "quay.io/submariner"
 	testImageVersion    = "devel"
 )
-
-var ctx = context.TODO()
 
 var _ = BeforeSuite(func() {
 	Expect(operatorv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/pkg/deploy/servicediscovery_test.go
+++ b/pkg/deploy/servicediscovery_test.go
@@ -51,13 +51,13 @@ var _ = Describe("ServiceDiscovery", func() {
 		}
 	})
 
-	runDepoy := func() error {
+	runDepoy := func(ctx context.Context) error {
 		return deploy.ServiceDiscovery(ctx, t.fakeProducer, options, t.brokerInfo, t.brokerSecret,
 			t.clustersetConfig, t.repositoryInfo, t.statusReporter)
 	}
 
-	expectServiceDiscoverySuccess := func() *operatorv1alpha1.ServiceDiscoverySpec {
-		Expect(runDepoy()).To(Succeed())
+	expectServiceDiscoverySuccess := func(ctx context.Context) *operatorv1alpha1.ServiceDiscoverySpec {
+		Expect(runDepoy(ctx)).To(Succeed())
 
 		serviceDiscoveryCR := &operatorv1alpha1.ServiceDiscovery{}
 		Expect(t.fakeProducer.ForGeneral().Get(ctx, ctrlClient.ObjectKey{
@@ -71,8 +71,8 @@ var _ = Describe("ServiceDiscovery", func() {
 		return &serviceDiscoveryCR.Spec
 	}
 
-	It("should successfully deploy the ServiceDiscovery resource", func() {
-		spec := expectServiceDiscoverySuccess()
+	It("should successfully deploy the ServiceDiscovery resource", func(ctx SpecContext) {
+		spec := expectServiceDiscoverySuccess(ctx)
 		Expect(spec.Repository).To(Equal(options.Repository))
 		Expect(spec.Version).To(Equal(options.ImageVersion))
 		Expect(spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString(t.brokerSecret.Data["ca.crt"])))
@@ -96,8 +96,8 @@ var _ = Describe("ServiceDiscovery", func() {
 			options.CoreDNSCustomConfigMap = "test-namespace/test-configmap"
 		})
 
-		It("should set the CoreDNSCustomConfig field", func() {
-			Expect(expectServiceDiscoverySuccess().CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
+		It("should set the CoreDNSCustomConfig field", func(ctx SpecContext) {
+			Expect(expectServiceDiscoverySuccess(ctx).CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
 				ConfigMapName: "test-configmap",
 				Namespace:     "test-namespace",
 			}))
@@ -109,8 +109,8 @@ var _ = Describe("ServiceDiscovery", func() {
 			options.CustomDomains = []string{"custom.domain"}
 		})
 
-		It("should set the CustomDomains field", func() {
-			Expect(expectServiceDiscoverySuccess().CustomDomains).To(Equal(options.CustomDomains))
+		It("should set the CustomDomains field", func(ctx SpecContext) {
+			Expect(expectServiceDiscoverySuccess(ctx).CustomDomains).To(Equal(options.CustomDomains))
 		})
 	})
 
@@ -123,8 +123,8 @@ var _ = Describe("ServiceDiscovery", func() {
 			}).Build()
 		})
 
-		It("should return an error", func() {
-			Expect(runDepoy()).NotTo(Succeed())
+		It("should return an error", func(ctx SpecContext) {
+			Expect(runDepoy(ctx)).NotTo(Succeed())
 			t.statusReporter.AssertHasFailure()
 		})
 	})

--- a/pkg/deploy/submariner_test.go
+++ b/pkg/deploy/submariner_test.go
@@ -78,13 +78,13 @@ func testSubmariner() {
 		}
 	})
 
-	runDepoy := func() error {
+	runDepoy := func(ctx context.Context) error {
 		return deploy.Submariner(ctx, t.fakeProducer, options, t.brokerInfo, t.brokerSecret, netconfig,
 			t.clustersetConfig, t.repositoryInfo, t.statusReporter)
 	}
 
-	expectDeploySuccess := func() *operatorv1alpha1.SubmarinerSpec {
-		Expect(runDepoy()).To(Succeed())
+	expectDeploySuccess := func(ctx context.Context) *operatorv1alpha1.SubmarinerSpec {
+		Expect(runDepoy(ctx)).To(Succeed())
 
 		submarinerCR := &operatorv1alpha1.Submariner{}
 		Expect(t.fakeProducer.ForGeneral().Get(ctx, ctrlClient.ObjectKey{
@@ -98,13 +98,13 @@ func testSubmariner() {
 		return &submarinerCR.Spec
 	}
 
-	expectDeployFailure := func() {
-		Expect(runDepoy()).NotTo(Succeed())
+	expectDeployFailure := func(ctx context.Context) {
+		Expect(runDepoy(ctx)).NotTo(Succeed())
 		t.statusReporter.AssertHasFailure()
 	}
 
-	It("should successfully deploy the Submariner resource", func() {
-		spec := expectDeploySuccess()
+	It("should successfully deploy the Submariner resource", func(ctx SpecContext) {
+		spec := expectDeploySuccess(ctx)
 		Expect(spec.Repository).To(Equal(t.repositoryInfo.Name))
 		Expect(spec.Version).To(Equal(t.repositoryInfo.Version))
 		Expect(spec.CeIPSecNATTPort).To(Equal(options.NATTPort))
@@ -143,8 +143,8 @@ func testSubmariner() {
 			netconfig.GlobalCIDR = "242.0.0.0/8"
 		})
 
-		It("should set the GlobalCIDR field", func() {
-			Expect(expectDeploySuccess().GlobalCIDR).To(Equal(netconfig.GlobalCIDR))
+		It("should set the GlobalCIDR field", func(ctx SpecContext) {
+			Expect(expectDeploySuccess(ctx).GlobalCIDR).To(Equal(netconfig.GlobalCIDR))
 		})
 	})
 
@@ -153,8 +153,8 @@ func testSubmariner() {
 			options.CoreDNSCustomConfigMap = "test-namespace/test-configmap"
 		})
 
-		It("should set the CoreDNSCustomConfig field", func() {
-			Expect(expectDeploySuccess().CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
+		It("should set the CoreDNSCustomConfig field", func(ctx SpecContext) {
+			Expect(expectDeploySuccess(ctx).CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
 				ConfigMapName: "test-configmap",
 				Namespace:     "test-namespace",
 			}))
@@ -166,8 +166,8 @@ func testSubmariner() {
 			options.CustomDomains = []string{"custom.domain"}
 		})
 
-		It("should not set the CustomDomains field", func() {
-			Expect(expectDeploySuccess().CustomDomains).To(Equal(options.CustomDomains))
+		It("should not set the CustomDomains field", func(ctx SpecContext) {
+			Expect(expectDeploySuccess(ctx).CustomDomains).To(Equal(options.CustomDomains))
 		})
 	})
 
@@ -176,8 +176,8 @@ func testSubmariner() {
 			t.brokerInfo.Components = []string{component.Connectivity}
 		})
 
-		It("should set ServiceDiscoveryEnabled to false", func() {
-			Expect(expectDeploySuccess().ServiceDiscoveryEnabled).To(BeFalse())
+		It("should set ServiceDiscoveryEnabled to false", func(ctx SpecContext) {
+			Expect(expectDeploySuccess(ctx).ServiceDiscoveryEnabled).To(BeFalse())
 		})
 	})
 
@@ -186,8 +186,8 @@ func testSubmariner() {
 			fake.FailOnAction(&t.fakeProducer.KubeClient.(*k8sfake.Clientset).Fake, "secrets", "create", nil, false)
 		})
 
-		It("should return an error", func() {
-			expectDeployFailure()
+		It("should return an error", func(ctx SpecContext) {
+			expectDeployFailure(ctx)
 		})
 	})
 
@@ -200,8 +200,8 @@ func testSubmariner() {
 			}).Build()
 		})
 
-		It("should return an error", func() {
-			expectDeployFailure()
+		It("should return an error", func(ctx SpecContext) {
+			expectDeployFailure(ctx)
 		})
 	})
 }

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -106,7 +106,7 @@ func checkCalicoIPPoolsIfCalicoCNI(info *cluster.Info, status reporter.Interface
 	status.Start("Calico CNI detected, checking if the Submariner IPPool pre-requisites are configured")
 	defer status.End()
 
-	gateways, err := info.GetGateways()
+	gateways, err := info.GetGateways(context.TODO())
 	if err != nil {
 		return status.Error(err, "Error retrieving Gateways")
 	}

--- a/pkg/diagnose/cni_test.go
+++ b/pkg/diagnose/cni_test.go
@@ -87,9 +87,9 @@ var _ = Describe("CNIConfig", func() {
 			t.submariner = nil
 		})
 
-		It("should panic", func() {
+		It("should panic", func(ctx SpecContext) {
 			Expect(func() {
-				_ = diagnose.CNIConfig(newClusterInfo(), "", t.statusTracker)
+				_ = diagnose.CNIConfig(newClusterInfo(ctx), "", t.statusTracker)
 			}).To(Panic())
 		})
 	})
@@ -321,5 +321,5 @@ func (t *cniTestDriver) createOVNPod(version, containerName string) {
 }
 
 func (t *cniTestDriver) run() error {
-	return diagnose.CNIConfig(newClusterInfo(), "", t.statusTracker)
+	return diagnose.CNIConfig(newClusterInfo(context.TODO()), "", t.statusTracker)
 }

--- a/pkg/diagnose/connections.go
+++ b/pkg/diagnose/connections.go
@@ -19,6 +19,7 @@ limitations under the License.
 package diagnose
 
 import (
+	"context"
 	"errors"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -39,7 +40,7 @@ func CheckGatewayConnections(clusterInfo *cluster.Info, status reporter.Interfac
 	status.Start("Checking gateway connections")
 	defer status.End()
 
-	gateways, err := clusterInfo.GetGateways()
+	gateways, err := clusterInfo.GetGateways(context.TODO())
 	if err != nil {
 		return status.Error(err, "Error retrieving gateways")
 	}

--- a/pkg/diagnose/connections_test.go
+++ b/pkg/diagnose/connections_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package diagnose_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/subctl/pkg/diagnose"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
@@ -28,7 +30,7 @@ var _ = Describe("CheckGatewayConnections", func() {
 	t := newTestDriver()
 
 	run := func() error {
-		return diagnose.CheckGatewayConnections(newClusterInfo(), t.statusTracker)
+		return diagnose.CheckGatewayConnections(newClusterInfo(context.TODO()), t.statusTracker)
 	}
 
 	When("all connections are established", func() {
@@ -95,7 +97,7 @@ var _ = Describe("CheckRouteAgentConnections", func() {
 	t := newTestDriver()
 
 	run := func() error {
-		return diagnose.CheckRouteAgentConnections(newClusterInfo(), t.statusTracker)
+		return diagnose.CheckRouteAgentConnections(newClusterInfo(context.TODO()), t.statusTracker)
 	}
 
 	When("all connections are established", func() {
@@ -171,7 +173,7 @@ var _ = Describe("Connections", func() {
 	t := newTestDriver()
 
 	run := func() error {
-		return diagnose.Connections(newClusterInfo(), "", t.statusTracker)
+		return diagnose.Connections(newClusterInfo(context.TODO()), "", t.statusTracker)
 	}
 
 	When("all connections are established", func() {

--- a/pkg/diagnose/deployments_test.go
+++ b/pkg/diagnose/deployments_test.go
@@ -404,5 +404,5 @@ func (t *deploymentTestDriver) testMultipleNodes() {
 }
 
 func (t *deploymentTestDriver) run() error {
-	return diagnose.Deployments(newClusterInfo(), "", t.imageOverrides, t.statusTracker)
+	return diagnose.Deployments(newClusterInfo(context.TODO()), "", t.imageOverrides, t.statusTracker)
 }

--- a/pkg/diagnose/diagnose_suite_test.go
+++ b/pkg/diagnose/diagnose_suite_test.go
@@ -304,8 +304,8 @@ func (t *testDriver) testImageRepositoryInfoFailure(before func(), run func() er
 	})
 }
 
-func newClusterInfo() *cluster.Info {
-	info, err := cluster.NewInfo(localCluster, &rest.Config{})
+func newClusterInfo(ctx context.Context) *cluster.Info {
+	info, err := cluster.NewInfo(ctx, localCluster, &rest.Config{})
 	Expect(err).NotTo(HaveOccurred())
 
 	return info

--- a/pkg/diagnose/firewall.go
+++ b/pkg/diagnose/firewall.go
@@ -138,7 +138,7 @@ func getActiveGatewayNodeName(clusterInfo *cluster.Info, status reporter.Interfa
 }
 
 func getGatewayIP(clusterInfo *cluster.Info, localClusterID string) (string, error) {
-	gateways, err := clusterInfo.GetGateways()
+	gateways, err := clusterInfo.GetGateways(context.TODO())
 	if err != nil {
 		return "", errors.Wrapf(err, "Error retrieving gateways from cluster %q", clusterInfo.Name)
 	}

--- a/pkg/diagnose/firewall_test.go
+++ b/pkg/diagnose/firewall_test.go
@@ -140,13 +140,13 @@ func newFirewallTestDriver() *firewallTestDriver {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		var err error
 
-		t.localClusterInfo, err = cluster.NewInfo(localCluster, &rest.Config{})
+		t.localClusterInfo, err = cluster.NewInfo(ctx, localCluster, &rest.Config{})
 		Expect(err).NotTo(HaveOccurred())
 
-		t.remoteClusterInfo, err = cluster.NewInfo(remoteCluster, &rest.Config{})
+		t.remoteClusterInfo, err = cluster.NewInfo(ctx, remoteCluster, &rest.Config{})
 		Expect(err).NotTo(HaveOccurred())
 
 		t.remoteClusterInfo.Submariner.Status.ClusterID = remoteCluster

--- a/pkg/diagnose/globalnet_test.go
+++ b/pkg/diagnose/globalnet_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package diagnose_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
@@ -380,7 +382,7 @@ func (t *globalnetTestDriver) testGlobalIngressIPs() {
 }
 
 func (t *globalnetTestDriver) run() error {
-	return diagnose.GlobalnetConfig(newClusterInfo(), "", t.statusTracker)
+	return diagnose.GlobalnetConfig(newClusterInfo(context.TODO()), "", t.statusTracker)
 }
 
 func (t *globalnetTestDriver) testMismatchedAllocatedIPs(before func()) {

--- a/pkg/diagnose/k8s_version_test.go
+++ b/pkg/diagnose/k8s_version_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package diagnose_test
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -82,7 +83,7 @@ func newK8sVersionTestDriver() *k8sVersionTestDriver {
 }
 
 func (t *k8sVersionTestDriver) run() error {
-	return diagnose.K8sVersion(newClusterInfo(), "", t.statusTracker)
+	return diagnose.K8sVersion(newClusterInfo(context.TODO()), "", t.statusTracker)
 }
 
 func (t *k8sVersionTestDriver) setK8sVersion(minor string) {

--- a/pkg/diagnose/kubeproxy_test.go
+++ b/pkg/diagnose/kubeproxy_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package diagnose_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/subctl/pkg/diagnose"
@@ -105,5 +107,5 @@ type kubeProxyTestDriver struct {
 }
 
 func (t *kubeProxyTestDriver) run() error {
-	return diagnose.KubeProxyMode(newClusterInfo(), "", []string{}, t.statusTracker)
+	return diagnose.KubeProxyMode(newClusterInfo(context.TODO()), "", []string{}, t.statusTracker)
 }

--- a/pkg/diagnose/servicediscovery_test.go
+++ b/pkg/diagnose/servicediscovery_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package diagnose_test
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -331,5 +332,5 @@ func newServiceDiscoveryTestDriver() *serviceDiscoveryTestDriver {
 }
 
 func (t *serviceDiscoveryTestDriver) run() error {
-	return diagnose.ServiceDiscovery(newClusterInfo(), "", t.statusTracker)
+	return diagnose.ServiceDiscovery(newClusterInfo(context.TODO()), "", t.statusTracker)
 }

--- a/pkg/lighthouse/serviceaccount/ensure_test.go
+++ b/pkg/lighthouse/serviceaccount/ensure_test.go
@@ -41,8 +41,6 @@ func TestServiceAccount(t *testing.T) {
 	RunSpecs(t, "Lighthouse ServiceAccount Suite")
 }
 
-var ctx = context.TODO()
-
 var _ = Describe("Ensure", func() {
 	var client *k8sfake.Clientset
 
@@ -51,16 +49,16 @@ var _ = Describe("Ensure", func() {
 	})
 
 	When("no resources exist", func() {
-		It("should create them and return true", func() {
+		It("should create them and return true", func(ctx SpecContext) {
 			created, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeTrue())
 
-			assertServiceAccountsCreated(client)
-			assertClusterRolesCreated(client)
-			assertClusterRoleBindingsCreated(client)
-			assertRolesCreated(client)
-			assertRoleBindingsCreated(client)
+			assertServiceAccountsCreated(ctx, client)
+			assertClusterRolesCreated(ctx, client)
+			assertClusterRoleBindingsCreated(ctx, client)
+			assertRolesCreated(ctx, client)
+			assertRoleBindingsCreated(ctx, client)
 		})
 	})
 
@@ -74,7 +72,7 @@ var _ = Describe("Ensure", func() {
 			})
 		})
 
-		It("should aggregate the returned flag correctly", func() {
+		It("should aggregate the returned flag correctly", func(ctx SpecContext) {
 			created, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeTrue()) // Should be true if any resource was created
@@ -82,12 +80,12 @@ var _ = Describe("Ensure", func() {
 	})
 
 	When("the resources already exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			_, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should succeed and return false", func() {
+		It("should succeed and return false", func(ctx SpecContext) {
 			created, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeFalse())
@@ -100,7 +98,7 @@ var _ = Describe("Ensure", func() {
 				fake.FailOnAction(&client.Fake, strings.ToLower(resource)+"s", "create", nil, false)
 			})
 
-			It("should return an error", func() {
+			It("should return an error", func(ctx SpecContext) {
 				_, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 				Expect(err).To(HaveOccurred())
 			})
@@ -108,7 +106,7 @@ var _ = Describe("Ensure", func() {
 	}
 })
 
-func assertServiceAccountsCreated(client *k8sfake.Clientset) {
+func assertServiceAccountsCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.ServiceDiscoveryComponent,
 		names.LighthouseCoreDNSComponent,
@@ -118,7 +116,7 @@ func assertServiceAccountsCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertClusterRolesCreated(client *k8sfake.Clientset) {
+func assertClusterRolesCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.ServiceDiscoveryComponent,
 		names.LighthouseCoreDNSComponent,
@@ -128,7 +126,7 @@ func assertClusterRolesCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertClusterRoleBindingsCreated(client *k8sfake.Clientset) {
+func assertClusterRoleBindingsCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.ServiceDiscoveryComponent,
 		names.LighthouseCoreDNSComponent,
@@ -138,7 +136,7 @@ func assertClusterRoleBindingsCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertRolesCreated(client *k8sfake.Clientset) {
+func assertRolesCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.ServiceDiscoveryComponent,
 		names.LighthouseCoreDNSComponent,
@@ -148,7 +146,7 @@ func assertRolesCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertRoleBindingsCreated(client *k8sfake.Clientset) {
+func assertRoleBindingsCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.ServiceDiscoveryComponent,
 		names.LighthouseCoreDNSComponent,

--- a/pkg/submariner/serviceaccount/ensure_test.go
+++ b/pkg/submariner/serviceaccount/ensure_test.go
@@ -39,8 +39,6 @@ func TestServiceAccount(t *testing.T) {
 	RunSpecs(t, "Submariner ServiceAccount Suite")
 }
 
-var ctx = context.TODO()
-
 var _ = Describe("Ensure", func() {
 	var client *k8sfake.Clientset
 
@@ -49,16 +47,16 @@ var _ = Describe("Ensure", func() {
 	})
 
 	When("no resources exist", func() {
-		It("should create them and return true", func() {
+		It("should create them and return true", func(ctx SpecContext) {
 			created, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeTrue())
 
-			assertServiceAccountsCreated(client)
-			assertClusterRolesCreated(client)
-			assertClusterRoleBindingsCreated(client)
-			assertRolesCreated(client)
-			assertRoleBindingsCreated(client)
+			assertServiceAccountsCreated(ctx, client)
+			assertClusterRolesCreated(ctx, client)
+			assertClusterRoleBindingsCreated(ctx, client)
+			assertRolesCreated(ctx, client)
+			assertRoleBindingsCreated(ctx, client)
 
 			created, err = serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -76,7 +74,7 @@ var _ = Describe("Ensure", func() {
 			})
 		})
 
-		It("should aggregate the returned flag correctly", func() {
+		It("should aggregate the returned flag correctly", func(ctx SpecContext) {
 			created, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeTrue()) // Should be true if any resource was created
@@ -84,12 +82,12 @@ var _ = Describe("Ensure", func() {
 	})
 
 	When("the resources already exist", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			_, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should succeed and return false", func() {
+		It("should succeed and return false", func(ctx SpecContext) {
 			created, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(created).To(BeFalse())
@@ -101,14 +99,14 @@ var _ = Describe("Ensure", func() {
 			fake.FailOnAction(&client.Fake, "roles", "create", nil, false)
 		})
 
-		It("should return an error", func() {
+		It("should return an error", func(ctx SpecContext) {
 			_, err := serviceaccount.Ensure(ctx, client, constants.OperatorNamespace)
 			Expect(err).To(HaveOccurred())
 		})
 	})
 })
 
-func assertServiceAccountsCreated(client *k8sfake.Clientset) {
+func assertServiceAccountsCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.GatewayComponent,
 		names.RouteAgentComponent,
@@ -120,7 +118,7 @@ func assertServiceAccountsCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertClusterRolesCreated(client *k8sfake.Clientset) {
+func assertClusterRolesCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.GatewayComponent,
 		names.RouteAgentComponent,
@@ -132,7 +130,7 @@ func assertClusterRolesCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertClusterRoleBindingsCreated(client *k8sfake.Clientset) {
+func assertClusterRoleBindingsCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.GatewayComponent,
 		names.RouteAgentComponent,
@@ -144,7 +142,7 @@ func assertClusterRoleBindingsCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertRolesCreated(client *k8sfake.Clientset) {
+func assertRolesCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.GatewayComponent,
 		names.RouteAgentComponent,
@@ -157,7 +155,7 @@ func assertRolesCreated(client *k8sfake.Clientset) {
 	}
 }
 
-func assertRoleBindingsCreated(client *k8sfake.Clientset) {
+func assertRoleBindingsCreated(ctx context.Context, client *k8sfake.Clientset) {
 	for _, name := range []string{
 		names.GatewayComponent,
 		names.RouteAgentComponent,

--- a/pkg/uninstall/all_test.go
+++ b/pkg/uninstall/all_test.go
@@ -46,13 +46,13 @@ var _ = Describe("All", func() {
 		Expect(uninstall.All(t.clients, testClusterName, testSubmarinerNS, t.statusReporter)).To(Succeed())
 	}
 
-	It("should uninstall all Submariner components", func() {
+	It("should uninstall all Submariner components", func(ctx SpecContext) {
 		assertUninstallSuccess()
-		t.assertComponentsDeleted()
+		t.assertComponentsDeleted(ctx)
 	})
 
 	When("only ServiceDiscovery is installed", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			t.submariner = nil
 
 			Expect(t.clients.ForGeneral().Create(ctx, &operatorv1alpha1.ServiceDiscovery{
@@ -63,7 +63,7 @@ var _ = Describe("All", func() {
 			})).To(Succeed())
 		})
 
-		It("should delete the ServiceDiscovery resource", func() {
+		It("should delete the ServiceDiscovery resource", func(ctx SpecContext) {
 			assertUninstallSuccess()
 
 			// Verify ServiceDiscovery resource is deleted
@@ -73,7 +73,7 @@ var _ = Describe("All", func() {
 			}, &operatorv1alpha1.ServiceDiscovery{})
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-			t.assertComponentsDeleted()
+			t.assertComponentsDeleted(ctx)
 		})
 	})
 
@@ -82,14 +82,14 @@ var _ = Describe("All", func() {
 			t.submariner = nil
 		})
 
-		It("should uninstall all remaining Submariner components", func() {
+		It("should uninstall all remaining Submariner components", func(ctx SpecContext) {
 			assertUninstallSuccess()
-			t.assertComponentsDeleted()
+			t.assertComponentsDeleted(ctx)
 		})
 	})
 
 	When("the broker is in use by other clusters", func() {
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			Expect(t.clients.ForGeneral().Create(ctx, &submarinerv1.Endpoint{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "remote-endpoint",
@@ -118,7 +118,7 @@ var _ = Describe("All", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should not delete broker and operator resources", func() {
+		It("should not delete broker and operator resources", func(ctx SpecContext) {
 			assertUninstallSuccess()
 
 			// Verify broker namespace still exists
@@ -154,9 +154,9 @@ var _ = Describe("All", func() {
 			t.broker = nil
 		})
 
-		It("should uninstall all Submariner components", func() {
+		It("should uninstall all Submariner components", func(ctx SpecContext) {
 			assertUninstallSuccess()
-			t.assertComponentsDeleted()
+			t.assertComponentsDeleted(ctx)
 		})
 	})
 
@@ -166,15 +166,15 @@ var _ = Describe("All", func() {
 		})
 
 		Context("and the operator deployment does not exist", func() {
-			It("should log a warning and eventually delete it", func() {
+			It("should log a warning and eventually delete it", func(ctx SpecContext) {
 				assertUninstallSuccess()
-				t.assertComponentsDeleted()
+				t.assertComponentsDeleted(ctx)
 				t.statusReporter.AssertWarningContainsStrings("deployment does not exist")
 			})
 		})
 
 		Context("and the operator deployment exists", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				_, err := t.clients.ForKubernetes().AppsV1().Deployments(testSubmarinerNS).Create(ctx, &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: names.OperatorComponent,
@@ -191,28 +191,28 @@ var _ = Describe("All", func() {
 			})
 
 			Context("but no pod exists", func() {
-				It("should log a warning and eventually delete it", func() {
+				It("should log a warning and eventually delete it", func(ctx SpecContext) {
 					assertUninstallSuccess()
-					t.assertComponentsDeleted()
+					t.assertComponentsDeleted(ctx)
 					t.statusReporter.AssertWarningContainsStrings("pod does not exist")
 				})
 			})
 
 			Context("and the pod is not running", func() {
-				BeforeEach(func() {
-					t.createOperatorPod(corev1.PodSucceeded)
+				BeforeEach(func(ctx SpecContext) {
+					t.createOperatorPod(ctx, corev1.PodSucceeded)
 				})
 
-				It("should log a warning and eventually delete it", func() {
+				It("should log a warning and eventually delete it", func(ctx SpecContext) {
 					assertUninstallSuccess()
-					t.assertComponentsDeleted()
+					t.assertComponentsDeleted(ctx)
 					t.statusReporter.AssertWarningContainsStrings("pod is not running")
 				})
 			})
 
 			Context("and the pod is running", func() {
-				BeforeEach(func() {
-					t.createOperatorPod(corev1.PodRunning)
+				BeforeEach(func(ctx SpecContext) {
+					t.createOperatorPod(ctx, corev1.PodRunning)
 				})
 
 				It("should fail", func() {

--- a/pkg/uninstall/uninstall_suite_test.go
+++ b/pkg/uninstall/uninstall_suite_test.go
@@ -54,8 +54,6 @@ const (
 	otherLabel       = "other-label"
 )
 
-var ctx = context.TODO()
-
 var _ = BeforeSuite(func() {
 	Expect(operatorv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(submarinerv1.AddToScheme(scheme.Scheme)).To(Succeed())
@@ -113,7 +111,7 @@ func newTestDriver() *testDriver {
 		}
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx SpecContext) {
 		if t.submarinerNS != nil {
 			_, err := t.clients.ForKubernetes().CoreV1().Namespaces().Create(ctx, t.submarinerNS, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -176,7 +174,7 @@ func newTestDriver() *testDriver {
 	return t
 }
 
-func (t *testDriver) createOperatorPod(phase corev1.PodPhase) {
+func (t *testDriver) createOperatorPod(ctx context.Context, phase corev1.PodPhase) {
 	_, err := t.clients.ForKubernetes().CoreV1().Pods(testSubmarinerNS).Create(ctx, &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "operator-pod",
@@ -189,7 +187,7 @@ func (t *testDriver) createOperatorPod(phase corev1.PodPhase) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func (t *testDriver) assertComponentsDeleted() {
+func (t *testDriver) assertComponentsDeleted(ctx context.Context) {
 	// Verify Submariner resource is deleted
 	if t.submariner != nil {
 		err := t.clients.ForGeneral().Get(ctx, controllerclient.ObjectKey{


### PR DESCRIPTION
The new `context.TODO()` calls will be addressed in a future change.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suites updated to use explicit per-test contexts across many packages, improving test reliability and consistency.

* **Refactor**
  * Core initialization and helper flows made context-aware and updated to propagate contexts through drivers and helpers, aligning runtime setup and diagnostics with the testing framework while preserving behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->