### PR TITLE
Read IPSec PSK from Secret for recover broker info

### DIFF
--- a/pkg/broker/recover_broker_info.go
+++ b/pkg/broker/recover_broker_info.go
@@ -22,9 +22,11 @@ import (
 	"context"
 	"encoding/base64"
 
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/set"
 )
@@ -37,9 +39,21 @@ func RecoverData(ctx context.Context, submCluster *cluster.Info, broker *v1alpha
 
 	status.Success("Retrieving IPSec PSK secret from Submariner found on cluster %s", submCluster.Name)
 
-	decodedPSKSecret, err := base64.StdEncoding.DecodeString(submCluster.Submariner.Spec.CeIPSecPSK)
-	if err != nil {
-		return status.Error(err, "error decoding the secret")
+	var decodedPSKSecret []byte
+	var err error
+
+	// Read PSK from Secret if configured, otherwise fall back to CR field
+	if submCluster.Submariner.Spec.CeIPSecPSKSecret != "" {
+		decodedPSKSecret, err = readIPSecPSKFromSecret(ctx, submCluster, submCluster.Submariner.Spec.CeIPSecPSKSecret)
+		if err != nil {
+			return status.Error(err, "error reading IPSec PSK from secret %q", submCluster.Submariner.Spec.CeIPSecPSKSecret)
+		}
+	} else {
+		// Fall back to reading from CR field for backwards compatibility
+		decodedPSKSecret, err = base64.StdEncoding.DecodeString(submCluster.Submariner.Spec.CeIPSecPSK)
+		if err != nil {
+			return status.Error(err, "error decoding the secret")
+		}
 	}
 
 	status.Success("Successfully retrieved the data. Writing it to broker-info.subm")
@@ -48,4 +62,20 @@ func RecoverData(ctx context.Context, submCluster *cluster.Info, broker *v1alpha
 		set.New(broker.Spec.Components...), broker.Spec.DefaultCustomDomains, status)
 
 	return status.Error(err, "error reconstructing broker-info.subm")
+}
+
+func readIPSecPSKFromSecret(ctx context.Context, submCluster *cluster.Info, secretName string) ([]byte, error) {
+	secret, err := submCluster.ClientProducer.ForKubernetes().CoreV1().Secrets(submCluster.Submariner.Namespace).Get(
+		ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading IPSec PSK secret %s/%s", submCluster.OperatorNamespace(), secretName)
+	}
+
+	pskData, ok := secret.Data["psk"]
+	if !ok || len(pskData) == 0 {
+		return nil, errors.Errorf("IPSec PSK secret %s/%s missing 'psk' data", submCluster.OperatorNamespace(), secretName)
+	}
+
+	// Secret.Data is already decoded from base64 by Kubernetes API client
+	return pskData, nil
 }

--- a/pkg/broker/recover_broker_info_test.go
+++ b/pkg/broker/recover_broker_info_test.go
@@ -28,17 +28,21 @@ import (
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/broker"
 	"github.com/submariner-io/subctl/pkg/brokercr"
+	clientfake "github.com/submariner-io/subctl/pkg/client/fake"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
 
 var _ = Describe("RecoverData", func() {
 	const (
-		testBrokerURL   = "https://broker.example.com:6443"
-		testIPSecPSKRaw = "my-secret-psk"
+		testBrokerURL      = "https://broker.example.com:6443"
+		ipSecPSKSecretData = "psk-secret-data" //nolint:gosec // Test data
+		ipSecPSKSecret     = "psk-secret"
+		fallbackIPSecPSK   = "fallback-psk"
 	)
 
 	t := newTestDriver()
@@ -53,14 +57,15 @@ var _ = Describe("RecoverData", func() {
 		setupInfoFileDir()
 
 		clusterInfo = &cluster.Info{
-			Name: "test-cluster",
+			Name:           "test-cluster",
+			ClientProducer: clientfake.New(),
 			Submariner: &v1alpha1.Submariner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      opnames.SubmarinerCrName,
 					Namespace: constants.OperatorNamespace,
 				},
 				Spec: v1alpha1.SubmarinerSpec{
-					CeIPSecPSK: base64.StdEncoding.EncodeToString([]byte(testIPSecPSKRaw)),
+					CeIPSecPSKSecret: ipSecPSKSecret,
 				},
 			},
 		}
@@ -82,6 +87,16 @@ var _ = Describe("RecoverData", func() {
 	JustBeforeEach(func(ctx SpecContext) {
 		_, err := t.kubeClient.CoreV1().Secrets(testBrokerNamespace).Create(ctx, newTokenSecret(), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		_, err = clusterInfo.ClientProducer.ForKubernetes().CoreV1().Secrets(clusterInfo.Submariner.Namespace).Create(ctx,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: ipSecPSKSecret,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{"psk": []byte(ipSecPSKSecretData)},
+			}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should write the recovered broker info to a file", func(ctx SpecContext) {
@@ -97,17 +112,34 @@ var _ = Describe("RecoverData", func() {
 		Expect(info.ClientToken).NotTo(BeNil())
 		Expect(info.ClientToken.Name).To(Equal(newTokenSecret().Name))
 		Expect(info.IPSecPSK).NotTo(BeNil())
-		Expect(info.IPSecPSK.Data["psk"]).To(Equal([]byte(testIPSecPSKRaw)))
+		Expect(info.IPSecPSK.Data["psk"]).To(Equal([]byte(ipSecPSKSecretData)))
 	})
 
-	When("the IPSec PSK is not a valid base64 string", func() {
+	When("the IPSec PSK Secret isn't configured", func() {
 		BeforeEach(func() {
-			clusterInfo.Submariner.Spec.CeIPSecPSK = "invalid"
+			clusterInfo.Submariner.Spec.CeIPSecPSKSecret = ""
+			clusterInfo.Submariner.Spec.CeIPSecPSK = base64.StdEncoding.EncodeToString([]byte(fallbackIPSecPSK))
 		})
 
-		It("should return an error", func(ctx SpecContext) {
-			Expect(broker.RecoverData(ctx, clusterInfo, brokerObj, testBrokerNamespace,
-				testBrokerURL, brokerRestConfig, t.statusReporter)).NotTo(Succeed())
+		It("should fallback to the clear text PSK", func(ctx SpecContext) {
+			Expect(broker.RecoverData(ctx, clusterInfo, brokerObj, testBrokerNamespace, testBrokerURL, brokerRestConfig,
+				t.statusReporter)).To(Succeed())
+
+			info, err := broker.ReadInfoFromFile(path.Join(broker.InfoFileDir, broker.InfoFileName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IPSecPSK).NotTo(BeNil())
+			Expect(info.IPSecPSK.Data["psk"]).To(Equal([]byte(fallbackIPSecPSK)))
+		})
+
+		Context("and the fallback PSK is not a valid base64 string", func() {
+			BeforeEach(func() {
+				clusterInfo.Submariner.Spec.CeIPSecPSK = "invalid"
+			})
+
+			It("should return an error", func(ctx SpecContext) {
+				Expect(broker.RecoverData(ctx, clusterInfo, brokerObj, testBrokerNamespace,
+					testBrokerURL, brokerRestConfig, t.statusReporter)).NotTo(Succeed())
+			})
 		})
 	})
 })


### PR DESCRIPTION
Update `RecoverData()` to read the IPSec PSK from the `CeIPSecPSKSecret` Secret if configured, otherwise fall back to the `CeIPSecPSK` CR field for backwards compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - IPSec recovery now supports retrieving the pre-shared key from a configured Kubernetes Secret.
  - Existing configurations without a Secret continue to use the configured, encoded PSK value.

- **Bug Fixes**
  - Added validation for missing or invalid Secret data.
  - Recovery now reports clearer errors when PSK retrieval or fallback decoding fails.

- **Tests**
  - Expanded coverage for Secret-based recovery, fallback behavior, and invalid configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->