### PR TITLE
Upgrade subctl to RHEL 10

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -1,7 +1,7 @@
 ARG BASE_BRANCH=release-0.23
 ARG SOURCE=/go/src/github.com/submariner-io/subctl
 
-FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi9/go-toolset:latest AS builder
+FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi10/go-toolset:latest AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 ARG BASE_BRANCH
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=1 GOARCH=${TARGETPLATFORM##*/} go build \
     -v -o ${SOURCE}/bin/${TARGETPLATFORM}/subctl \
     ./cmd
 
-FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi9:latest
+FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi10:latest
 ARG BASE_BRANCH
 ARG SOURCE
 ARG SOURCE_DATE_EPOCH
@@ -49,7 +49,7 @@ USER submariner
 ENTRYPOINT ["/usr/local/bin/subctl"]
 
 LABEL com.redhat.component="subctl-container" \
-      name="rhacm2/subctl-rhel9" \
+      name="rhacm2/subctl-rhel10" \
       version="v0.23.0" \
       summary="The command-line interface for Submariner (subctl)" \
       description="A command-line utility for installing, configuring, and troubleshooting Submariner cross-cluster connectivity." \
@@ -59,5 +59,5 @@ LABEL com.redhat.component="subctl-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.15::el9" \
+      cpe="cpe:/a:redhat:acm:2.16::el10" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
Changes:
- Update Dockerfile.subctl.konflux to UBI 10 base images
- Update container labels from rhel9 to rhel10
- Update CPE from 2.15::el9 to 2.16::el10

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
