### PR TITLE
Add Cilium CNI diagnose checks

### DIFF
--- a/cmd/subctl/join.go
+++ b/cmd/subctl/join.go
@@ -182,6 +182,10 @@ func (c *JoinCommand) joinInContext(ctx context.Context, brokerInfo *broker.Info
 	c.flags.ClusterCIDR = determineCIDR("Pod", c.flags.ClusterCIDR, networkDetails.PodCIDRs, status)
 	c.flags.ServiceCIDR = determineCIDR("Service", c.flags.ServiceCIDR, networkDetails.ServiceCIDRs, status)
 
+	if err := c.ensureCiliumClusterMeshPrerequisites(ctx, clusterInfo, networkDetails.NetworkPlugin, status); err != nil {
+		return err
+	}
+
 	if brokerInfo.IsConnectivityEnabled() && c.labelGateway {
 		possiblyLabelGateway(ctx, clusterInfo.ClientProducer.ForKubernetes(), status)
 	}

--- a/cmd/subctl/join_cilium.go
+++ b/cmd/subctl/join_cilium.go
@@ -1,0 +1,186 @@
+//go:build !non_deploy
+
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subctl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/subctl/internal/env"
+	"github.com/submariner-io/subctl/pkg/client"
+	"github.com/submariner-io/subctl/pkg/cluster"
+	"github.com/submariner-io/subctl/pkg/deploy"
+	"github.com/submariner-io/submariner-operator/pkg/ciliumcm"
+)
+
+func (c *JoinCommand) ensureCiliumClusterMeshPrerequisites(ctx context.Context, clusterInfo *cluster.Info,
+	networkPlugin string, status reporter.Interface,
+) error {
+	err := deploy.EnsureCiliumClusterMeshPrerequisites(ctx, clusterInfo.ClientProducer.ForKubernetes(), "",
+		networkPlugin, status)
+	if err == nil {
+		return nil
+	}
+
+	if !strings.EqualFold(networkPlugin, "cilium") {
+		return err
+	}
+
+	ciliumNS, findErr := ciliumcm.FindUniqueCiliumConfigNamespace(ctx, clusterInfo.ClientProducer.ForKubernetes())
+	if findErr != nil || ciliumNS == "" {
+		return err
+	}
+
+	clusterID, clusterName, readErr := deploy.ReadCiliumClusterIdentity(ctx, clusterInfo.ClientProducer.ForKubernetes(), ciliumNS)
+	if readErr != nil {
+		return status.Error(readErr, "Error reading Cilium cluster identity")
+	}
+
+	if len(ciliumcm.LocalClusterIdentityFailures(clusterID, clusterName)) == 0 {
+		return err
+	}
+
+	return c.configureCiliumClusterIdentity(ctx, clusterInfo.ClientProducer, ciliumNS,
+		clusterID, clusterName, status)
+}
+
+func (c *JoinCommand) configureCiliumClusterIdentity(ctx context.Context, producer client.Producer, ciliumNS,
+	currentID, currentName string, status reporter.Interface,
+) error {
+	problems := deploy.FormatCiliumIdentityProblems(currentID, currentName)
+
+	if problems != "" {
+		status.Warning("%s", problems)
+	}
+
+	fmt.Printf(`
+Submariner needs a non-default Cilium cluster identity in ConfigMap %q
+(namespace %q) for its ClusterMesh-shaped ipcache publisher.
+cluster-id and cluster-name are read when Cilium agents start, so the
+%s after the ConfigMap is updated.
+
+`, ciliumcm.CiliumConfigMapName, ciliumNS, boldIfSmart("Cilium agent pods must be restarted"))
+
+	configure := false
+	err := survey.AskOne(NewInputPrompt(&survey.Confirm{
+		Message: "Configure Cilium cluster-id and cluster-name now?",
+		Default: true,
+	}), &configure)
+	if err != nil {
+		if isNonInteractive(err) {
+			return status.Error(errors.New(
+				"Cilium cluster identity is invalid and subctl is running non-interactively; "+
+					"set cilium-config cluster-id (1..254) and cluster-name, restart the Cilium agents, then re-run join"),
+				"Cilium ClusterMesh prerequisites not met")
+		}
+
+		return status.Error(err, "Prompt failure")
+	}
+
+	if !configure {
+		return status.Error(errors.New("Cilium cluster identity left unchanged"),
+			"Cilium ClusterMesh prerequisites not met")
+	}
+
+	defaultName := currentName
+	if defaultName == "" || defaultName == "default" || defaultName == ciliumcm.DefaultRemoteName {
+		defaultName = c.flags.ClusterID
+	}
+
+	defaultID := ciliumcm.SuggestedLocalClusterID
+	if idNum, parseErr := strconv.Atoi(currentID); parseErr == nil && idNum >= 1 && idNum <= 254 {
+		defaultID = currentID
+	}
+
+	var clusterName string
+	err = survey.AskOne(NewInputPrompt(&survey.Input{
+		Message: "Cilium cluster-name",
+		Default: defaultName,
+	}), &clusterName, survey.WithValidator(func(val any) error {
+		str, _ := val.(string)
+		return ciliumcm.ValidateLocalClusterIdentity(ciliumcm.SuggestedLocalClusterID, strings.TrimSpace(str))
+	}))
+	if err != nil {
+		return status.Error(err, "Prompt failure")
+	}
+
+	clusterName = strings.TrimSpace(clusterName)
+
+	var clusterID string
+	err = survey.AskOne(NewInputPrompt(&survey.Input{
+		Message: "Cilium cluster-id (1..254; 255 is reserved for Submariner)",
+		Default: defaultID,
+	}), &clusterID, survey.WithValidator(func(val any) error {
+		str, _ := val.(string)
+		return ciliumcm.ValidateLocalClusterIdentity(strings.TrimSpace(str), clusterName)
+	}))
+	if err != nil {
+		return status.Error(err, "Prompt failure")
+	}
+
+	clusterID = strings.TrimSpace(clusterID)
+
+	restart := false
+	err = survey.AskOne(NewInputPrompt(&survey.Confirm{
+		Message: fmt.Sprintf(
+			"Update ConfigMap %q and restart Cilium agent pods in namespace %q now?",
+			ciliumcm.CiliumConfigMapName, ciliumNS),
+		Default: true,
+	}), &restart)
+	if err != nil {
+		return status.Error(err, "Prompt failure")
+	}
+
+	if !restart {
+		return status.Error(errors.New("Cilium ConfigMap update canceled"),
+			"Cilium ClusterMesh prerequisites not met")
+	}
+
+	status.Start("Updating Cilium ConfigMap %q in namespace %q", ciliumcm.CiliumConfigMapName, ciliumNS)
+
+	kubeClient := producer.ForKubernetes()
+
+	if err := deploy.SetCiliumClusterIdentity(ctx, kubeClient, ciliumNS, clusterID, clusterName); err != nil {
+		return status.Error(err, "Error updating Cilium cluster identity")
+	}
+
+	status.Success("Updated cluster-id=%s cluster-name=%q", clusterID, clusterName)
+
+	if err := deploy.RestartCiliumAgents(ctx, kubeClient, ciliumNS, status); err != nil {
+		return err
+	}
+
+	return deploy.EnsureCiliumClusterMeshPrerequisites(ctx, kubeClient, ciliumNS, "cilium", status)
+}
+
+func boldIfSmart(s string) string {
+	if env.IsSmartTerminal(os.Stdout) {
+		return "\x1b[1m" + s + "\x1b[0m"
+	}
+
+	return s
+}

