### PR TITLE
Update CPE label to ACM 2.15

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -59,5 +59,5 @@ LABEL com.redhat.component="subctl-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.14::el9" \
+      cpe="cpe:/a:redhat:acm:2.15::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
Updates CPE from 2.14 to 2.15 for Submariner 0.22 release.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image metadata to version 2.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->