### PR TITLE
Fix wsl_v5 linter warnings reported in golangci-lint 2.9.0

### DIFF
--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Reporter", func() {
 				Expect(output.String()).NotTo(ContainSubstring(msg))
 
 				reporter.End()
+
 				s := strings.Split(output.String(), "\n")
 				Expect(s).To(ContainElements(ContainSubstring(completionStr+startMsg), ContainSubstring(completionStr+msg)))
 			})

--- a/pkg/serviceaccount/ensure_test.go
+++ b/pkg/serviceaccount/ensure_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Ensure", func() {
 				},
 			})
 			Expect(err).To(Succeed())
+
 			actual := t.assertServiceAccount(ctx)
 			Expect(created).To(Equal(actual))
 		})


### PR DESCRIPTION
Add blank lines before return and go statements to satisfy wsl_v5 whitespace requirements.
