### PR TITLE
Automated backport of #1723: Fix upgrade with version prefix causing image pull failures

### DIFF
--- a/cmd/subctl/upgrade.go
+++ b/cmd/subctl/upgrade.go
@@ -130,14 +130,17 @@ func (c *upgradeCommand) upgradeSubctl(status reporter.Interface) (string, error
 		}
 	}
 
-	if c.subctlVersion == version.Version {
+	// Normalize versions by stripping 'v' prefix for comparison and further use
+	if c.subctlVersion != "" {
+		c.subctlVersion = strings.TrimPrefix(c.subctlVersion, "v")
+	}
+
+	if c.subctlVersion == strings.TrimPrefix(version.Version, "v") {
 		// Already running the right version
 		return "", nil
 	}
 
 	if c.subctlVersion != "" {
-		c.subctlVersion = strings.TrimPrefix(c.subctlVersion, "v")
-
 		toVersion, err := semver.NewVersion(c.subctlVersion)
 		if toVersion == nil {
 			return "", status.Error(err, "Invalid target version")

--- a/cmd/subctl/upgrade_test.go
+++ b/cmd/subctl/upgrade_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -128,15 +129,6 @@ var _ = Describe("Upgrade", func() {
 	When("the --to-version flag is specified", func() {
 		var toVersion string
 
-		BeforeEach(func() {
-			oldVersion := version.Version
-			version.Version = "100.0.0"
-
-			DeferCleanup(func() {
-				version.Version = oldVersion
-			})
-		})
-
 		Context("and the specified version is newer", func() {
 			BeforeEach(func() {
 				toVersion = "101.0.0"
@@ -222,6 +214,13 @@ func newUpgradeTestDriver() *upgradeTestDriver {
 	BeforeEach(func() {
 		t.cmd = subctl.NewUpgradeCmd()
 
+		oldVersion := version.Version
+		version.Version = "v100.0.0"
+
+		DeferCleanup(func() {
+			version.Version = oldVersion
+		})
+
 		t.httpHandler = func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, err := fmt.Fprintf(w, "{\"tag_name\": \"%s\"}", version.Version)
@@ -261,5 +260,5 @@ func (t *upgradeTestDriver) assertOperatorDeploymentUpgraded(ctx context.Context
 		ctx, names.OperatorComponent, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-	Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring(toVersion))
+	Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(HaveSuffix(":" + strings.TrimPrefix(toVersion, "v")))
 }


### PR DESCRIPTION
Backport of #1723 on release-0.23.

#1723: Fix upgrade with version prefix causing image pull failures

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed version comparison logic in the upgrade process to consistently normalize and handle version strings, ensuring accurate upgrade detection regardless of format variations. This improves the reliability of identifying when upgrades are needed and available across all upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->