### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -58,6 +58,5 @@ LABEL com.redhat.component="subctl-container" \
       io.openshift.tags="submariner, subctl, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/submariner-operator" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.15::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label was never used by any tooling and contained stale values.