### PR TITLE
Fix issue with AWS instance type

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -88,7 +88,7 @@ func init() {
 	}
 
 	addGeneralAWSFlags(awsPrepareCmd)
-	awsPrepareCmd.Flags().StringVar(&awsConfig.GWInstanceType, "gateway-instance", "c5d.large", "Type of gateways instance machine")
+	awsPrepareCmd.Flags().StringVar(&awsConfig.GWInstanceType, "gateway-instance", "m5.xlarge", "Type of gateways instance machine")
 	awsPrepareCmd.Flags().IntVar(&awsConfig.Gateways, "gateways", defaultNumGateways,
 		"Number of dedicated gateways to deploy (Set to `0` when using --load-balancer mode)")
 


### PR DESCRIPTION
`c5d.large` is not working so changed to `m5.xlarge`
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AWS instance type for gateway deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->