### PR TITLE
Add --coredns-custom-configmap-key join flag

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -154,6 +154,9 @@ func (c *JoinCommand) addFlags() {
 	c.cmd.Flags().StringVar(&c.flags.CoreDNSCustomConfigMap, "coredns-custom-configmap", "",
 		"Name of the custom CoreDNS configmap to configure forwarding to lighthouse. It should be in "+
 			"<namespace>/<name> format where <namespace> is optional and defaults to kube-system")
+	c.cmd.Flags().StringVar(&c.flags.CoreDNSCustomConfigKey, "coredns-custom-configmap-key", "",
+		"Data key in --coredns-custom-configmap for lighthouse forwarding (default lighthouse.server; "+
+			"use Corefile when CoreDNS imports a full Corefile snippet)")
 	c.cmd.Flags().BoolVar(&c.flags.IgnoreRequirements, "ignore-requirements", false, "ignore requirement failures (unsupported)")
 
 	c.cmd.Flags().BoolVar(&c.flags.BrokerK8sSecure, "check-broker-certificate", true,

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -159,8 +159,7 @@ func (c *JoinCommand) addFlags() {
 		"Name of the custom CoreDNS configmap to configure forwarding to lighthouse. It should be in "+
 			"<namespace>/<name> format where <namespace> is optional and defaults to kube-system")
 	c.cmd.Flags().StringVar(&c.flags.CoreDNSCustomConfigKey, "coredns-custom-configmap-key", "",
-		"Data key in --coredns-custom-configmap for lighthouse forwarding (default lighthouse.server; "+
-			"use Corefile when CoreDNS imports a full Corefile snippet)")
+		"CoreDNS ConfigMap key where Lighthouse configuration is written (default lighthouse.server)")
 	c.cmd.Flags().BoolVar(&c.flags.IgnoreRequirements, "ignore-requirements", false, "ignore requirement failures (unsupported)")
 
 	c.cmd.Flags().BoolVar(&c.flags.BrokerK8sSecure, "check-broker-certificate", true,

--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -102,6 +102,10 @@ func (c *JoinCommand) checkArguments(args []string) error {
 		return err
 	}
 
+	if err := join.ValidateCustomCoreDNSConfig(c.flags.CoreDNSCustomConfigMap, c.flags.CoreDNSCustomConfigKey); err != nil {
+		return err
+	}
+
 	return checkImageOverrides(c.flags.ImageOverrideArr)
 }
 

--- a/cmd/subctl/join_test.go
+++ b/cmd/subctl/join_test.go
@@ -361,4 +361,11 @@ func testCheckArguments() {
 			Expect(cmd.Args(cmd, []string{"broker-info.subm"})).NotTo(Succeed())
 		})
 	})
+
+	When("a CoreDNS custom config key is specified without a ConfigMap", func() {
+		It("should fail", func() {
+			Expect(cmd.Flags().Set("coredns-custom-configmap-key", "Corefile")).To(Succeed())
+			Expect(cmd.Args(cmd, []string{"broker-info.subm"})).NotTo(Succeed())
+		})
+	})
 }

