### PR TITLE
Gather nftables rules alongside iptables in subctl gather

### DIFF
--- a/internal/gather/cni.go
+++ b/internal/gather/cni.go
@@ -55,6 +55,11 @@ var ipTablesCmds = map[string]string{
 	"iptables-save":   "iptables-save -c",
 }
 
+var nfTablesCmds = map[string]string{
+	"nftables-ruleset": "nft list ruleset",
+	"nftables-save":    "nft -a list ruleset",
+}
+
 var libreswanCmds = map[string]string{
 	"ip-xfrm-policy":      "ip xfrm policy",
 	"ip-xfrm-state":       "ip xfrm state",
@@ -102,6 +107,7 @@ func gatherCNIResources(ctx context.Context, info *Info, networkPlugin string) {
 		switch networkPluginCNIType[networkPlugin] {
 		case typeIPTables, typeOvn:
 			logIPTablesCmds(ctx, info, pod)
+			logNFTablesCmds(ctx, info, pod)
 		case typeUnknown:
 			info.Status.Failure("Unsupported CNI Type")
 		}
@@ -129,6 +135,12 @@ func logIPGatewayCmds(ctx context.Context, info *Info, pod *v1.Pod) {
 func logIPTablesCmds(ctx context.Context, info *Info, pod *v1.Pod) {
 	for name, cmd := range ipTablesCmds {
 		logCmdOutput(ctx, info, pod, cmd, name, false)
+	}
+}
+
+func logNFTablesCmds(ctx context.Context, info *Info, pod *v1.Pod) {
+	for name, cmd := range nfTablesCmds {
+		logCmdOutput(ctx, info, pod, cmd, name, true)
 	}
 }
 


### PR DESCRIPTION
Submariner switched from iptables to nftables as the default packet filter driver starting in v0.22.0. However, subctl gather only collects iptables rules, creating a diagnostic gap when analyzing nftables-based deployments offline.

This commit adds collection of nftables rulesets alongside the existing iptables collection:
- nft list ruleset: Complete nftables configuration
- nft -a list ruleset: Same with rule handles (similar to iptables line numbers)

The nftables commands use ignoreError=true to avoid failures on systems that don't have nftables installed, ensuring backward compatibility with iptables-only environments.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network diagnostics now collect nftables ruleset output alongside iptables, giving better visibility into active network rules.
* **Bug Fixes**
  * Firewall data collection is more robust: individual nftables query failures are ignored so diagnostics complete reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->