### PR TITLE
Automated backport of #1683: Fix issue with AWS instance type

### DIFF
--- a/cmd/subctl/aws.go
+++ b/cmd/subctl/aws.go
@@ -88,7 +88,7 @@ func init() {
 	}
 
 	addGeneralAWSFlags(awsPrepareCmd)
-	awsPrepareCmd.Flags().StringVar(&awsConfig.GWInstanceType, "gateway-instance", "c5d.large", "Type of gateways instance machine")
+	awsPrepareCmd.Flags().StringVar(&awsConfig.GWInstanceType, "gateway-instance", "m5.xlarge", "Type of gateways instance machine")
 	awsPrepareCmd.Flags().IntVar(&awsConfig.Gateways, "gateways", defaultNumGateways,
 		"Number of dedicated gateways to deploy (Set to `0` when using --load-balancer mode)")
 


### PR DESCRIPTION
Backport of #1683 on release-0.23.

#1683: Fix issue with AWS instance type

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AWS gateway instance type from c5d.large to m5.xlarge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->