--- a/pkg/deploy/cilium.go
+++ b/pkg/deploy/cilium.go
@@ -1,0 +1,176 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/submariner-operator/pkg/ciliumcm"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	ciliumRestartAnnotation = "kubectl.kubernetes.io/restartedAt"
+	ciliumRolloutTimeout    = 5 * time.Minute
+)
+
+// SetCiliumClusterIdentity updates cluster-id and cluster-name in cilium-config.
+// Cilium agents must be restarted afterwards for the values to take effect.
+func SetCiliumClusterIdentity(ctx context.Context, client kubernetes.Interface, ciliumNS, clusterID, clusterName string) error {
+	if err := ciliumcm.ValidateLocalClusterIdentity(clusterID, clusterName); err != nil {
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := client.CoreV1().ConfigMaps(ciliumNS).Get(ctx, ciliumcm.CiliumConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "get ConfigMap %q", ciliumcm.CiliumConfigMapName)
+		}
+
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+
+		cm.Data["cluster-id"] = clusterID
+		cm.Data["cluster-name"] = clusterName
+
+		_, err = client.CoreV1().ConfigMaps(ciliumNS).Update(ctx, cm, metav1.UpdateOptions{})
+
+		return errors.Wrapf(err, "update ConfigMap %q", ciliumcm.CiliumConfigMapName)
+	})
+}
+
+// RestartCiliumAgents triggers a rolling restart of the Cilium agent DaemonSet and
+// waits until the rollout completes. cluster-id / cluster-name are applied at agent start.
+func RestartCiliumAgents(ctx context.Context, client kubernetes.Interface, ciliumNS string, status reporter.Interface) error {
+	status.Start("Restarting Cilium agent DaemonSet in namespace %q", ciliumNS)
+	defer status.End()
+
+	ds, err := findCiliumDaemonSet(ctx, client, ciliumNS)
+	if err != nil {
+		return status.Error(err, "Error locating the Cilium DaemonSet")
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, getErr := client.AppsV1().DaemonSets(ciliumNS).Get(ctx, ds.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+
+		if current.Spec.Template.Annotations == nil {
+			current.Spec.Template.Annotations = map[string]string{}
+		}
+
+		current.Spec.Template.Annotations[ciliumRestartAnnotation] = time.Now().Format(time.RFC3339)
+
+		_, updateErr := client.AppsV1().DaemonSets(ciliumNS).Update(ctx, current, metav1.UpdateOptions{})
+
+		return updateErr
+	})
+	if err != nil {
+		return status.Error(err, "Error restarting Cilium DaemonSet %q", ds.Name)
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, ciliumRolloutTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			current, getErr := client.AppsV1().DaemonSets(ciliumNS).Get(ctx, ds.Name, metav1.GetOptions{})
+			if getErr != nil {
+				return false, getErr
+			}
+
+			if current.Status.DesiredNumberScheduled == 0 {
+				return false, nil
+			}
+
+			return current.Status.UpdatedNumberScheduled == current.Status.DesiredNumberScheduled &&
+				current.Status.NumberAvailable == current.Status.DesiredNumberScheduled &&
+				current.Status.NumberUnavailable == 0, nil
+		})
+	if err != nil {
+		return status.Error(err, "Timed out waiting for Cilium DaemonSet %q to finish restarting", ds.Name)
+	}
+
+	status.Success("Cilium agent DaemonSet %q restarted", ds.Name)
+
+	return nil
+}
+
+func findCiliumDaemonSet(ctx context.Context, client kubernetes.Interface, ciliumNS string) (*appsv1.DaemonSet, error) {
+	ds, err := client.AppsV1().DaemonSets(ciliumNS).Get(ctx, ciliumcm.CiliumDaemonSetName, metav1.GetOptions{})
+	if err == nil {
+		return ds, nil
+	}
+
+	list, listErr := client.AppsV1().DaemonSets(ciliumNS).List(ctx, metav1.ListOptions{
+		LabelSelector: "k8s-app=cilium",
+	})
+	if listErr != nil {
+		return nil, errors.Wrap(listErr, "list Cilium DaemonSets")
+	}
+
+	if len(list.Items) == 0 {
+		return nil, errors.Errorf("no Cilium DaemonSet named %q (or labeled k8s-app=cilium) in namespace %q",
+			ciliumcm.CiliumDaemonSetName, ciliumNS)
+	}
+
+	return &list.Items[0], nil
+}
+
+// ReadCiliumClusterIdentity returns cluster-id and cluster-name from cilium-config.
+func ReadCiliumClusterIdentity(ctx context.Context, client kubernetes.Interface, ciliumNS string) (string, string, error) {
+	cm, err := client.CoreV1().ConfigMaps(ciliumNS).Get(ctx, ciliumcm.CiliumConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", errors.Wrapf(err, "get ConfigMap %q", ciliumcm.CiliumConfigMapName)
+	}
+
+	if cm.Data == nil {
+		return "", "", nil
+	}
+
+	return cm.Data["cluster-id"], cm.Data["cluster-name"], nil
+}
+
+// FormatCiliumIdentityProblems returns a multi-line description for prompts.
+// Callers should print this via status.Warning (yellow ⚠).
+func FormatCiliumIdentityProblems(clusterID, clusterName string) string {
+	failures := ciliumcm.LocalClusterIdentityFailures(clusterID, clusterName)
+	if len(failures) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("Problems found in ConfigMap \"cilium-config\":\n")
+
+	for _, f := range failures {
+		// Failures already name the ConfigMap; drop the redundant prefix in the list.
+		b.WriteString("  - ")
+		b.WriteString(strings.TrimPrefix(f, "cilium-config "))
+		b.WriteByte('\n')
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/pkg/deploy/cilium_test.go
+++ b/pkg/deploy/cilium_test.go
@@ -1,0 +1,99 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/subctl/pkg/deploy"
+	"github.com/submariner-io/submariner-operator/pkg/ciliumcm"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("SetCiliumClusterIdentity", func() {
+	t := newTestDriver()
+
+	BeforeEach(func(ctx SpecContext) {
+		_, err := t.fakeProducer.KubeClient.CoreV1().ConfigMaps("kube-system").Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: ciliumcm.CiliumConfigMapName, Namespace: "kube-system"},
+			Data:       map[string]string{"cluster-id": "0", "cluster-name": "default"},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should update cluster-id and cluster-name", func(ctx SpecContext) {
+		Expect(deploy.SetCiliumClusterIdentity(ctx, t.fakeProducer.ForKubernetes(), "kube-system",
+			"1", "test-cluster")).To(Succeed())
+
+		cm, err := t.fakeProducer.KubeClient.CoreV1().ConfigMaps("kube-system").Get(ctx,
+			ciliumcm.CiliumConfigMapName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cm.Data["cluster-id"]).To(Equal("1"))
+		Expect(cm.Data["cluster-name"]).To(Equal("test-cluster"))
+	})
+
+	It("should reject an invalid identity", func(ctx SpecContext) {
+		Expect(deploy.SetCiliumClusterIdentity(ctx, t.fakeProducer.ForKubernetes(), "kube-system",
+			"0", "default")).NotTo(Succeed())
+	})
+})
+
+var _ = Describe("RestartCiliumAgents", func() {
+	t := newTestDriver()
+
+	BeforeEach(func(ctx SpecContext) {
+		_, err := t.fakeProducer.KubeClient.AppsV1().DaemonSets("kube-system").Create(ctx, &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: ciliumcm.CiliumDaemonSetName, Namespace: "kube-system"},
+			Spec: appsv1.DaemonSetSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				},
+			},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 1,
+				UpdatedNumberScheduled: 1,
+				NumberAvailable:        1,
+				NumberUnavailable:      0,
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should annotate the Cilium DaemonSet for a rolling restart", func(ctx SpecContext) {
+		Expect(deploy.RestartCiliumAgents(ctx, t.fakeProducer.ForKubernetes(), "kube-system",
+			t.statusReporter)).To(Succeed())
+
+		ds, err := t.fakeProducer.KubeClient.AppsV1().DaemonSets("kube-system").Get(ctx,
+			ciliumcm.CiliumDaemonSetName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.Spec.Template.Annotations).To(HaveKey("kubectl.kubernetes.io/restartedAt"))
+	})
+})
+
+var _ = Describe("FormatCiliumIdentityProblems", func() {
+	It("should list problems without repeating the ConfigMap name", func() {
+		msg := deploy.FormatCiliumIdentityProblems("0", "default")
+		Expect(msg).To(ContainSubstring(`Problems found in ConfigMap "cilium-config"`))
+		Expect(msg).To(ContainSubstring(`  - cluster-id is "0"`))
+		Expect(msg).To(ContainSubstring(`  - cluster-name is "default"`))
+		Expect(msg).NotTo(ContainSubstring("  - cilium-config cluster-id"))
+	})
+})

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/broker"
@@ -31,9 +32,11 @@ import (
 	"github.com/submariner-io/subctl/pkg/secret"
 	"github.com/submariner-io/subctl/pkg/submarinercr"
 	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
+	"github.com/submariner-io/submariner-operator/pkg/ciliumcm"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/clustersetip"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -74,9 +77,56 @@ func Submariner(ctx context.Context, clientProducer client.Producer, options *Su
 
 	submarinerSpec := populateSubmarinerSpec(options, brokerInfo, brokerSecret, pskSecret, netconfig, clustersetConfig, repositoryInfo)
 
+	if submarinerSpec.CiliumNamespace == "" {
+		ciliumNS, findErr := ciliumcm.FindUniqueCiliumConfigNamespace(ctx, clientProducer.ForKubernetes())
+		if findErr != nil {
+			return status.Error(findErr, "Error discovering Cilium namespace")
+		}
+
+		submarinerSpec.CiliumNamespace = ciliumNS
+	}
+
 	err = SubmarinerFromSpec(ctx, clientProducer.ForGeneral(), submarinerSpec)
 
 	return status.Error(err, "Submariner deployment failed")
+}
+
+// EnsureCiliumClusterMeshPrerequisites runs local Cilium identity checks when Cilium is
+// detected (by network plugin name and/or an already-known cilium namespace).
+func EnsureCiliumClusterMeshPrerequisites(ctx context.Context, kubeClient kubernetes.Interface, ciliumNS, networkPlugin string,
+	status reporter.Interface,
+) error {
+	ciliumDetected := strings.EqualFold(networkPlugin, "cilium") || ciliumNS != ""
+	if !ciliumDetected {
+		return nil
+	}
+
+	status.Start("Validating Cilium ClusterMesh prerequisites")
+	defer status.End()
+
+	if ciliumNS == "" {
+		var findErr error
+
+		ciliumNS, findErr = ciliumcm.FindUniqueCiliumConfigNamespace(ctx, kubeClient)
+		if findErr != nil {
+			return status.Error(findErr, "Error discovering Cilium namespace")
+		}
+	}
+
+	if ciliumNS == "" {
+		return status.Error(
+			errors.Errorf("no unique %q ConfigMap found; set a single cilium-config (and Spec.CiliumNamespace if needed)",
+				ciliumcm.CiliumConfigMapName),
+			"Cilium CNI detected; cannot validate ClusterMesh prerequisites")
+	}
+
+	if err := ciliumcm.LoadAndValidateLocalClusterIdentity(ctx, kubeClient, ciliumNS); err != nil {
+		return status.Error(err, "Cilium ClusterMesh prerequisites not met")
+	}
+
+	status.Success("Cilium ClusterMesh prerequisites OK (namespace %q)", ciliumNS)
+
+	return nil
 }
 
 func SubmarinerFromSpec(ctx context.Context, ctlClient controllerClient.Client, submarinerSpec *operatorv1alpha1.SubmarinerSpec) error {

--- a/pkg/deploy/submariner_test.go
+++ b/pkg/deploy/submariner_test.go
@@ -32,6 +32,8 @@ import (
 	operatorv1alpha1 "github.com/submariner-io/submariner-operator/api/v1alpha1"
 	"github.com/submariner-io/submariner-operator/pkg/discovery/globalnet"
 	"github.com/submariner-io/submariner-operator/pkg/names"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -205,6 +207,40 @@ func testSubmariner() {
 		})
 	})
 }
