### PR TITLE
Add Amazon VPC CNI to diagnose support

### DIFF
--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -48,7 +48,7 @@ var MinOVNNBVersion = semver.New("6.1.0")
 var supportedNetworkPlugins = []string{
 	cni.Generic, cni.CanalFlannel, cni.WeaveNet,
 	cni.OpenShiftSDN, cni.OVNKubernetes, cni.Calico,
-	cni.KindNet,
+	cni.KindNet, cni.AmazonVPCCNI,
 }
 
 var CalicoGVR = schema.GroupVersionResource{

--- a/pkg/diagnose/cni_test.go
+++ b/pkg/diagnose/cni_test.go
@@ -52,6 +52,7 @@ var _ = Describe("CNIConfig", func() {
 		Entry("the WeaveNet", cni.WeaveNet),
 		Entry("the OpenShiftSDN", cni.OpenShiftSDN),
 		Entry("the KindNet", cni.KindNet),
+		Entry("the Amazon VPC CNI", cni.AmazonVPCCNI),
 	)
 
 	When("the network plugin is Generic", func() {


### PR DESCRIPTION
## What this PR does / why we need it

Recognizes `amazon-vpc-cni` as a supported network plugin in `subctl diagnose`, so EKS clusters are not reported as unsupported/`generic` once the operator/route-agent side lands.

## Depends on

- Related to operator discovery + route-agent handler PRs (plugin name constant).

## Related issues

- Related to https://github.com/submariner-io/submariner/issues/3697

## Checklist

- [ ] Tests updated

## Cross-links (this series)

- Related operator discovery: https://github.com/submariner-io/submariner-operator/pull/4143
- Related route-agent handler: https://github.com/submariner-io/submariner/pull/4100

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for Amazon VPC CNI in network plugin diagnostics.
  * Diagnostics now correctly recognize Amazon VPC CNI as a supported configuration.

* **Tests**
  * Added coverage to verify successful diagnostics with Amazon VPC CNI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->