### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -58,6 +58,5 @@ LABEL com.redhat.component="subctl-container" \
       io.openshift.tags="submariner, subctl, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.17::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label contained a branch name, not a commit hash, was never updated, and nothing reads it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
