### PR TITLE
Update version labels to v0.21.3

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -50,7 +50,7 @@ ENTRYPOINT ["/usr/local/bin/subctl"]
 
 LABEL com.redhat.component="subctl-container" \
       name="rhacm2/subctl-rhel9" \
-      version="v0.21.2" \
+      version="v0.21.3" \
       summary="The command-line interface for Submariner (subctl)" \
       description="A command-line utility for installing, configuring, and troubleshooting Submariner cross-cluster connectivity." \
       io.k8s.display-name="Submariner Control Utility (subctl)" \


### PR DESCRIPTION
Update Dockerfile version labels from v0.21.2 to v0.21.3 for correct Konflux image tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image version to v0.21.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/subctl/pull/1792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->