+
+var _ = Describe("EnsureCiliumClusterMeshPrerequisites", func() {
+	t := newTestDriver()
+
+	It("should succeed when Cilium is not detected", func(ctx SpecContext) {
+		Expect(deploy.EnsureCiliumClusterMeshPrerequisites(ctx, t.fakeProducer.ForKubernetes(), "", "",
+			t.statusReporter)).To(Succeed())
+		t.statusReporter.AssertFailureCount(0)
+	})
+
+	It("should fail when Cilium is detected with an invalid cluster-id", func(ctx SpecContext) {
+		_, err := t.fakeProducer.KubeClient.CoreV1().ConfigMaps("kube-system").Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cilium-config", Namespace: "kube-system"},
+			Data:       map[string]string{"cluster-id": "0", "cluster-name": "default"},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(deploy.EnsureCiliumClusterMeshPrerequisites(ctx, t.fakeProducer.ForKubernetes(), "", "cilium",
+			t.statusReporter)).NotTo(Succeed())
+		t.statusReporter.AssertFailureContainsStrings("cluster-id")
+	})
+
+	It("should succeed with a valid local Cilium identity", func(ctx SpecContext) {
+		_, err := t.fakeProducer.KubeClient.CoreV1().ConfigMaps("kube-system").Create(ctx, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "cilium-config", Namespace: "kube-system"},
+			Data:       map[string]string{"cluster-id": "1", "cluster-name": "test-cluster"},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(deploy.EnsureCiliumClusterMeshPrerequisites(ctx, t.fakeProducer.ForKubernetes(), "kube-system", "cilium",
+			t.statusReporter)).To(Succeed())
+		t.statusReporter.AssertFailureCount(0)
+	})
+})
 
 func testRemoveSchemaPrefix() {
 	DescribeTable("should correctly remove the schema prefix",

--- a/pkg/diagnose/cilium.go
+++ b/pkg/diagnose/cilium.go
@@ -1,0 +1,119 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnose
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/reporter"
+	"github.com/submariner-io/subctl/pkg/cluster"
+	"github.com/submariner-io/submariner-operator/pkg/ciliumcm"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ciliumCNI matches github.com/submariner-io/submariner/pkg/cni.Cilium.
+// Inline until that constant is in subctl's released submariner dependency.
+const ciliumCNI = "cilium"
+
+func checkCiliumClusterMeshPublisher(ctx context.Context, info *cluster.Info, status reporter.Interface) error {
+	if !strings.EqualFold(info.Submariner.Status.NetworkPlugin, ciliumCNI) {
+		return nil
+	}
+
+	status.Start("Cilium CNI detected, checking ClusterMesh-shaped publisher prerequisites")
+	defer status.End()
+
+	tracker := reporter.NewTracker(status)
+	client := info.ClientProducer.ForKubernetes()
+
+	ciliumNS := info.Submariner.Spec.CiliumNamespace
+	if ciliumNS == "" {
+		ciliumNS = info.Submariner.Status.CiliumNamespace
+	}
+
+	secretName := ciliumcm.ClusterMeshSecretNameOrDefault(info.Submariner.Spec.CiliumClusterMeshSecret)
+	if info.Submariner.Spec.CiliumClusterMeshSecret == "" && info.Submariner.Status.CiliumClusterMeshSecret != "" {
+		secretName = info.Submariner.Status.CiliumClusterMeshSecret
+	}
+
+	if ciliumNS == "" {
+		tracker.Failure(
+			"spec.ciliumNamespace is empty; set it to the namespace containing cilium-config " +
+				"(subctl join sets this when exactly one cilium-config is found)")
+	} else {
+		checkCiliumClusterID(ctx, client, ciliumNS, tracker)
+		checkCiliumClusterMeshPeer(ctx, client, ciliumNS, secretName, tracker)
+	}
+
+	if tracker.HasFailures() {
+		return errors.New("failures while diagnosing Cilium CNI publisher prerequisites")
+	}
+
+	status.Success("Cilium ClusterMesh-shaped publisher prerequisites look OK")
+
+	return nil
+}
+
+func checkCiliumClusterID(ctx context.Context, client kubernetes.Interface, ciliumNS string, status reporter.Interface) {
+	cm, err := client.CoreV1().ConfigMaps(ciliumNS).Get(ctx, ciliumcm.CiliumConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			status.Failure("ConfigMap %q not found in %q; cannot validate Cilium cluster-id",
+				ciliumcm.CiliumConfigMapName, ciliumNS)
+
+			return
+		}
+
+		status.Failure("Error reading ConfigMap %q: %v", ciliumcm.CiliumConfigMapName, err)
+
+		return
+	}
+
+	for _, failure := range ciliumcm.LocalClusterIdentityFailures(cm.Data["cluster-id"], cm.Data["cluster-name"]) {
+		status.Failure("%s", failure)
+	}
+}
+
+func checkCiliumClusterMeshPeer(ctx context.Context, client kubernetes.Interface, ciliumNS, secretName string,
+	status reporter.Interface,
+) {
+	secret, err := client.CoreV1().Secrets(ciliumNS).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			status.Failure("Secret %q not found in %q; operator should merge the Submariner peer",
+				secretName, ciliumNS)
+
+			return
+		}
+
+		status.Failure("Error reading Secret %q: %v", secretName, err)
+
+		return
+	}
+
+	for _, key := range ciliumcm.PeerSecretKeys(ciliumcm.DefaultRemoteName) {
+		if len(secret.Data[key]) == 0 {
+			status.Failure("%s is missing peer key %q", secretName, key)
+		}
+	}
+}