--- a/pkg/deploy/servicediscovery.go
+++ b/pkg/deploy/servicediscovery.go
@@ -40,6 +40,7 @@ type ServiceDiscoveryOptions struct {
 	ClustersetIPEnabled    bool
 	ClusterID              string
 	CoreDNSCustomConfigMap string
+	CoreDNSCustomConfigKey string
 	Repository             string
 	ImageVersion           string
 	CustomDomains          []string
@@ -95,6 +96,7 @@ func populateServiceDiscoverySpec(options *ServiceDiscoveryOptions, brokerInfo *
 		serviceDiscoverySpec.CoreDNSCustomConfig = &operatorv1alpha1.CoreDNSCustomConfig{
 			ConfigMapName: name,
 			Namespace:     namespace,
+			Key:           options.CoreDNSCustomConfigKey,
 		}
 	}
 

--- a/pkg/deploy/servicediscovery_test.go
+++ b/pkg/deploy/servicediscovery_test.go
@@ -96,11 +96,25 @@ var _ = Describe("ServiceDiscovery", func() {
 			options.CoreDNSCustomConfigMap = "test-namespace/test-configmap"
 		})
 
-		It("should set the CoreDNSCustomConfig field", func(ctx SpecContext) {
+		It("should set the CoreDNSCustomConfig field without a key", func(ctx SpecContext) {
 			Expect(expectServiceDiscoverySuccess(ctx).CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
 				ConfigMapName: "test-configmap",
 				Namespace:     "test-namespace",
 			}))
+		})
+
+		When("a custom config map key is provided", func() {
+			BeforeEach(func() {
+				options.CoreDNSCustomConfigKey = "Corefile"
+			})
+
+			It("should set the Key field", func(ctx SpecContext) {
+				Expect(expectServiceDiscoverySuccess(ctx).CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
+					ConfigMapName: "test-configmap",
+					Namespace:     "test-namespace",
+					Key:           "Corefile",
+				}))
+			})
 		})
 	})
 

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -56,6 +56,7 @@ type SubmarinerOptions struct {
 	ClusterID                       string
 	CableDriver                     string
 	CoreDNSCustomConfigMap          string
+	CoreDNSCustomConfigKey          string
 	Repository                      string
 	ImageVersion                    string
 	ServiceCIDR                     string
@@ -137,6 +138,7 @@ func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info,
 		submarinerSpec.CoreDNSCustomConfig = &operatorv1alpha1.CoreDNSCustomConfig{
 			ConfigMapName: name,
 			Namespace:     namespace,
+			Key:           options.CoreDNSCustomConfigKey,
 		}
 	}
 

--- a/pkg/deploy/submariner_test.go
+++ b/pkg/deploy/submariner_test.go
@@ -153,11 +153,25 @@ func testSubmariner() {
 			options.CoreDNSCustomConfigMap = "test-namespace/test-configmap"
 		})
 
-		It("should set the CoreDNSCustomConfig field", func(ctx SpecContext) {
+		It("should set the CoreDNSCustomConfig field without a key", func(ctx SpecContext) {
 			Expect(expectDeploySuccess(ctx).CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
 				ConfigMapName: "test-configmap",
 				Namespace:     "test-namespace",
 			}))
+		})
+
+		When("a custom config map key is provided", func() {
+			BeforeEach(func() {
+				options.CoreDNSCustomConfigKey = "Corefile"
+			})
+
+			It("should set the Key field", func(ctx SpecContext) {
+				Expect(expectDeploySuccess(ctx).CoreDNSCustomConfig).To(Equal(&operatorv1alpha1.CoreDNSCustomConfig{
+					ConfigMapName: "test-configmap",
+					Namespace:     "test-namespace",
+					Key:           "Corefile",
+				}))
+			})
 		})
 	})
 

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -54,7 +54,7 @@ func ClusterToBroker(ctx context.Context, brokerInfo *broker.Info, options *Opti
 		return err
 	}
 
-	err = isValidCustomCoreDNSConfig(options.CoreDNSCustomConfigMap)
+	err = isValidCustomCoreDNSConfig(options.CoreDNSCustomConfigMap, options.CoreDNSCustomConfigKey)
 	if err != nil {
 		return status.Error(err, "error validating custom CoreDNS config")
 	}
@@ -182,6 +182,7 @@ func submarinerOptionsFrom(joinOptions *Options) *deploy.SubmarinerOptions {
 		ClusterID:                       joinOptions.ClusterID,
 		CableDriver:                     joinOptions.CableDriver,
 		CoreDNSCustomConfigMap:          joinOptions.CoreDNSCustomConfigMap,
+		CoreDNSCustomConfigKey:          joinOptions.CoreDNSCustomConfigKey,
 		Repository:                      joinOptions.Repository,
 		ImageVersion:                    joinOptions.ImageVersion,
 		CustomDomains:                   joinOptions.CustomDomains,
@@ -199,6 +200,7 @@ func serviceDiscoveryOptionsFrom(joinOptions *Options) *deploy.ServiceDiscoveryO
 		SubmarinerDebug:        joinOptions.SubmarinerDebug,
 		ClusterID:              joinOptions.ClusterID,
 		CoreDNSCustomConfigMap: joinOptions.CoreDNSCustomConfigMap,
+		CoreDNSCustomConfigKey: joinOptions.CoreDNSCustomConfigKey,
 		Repository:             joinOptions.Repository,
 		ImageVersion:           joinOptions.ImageVersion,
 		CustomDomains:          joinOptions.CustomDomains,
@@ -241,9 +243,13 @@ func populateBrokerSecret(brokerInfo *broker.Info) *v1.Secret {
 	}
 }
 
