### PR TITLE
Pin Konflux Dockerfile version labels to v0.22.1

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -50,7 +50,7 @@ ENTRYPOINT ["/usr/local/bin/subctl"]
 
 LABEL com.redhat.component="subctl-container" \
       name="rhacm2/subctl-rhel9" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="The command-line interface for Submariner (subctl)" \
       description="A command-line utility for installing, configuring, and troubleshooting Submariner cross-cluster connectivity." \
       io.k8s.display-name="Submariner Control Utility (subctl)" \


### PR DESCRIPTION
Enables dynamic tagging in Konflux releases for 0.22.1 Z-stream.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
