### PR TITLE
Adjust to golangci-lint v2.11.3

### DIFF
--- a/pkg/broker/file_test.go
+++ b/pkg/broker/file_test.go
@@ -151,7 +151,7 @@ func testReadInfoFromFile() {
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {
-				_ = os.Remove(file.Name()) //nolint:gosec // Test cleanup of temp file we just created
+				_ = os.Remove(file.Name())
 			})
 		})
 

--- a/pkg/client/fake/producer.go
+++ b/pkg/client/fake/producer.go
@@ -69,7 +69,7 @@ func CreateKubeConfigFile(clientConfig *api.Config) string {
 	Expect(err).To(Succeed())
 
 	DeferCleanup(func() {
-		_ = os.Remove(file.Name()) //nolint:gosec // Test cleanup of temp file we just created
+		_ = os.Remove(file.Name())
 	})
 
 	Expect(clientcmd.WriteToFile(*clientConfig, file.Name())).To(Succeed())

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -132,7 +132,7 @@ func initializeFromAuthFile(authFile string) (string, error) {
 
 	var authInfo struct {
 		ClientID       string
-		ClientSecret   string //nolint:gosec // Field name required by Azure auth file format
+		ClientSecret   string
 		SubscriptionID string
 		TenantID       string
 	}


### PR DESCRIPTION
See commits for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed lint directives from test and client code files. No functional changes or user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->