### PR TITLE
Fix upgrade with version prefix causing image pull failures

### DIFF
--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -130,14 +130,17 @@ func (c *upgradeCommand) upgradeSubctl(status reporter.Interface) (string, error
 		}
 	}
 
-	if c.subctlVersion == version.Version {
+	// Normalize versions by stripping 'v' prefix for comparison and further use
+	if c.subctlVersion != "" {
+		c.subctlVersion = strings.TrimPrefix(c.subctlVersion, "v")
+	}
+
+	if c.subctlVersion == strings.TrimPrefix(version.Version, "v") {
 		// Already running the right version
 		return "", nil
 	}
 
 	if c.subctlVersion != "" {
-		c.subctlVersion = strings.TrimPrefix(c.subctlVersion, "v")
-
 		toVersion, err := semver.NewVersion(c.subctlVersion)
 		if toVersion == nil {
 			return "", status.Error(err, "Invalid target version")

--- a/cmd/subctl/upgrade_test.go
+++ b/cmd/subctl/upgrade_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -128,15 +129,6 @@ var _ = Describe("Upgrade", func() {
 	When("the --to-version flag is specified", func() {
 		var toVersion string
 
-		BeforeEach(func() {
-			oldVersion := version.Version
-			version.Version = "100.0.0"
-
-			DeferCleanup(func() {
-				version.Version = oldVersion
-			})
-		})
-
 		Context("and the specified version is newer", func() {
 			BeforeEach(func() {
 				toVersion = "101.0.0"
@@ -222,6 +214,13 @@ func newUpgradeTestDriver() *upgradeTestDriver {
 	BeforeEach(func() {
 		t.cmd = subctl.NewUpgradeCmd()
 
+		oldVersion := version.Version
+		version.Version = "v100.0.0"
+
+		DeferCleanup(func() {
+			version.Version = oldVersion
+		})
+
 		t.httpHandler = func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, err := fmt.Fprintf(w, "{\"tag_name\": \"%s\"}", version.Version)
@@ -261,5 +260,5 @@ func (t *upgradeTestDriver) assertOperatorDeploymentUpgraded(ctx context.Context
 		ctx, names.OperatorComponent, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-	Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring(toVersion))
+	Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HaveSuffix(":" + strings.TrimPrefix(toVersion, "v")))
 }


### PR DESCRIPTION
When upgrading without specifying --to-version, the latest release tag (e.g., "v0.23.1") is retrieved from GitHub. If the upgraded binary's version matches the retrieved tag, the code returns early before stripping the "v" prefix. This causes the operator version to retain the "v" prefix, resulting in image pull failures with tags like "v0.23.1" instead of "0.23.1".

The fix normalizes the version by stripping the "v" prefix immediately after retrieval and compares both versions without the prefix to ensure consistent behavior regardless of code path.

Fixes https://github.com/submariner-io/subctl/issues/1699


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed version string handling during subctl upgrades to correctly process version identifiers with or without "v" prefix formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->