-func isValidCustomCoreDNSConfig(corednsCustomConfigMap string) error {
+func isValidCustomCoreDNSConfig(corednsCustomConfigMap, corednsCustomConfigKey string) error {
 	if corednsCustomConfigMap != "" && strings.Count(corednsCustomConfigMap, "/") > 1 {
 		return errors.New("coredns-custom-configmap should be in <namespace>/<name> format, namespace is optional")
+	}
+
+	if corednsCustomConfigKey != "" && corednsCustomConfigMap == "" {
+		return errors.New("--coredns-custom-configmap-key requires --coredns-custom-configmap")
 	}
 
 	return nil

--- a/pkg/join/join.go
+++ b/pkg/join/join.go
@@ -54,7 +54,7 @@ func ClusterToBroker(ctx context.Context, brokerInfo *broker.Info, options *Opti
 		return err
 	}
 
-	err = isValidCustomCoreDNSConfig(options.CoreDNSCustomConfigMap, options.CoreDNSCustomConfigKey)
+	err = ValidateCustomCoreDNSConfig(options.CoreDNSCustomConfigMap, options.CoreDNSCustomConfigKey)
 	if err != nil {
 		return status.Error(err, "error validating custom CoreDNS config")
 	}
@@ -243,7 +243,7 @@ func populateBrokerSecret(brokerInfo *broker.Info) *v1.Secret {
 	}
 }
 
-func isValidCustomCoreDNSConfig(corednsCustomConfigMap, corednsCustomConfigKey string) error {
+func ValidateCustomCoreDNSConfig(corednsCustomConfigMap, corednsCustomConfigKey string) error {
 	if corednsCustomConfigMap != "" && strings.Count(corednsCustomConfigMap, "/") > 1 {
 		return errors.New("coredns-custom-configmap should be in <namespace>/<name> format, namespace is optional")
 	}

--- a/pkg/join/join_test.go
+++ b/pkg/join/join_test.go
@@ -432,4 +432,15 @@ func testInvalidInput() {
 			Expect(t.runJoinClusterToBroker(ctx)).NotTo(Succeed())
 		})
 	})
+
+	When("a CoreDNS custom config key is specified without a ConfigMap", func() {
+		BeforeEach(func() {
+			t.options.CoreDNSCustomConfigMap = ""
+			t.options.CoreDNSCustomConfigKey = "Corefile"
+		})
+
+		It("should fail", func(ctx SpecContext) {
+			Expect(t.runJoinClusterToBroker(ctx)).NotTo(Succeed())
+		})
+	})
 }

--- a/pkg/join/options.go
+++ b/pkg/join/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	ImageVersion                    string
 	CableDriver                     string
 	CoreDNSCustomConfigMap          string
+	CoreDNSCustomConfigKey          string
 	BrokerURL                       string
 	ClustersetIPCIDR                string
 	CustomDomains                   []string


### PR DESCRIPTION
## What this PR does / why we need it

Adds:

```bash
--coredns-custom-configmap-key=Corefile
```

paired with existing `--coredns-custom-configmap`, to set `spec.coreDNSCustomConfig.key`.

Example when the custom ConfigMap holds a full Corefile (rather than an AKS-style
`lighthouse.server` snippet):

```bash
subctl join broker-info.subm \
  --coredns-custom-configmap=kube-system/coredns-user \
  --coredns-custom-configmap-key=Corefile
```

Omitting the flag leaves `key` empty so the operator keeps the default
`lighthouse.server` behavior.

## Depends on

- **Requires** operator PR that adds `CoreDNSCustomConfig.Key` and updates embedded/deploy CRDs. Without the CRD field, the API silently drops `key`.

Depends-on https://github.com/submariner-io/submariner-operator/pull/4144

## Related issues

- Related to https://github.com/submariner-io/submariner-operator/issues/1046
- Related to https://github.com/submariner-io/submariner-operator/issues/3005

## Checklist

- [x] Wired through join → deploy
- [x] Built/tested against operator that includes the CRD `key` field
- [x] `subctl join --help` documents the flag
- [x] Reject key without `--coredns-custom-configmap`

## Cross-links (this series)

- **Requires** operator CRD field: https://github.com/submariner-io/submariner-operator/pull/4144

Depends-on https://github.com/submariner-io/submariner-operator/pull/4144