--- a/pkg/diagnose/cni.go
+++ b/pkg/diagnose/cni.go
@@ -48,7 +48,7 @@ var MinOVNNBVersion = semver.New("6.1.0")
 var supportedNetworkPlugins = []string{
 	cni.Generic, cni.CanalFlannel, cni.WeaveNet,
 	cni.OpenShiftSDN, cni.OVNKubernetes, cni.Calico,
-	cni.KindNet,
+	cni.KindNet, ciliumCNI,
 }
 
 var CalicoGVR = schema.GroupVersionResource{
@@ -95,7 +95,11 @@ func CNIConfig(ctx context.Context, clusterInfo *cluster.Info, _ string, status 
 		return checkOVNVersion(ctx, clusterInfo, status)
 	}
 
-	return checkCalicoIPPoolsIfCalicoCNI(ctx, clusterInfo, status)
+	if err := checkCalicoIPPoolsIfCalicoCNI(ctx, clusterInfo, status); err != nil {
+		return err
+	}
+
+	return checkCiliumClusterMeshPublisher(ctx, clusterInfo, status)
 }
 
 func checkCalicoIPPoolsIfCalicoCNI(ctx context.Context, info *cluster.Info, status reporter.Interface) error {

--- a/pkg/diagnose/cni_test.go
+++ b/pkg/diagnose/cni_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/subctl/pkg/diagnose"
+	"github.com/submariner-io/submariner-operator/pkg/ciliumcm"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cni"
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +66,8 @@ var _ = Describe("CNIConfig", func() {
 	When("the network plugin is OVNKubernetes", t.testOVNKubernetesCNIPlugin)
 
 	When("the network plugin is Calico", t.testCalicoCNIPlugin)
+
+	When("the network plugin is Cilium", t.testCiliumCNIPlugin)
 
 	When("the network plugin hasn't been determined", func() {
 		BeforeEach(func() {
@@ -318,6 +321,95 @@ func (t *cniTestDriver) createOVNPod(ctx context.Context, version, containerName
 	Expect(err).NotTo(HaveOccurred())
 
 	fake.SetSPDYExecutor("DB Schema "+version, "", nil)
+}
+
+func (t *cniTestDriver) testCiliumCNIPlugin() {
+	BeforeEach(func() {
+		t.submariner.Status.NetworkPlugin = "cilium"
+		t.submariner.Spec.CiliumNamespace = metav1.NamespaceSystem
+	})
+
+	Context("and publisher prerequisites are configured correctly", func() {
+		BeforeEach(func(ctx SpecContext) {
+			t.createCiliumPublisherWiring(ctx, true)
+		})
+
+		t.testSuccess(t.run)
+	})
+
+	Context("and spec.ciliumNamespace is empty", func() {
+		BeforeEach(func(ctx SpecContext) {
+			t.submariner.Spec.CiliumNamespace = ""
+			t.createCiliumPublisherWiring(ctx, true)
+		})
+
+		t.testFailure(t.run, "ciliumNamespace")
+	})
+
+	Context("and cilium-config cluster-id is 0", func() {
+		BeforeEach(func(ctx SpecContext) {
+			t.createCiliumPublisherWiring(ctx, false)
+		})
+
+		t.testFailure(t.run, "cluster-id")
+	})
+
+	Context("and cilium-config cluster-id is reserved for Submariner", func() {
+		BeforeEach(func(ctx SpecContext) {
+			t.createCiliumConfig(ctx, ciliumcm.DefaultClusterID, "test-cluster")
+			t.createCiliumClusterMeshSecret(ctx)
+		})
+
+		t.testFailure(t.run, "reserved")
+	})
+
+	Context("and the cilium-clustermesh peer is missing", func() {
+		BeforeEach(func(ctx SpecContext) {
+			t.createCiliumConfig(ctx, "1", "test-cluster")
+		})
+
+		t.testFailure(t.run, "cilium-clustermesh")
+	})
+}
+
+func (t *cniTestDriver) createCiliumPublisherWiring(ctx context.Context, validClusterID bool) {
+	clusterID := "1"
+	if !validClusterID {
+		clusterID = "0"
+	}
+
+	t.createCiliumConfig(ctx, clusterID, "test-cluster")
+	t.createCiliumClusterMeshSecret(ctx)
+}
+
+func (t *cniTestDriver) createCiliumConfig(ctx context.Context, clusterID, clusterName string) {
+	_, err := t.fakeProducer.KubeClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cilium-config",
+			Namespace: metav1.NamespaceSystem,
+		},
+		Data: map[string]string{
+			"cluster-id":   clusterID,
+			"cluster-name": clusterName,
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (t *cniTestDriver) createCiliumClusterMeshSecret(ctx context.Context) {
+	_, err := t.fakeProducer.KubeClient.CoreV1().Secrets(metav1.NamespaceSystem).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cilium-clustermesh",
+			Namespace: metav1.NamespaceSystem,
+		},
+		Data: map[string][]byte{
+			"submariner":                    []byte("endpoints:\n- https://127.0.0.1:12379\n"),
+			"submariner.etcd-client-ca.crt": []byte("ca"),
+			"submariner.etcd-client.crt":    []byte("crt"),
+			"submariner.etcd-client.key":    []byte("key"),
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func (t *cniTestDriver) run(ctx context.Context) error {


### PR DESCRIPTION
## What this PR does / why we need it

Adds `subctl diagnose` coverage for the Cilium ClusterMesh-shaped publisher
setup so misconfiguration is visible before connectivity debugging.

On join, if `spec.ciliumNamespace` is empty, discovers the unique
`cilium-config` ConfigMap and sets that namespace on the Submariner CR.

Checks (when network plugin is cilium):

- `spec.ciliumNamespace` present
- `cilium-config` `cluster-id` / `cluster-name` prerequisites (`1..254`, not
  reserved id **255** or peer name `submariner`)
- TLS Secret `submariner-cilium-cm-tls`
- Peer keys `submariner*` in `cilium-clustermesh`
- Route-agent env / TLS volume for the publisher

Also lists `cilium` among supported CNIs for diagnose.

## Related

- Design / overview: https://github.com/submariner-io/submariner/issues/4105
- Related https://github.com/submariner-io/submariner/issues/3168
- Companion submariner: https://github.com/submariner-io/submariner/pull/4106
- Companion operator: https://github.com/submariner-io/submariner-operator/pull/4146

## How to verify

- Unit tests for diagnose helpers
- On a joined Cilium cluster: `subctl diagnose` shows Cilium publisher checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cilium ClusterMesh prerequisite checks during cluster join and deployment, with guided remediation when identity data is invalid.
  * Automatically discovers the Cilium namespace if it isn’t provided.
  * Added Cilium-specific diagnostics for cluster identity and ClusterMesh peer secret readiness.
  * When required, the system can update Cilium identity settings and restart Cilium agents to apply changes.
* **Bug Fixes**
  * CNI diagnostics now run applicable Calico and Cilium checks in sequence (instead of exiting after the Calico path).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->