### PR TITLE
Refactor broker connection to use Secret-based credentials

### DIFF
--- a/cmd/subctl/recover_broker_info.go
+++ b/cmd/subctl/recover_broker_info.go
@@ -85,9 +85,9 @@ func (c *RecoverBrokerCommand) recoverBrokerInfo(ctx context.Context, submCluste
 	if !found {
 		status.Warning("Broker not found. Trying to connect to the Broker installed on a different cluster")
 
-		brokerRestConfig, brokerNamespace, err = restconfig.ForBroker(ctx, submCluster.Submariner, submCluster.ServiceDiscovery)
+		brokerRestConfig, brokerNamespace, err = submCluster.NewBrokerRestConfig(ctx)
 		if err != nil {
-			return status.Error(err, "Error getting the Broker's REST config")
+			return status.Error(err, "Error creating broker REST config")
 		}
 
 		brokerObj, found, err = getBroker(ctx, brokerRestConfig, brokerNamespace)

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/submariner-io/lighthouse v0.25.0-m0.0.20260720165819-ed6aec845c65
 	github.com/submariner-io/shipyard v0.25.0-m0.0.20260720121336-f93811d249ff
 	github.com/submariner-io/submariner v0.25.0-m0.0.20260720170504-eaebb7c69ac6
-	github.com/submariner-io/submariner-operator v0.25.0-m0.0.20260801124230-f2a7d029c7c1
+	github.com/submariner-io/submariner-operator v0.25.0-m0.0.20260811120816-8bef08878f9c
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/submariner-io/shipyard v0.25.0-m0.0.20260720121336-f93811d249ff h1:Fb
 github.com/submariner-io/shipyard v0.25.0-m0.0.20260720121336-f93811d249ff/go.mod h1:HMntb7UlPZ2u6Fg3UykcE9Get//ujNh8gqXXmPLm2+Y=
 github.com/submariner-io/submariner v0.25.0-m0.0.20260720170504-eaebb7c69ac6 h1:XAULTv2PoEDjccYSk9wwiXpZf8EOFO4pNaRew4c/L/4=
 github.com/submariner-io/submariner v0.25.0-m0.0.20260720170504-eaebb7c69ac6/go.mod h1:j6Wc1xX87W+Q3YQaFNlPxT9CIaPVSTHr34M0px07+u8=
-github.com/submariner-io/submariner-operator v0.25.0-m0.0.20260801124230-f2a7d029c7c1 h1:/LkmEnfR0EF38o8+VukSriphKZkqum1x6fuBsbNJEOg=
-github.com/submariner-io/submariner-operator v0.25.0-m0.0.20260801124230-f2a7d029c7c1/go.mod h1:tb9Kues5bZ/CM3onehooPV8Q5N0Ui7BvCaVTOxaYSx8=
+github.com/submariner-io/submariner-operator v0.25.0-m0.0.20260811120816-8bef08878f9c h1:rkbzdfoW1eezM30sTLR6Sjw+PAR1itG0gTdNbGwixKM=
+github.com/submariner-io/submariner-operator v0.25.0-m0.0.20260811120816-8bef08878f9c/go.mod h1:oxefChQltKYPZldnUBdBqOnvwgbwY1uJO3XNHituzVA=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -30,9 +30,7 @@ import (
 	"github.com/submariner-io/subctl/internal/component"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/exit"
-	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/brokercr"
-	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -180,21 +178,17 @@ func gatherDiscovery(ctx context.Context, dataType string, info Info) bool {
 func gatherBroker(ctx context.Context, dataType string, info Info) bool {
 	switch dataType {
 	case Resources:
-		brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(ctx, info.Submariner, info.ServiceDiscovery)
+		brokerProducer, brokerNamespace, err := info.NewBrokerProducer(ctx)
 		if err != nil {
-			info.Status.Failure("Error getting the broker's rest config: %s", err)
+			info.Status.Failure("Error creating broker client Producer: %s", err)
 			return true
 		}
 
-		if brokerRestConfig != nil {
-			info.RestConfig = brokerRestConfig
-
-			info.ClientProducer, err = client.NewProducerFromRestConfig(brokerRestConfig)
-			if err != nil {
-				info.Status.Failure("Error creating broker client Producer: %s", err)
-				return true
-			}
+		if brokerProducer != nil {
+			// Successfully got broker producer - this cluster is connected to a remote broker
+			info.ClientProducer = brokerProducer
 		} else {
+			// No Submariner/ServiceDiscovery CR found - check if broker is installed locally
 			err = info.ClientProducer.ForGeneral().Get(ctx, controllerClient.ObjectKey{
 				Namespace: constants.OperatorNamespace,
 				Name:      brokercr.Name,

--- a/internal/restconfig/producer_test.go
+++ b/internal/restconfig/producer_test.go
@@ -20,7 +20,6 @@ package restconfig_test
 
 import (
 	"context"
-	"encoding/base64"
 	"os"
 	"sort"
 	"strings"
@@ -29,7 +28,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 	"github.com/submariner-io/admiral/pkg/reporter"
-	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/client"
@@ -40,10 +38,6 @@ import (
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -68,7 +62,6 @@ var (
 	})
 	_ = Describe("IfConnectivityInstalled", testIfConnectivityInstalled)
 	_ = Describe("IfServiceDiscoveryInstalled", testIfServiceDiscoveryInstalled)
-	_ = Describe("ForBroker", testForBroker)
 )
 
 func testSetupFlags() {
@@ -904,71 +897,6 @@ func testIfServiceDiscoveryInstalled() {
 					return nil
 				}), reporter.Stdout())
 
-			Expect(err).To(Succeed())
-		})
-	})
-}
-
-func testForBroker() {
-	const (
-		brokerNS  = "brokerNS"
-		apiServer = "api-server"
-	)
-
-	var (
-		apiServerToken = base64.StdEncoding.EncodeToString([]byte("token"))
-		dynClient      dynamic.Interface
-	)
-
-	BeforeEach(func() {
-		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
-
-		resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
-			return dynClient, nil
-		}
-	})
-
-	When("a Submariner resource is provided", func() {
-		It("should return a valid REST config", func(ctx context.Context) {
-			restConfig, ns, err := restconfig.ForBroker(ctx, &v1alpha1.Submariner{
-				Spec: v1alpha1.SubmarinerSpec{
-					BrokerK8sApiServer:       apiServer,
-					BrokerK8sApiServerToken:  apiServerToken,
-					BrokerK8sRemoteNamespace: brokerNS,
-				},
-			}, nil)
-
-			Expect(err).To(Succeed())
-			Expect(restConfig).ToNot(BeNil())
-			Expect(restConfig.Host).To(ContainSubstring(apiServer))
-			Expect(restConfig.BearerToken).To(Equal(apiServerToken))
-			Expect(ns).To(Equal(brokerNS))
-			Expect(err).To(Succeed())
-		})
-	})
-
-	When("a ServiceDiscovery resource is provided", func() {
-		It("should return a valid REST config", func(ctx context.Context) {
-			restConfig, ns, err := restconfig.ForBroker(ctx, nil, &v1alpha1.ServiceDiscovery{
-				Spec: v1alpha1.ServiceDiscoverySpec{
-					BrokerK8sApiServer:       apiServer,
-					BrokerK8sApiServerToken:  apiServerToken,
-					BrokerK8sRemoteNamespace: brokerNS,
-				},
-			})
-
-			Expect(err).To(Succeed())
-			Expect(restConfig).ToNot(BeNil())
-			Expect(restConfig.Host).To(ContainSubstring(apiServer))
-			Expect(restConfig.BearerToken).To(Equal(apiServerToken))
-			Expect(ns).To(Equal(brokerNS))
-			Expect(err).To(Succeed())
-		})
-	})
-
-	When("no resource is provided", func() {
-		It("should succeed", func(ctx context.Context) {
-			_, _, err := restconfig.ForBroker(ctx, nil, nil)
 			Expect(err).To(Succeed())
 		})
 	})

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -30,15 +30,11 @@ import (
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
-	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/subctl/pkg/version"
-	"github.com/submariner-io/submariner-operator/api/v1alpha1"
-	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	mcsv1b1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 const InCluster = "in-cluster"
@@ -451,37 +447,6 @@ func (rcp *Producer) overrideContextAndRun(ctx context.Context, clusterName, con
 	rcp.defaultClientConfig.overrides.CurrentContext = contextName
 
 	return rcp.RunOnSelectedContext(ctx, function, status)
-}
-
-func ForBroker(ctx context.Context, submariner *v1alpha1.Submariner, serviceDisc *v1alpha1.ServiceDiscovery) (*rest.Config, string, error) {
-	var restConfig *rest.Config
-	var namespace string
-	var err error
-
-	// This is used in subctl; the broker secret isn't available mounted, so we use the old strings for now
-	if submariner != nil {
-		// Try to authorize against the submariner Cluster resource as we know the CRD should exist and the credentials
-		// should allow read access.
-		restConfig, _, err = resource.GetAuthorizedRestConfigFromData(ctx, submariner.Spec.BrokerK8sApiServer,
-			submariner.Spec.BrokerK8sApiServerToken,
-			submariner.Spec.BrokerK8sCA,
-			&rest.TLSClientConfig{},
-			subv1.SchemeGroupVersion.WithResource("clusters"),
-			submariner.Spec.BrokerK8sRemoteNamespace)
-		namespace = submariner.Spec.BrokerK8sRemoteNamespace
-	} else if serviceDisc != nil {
-		// Try to authorize against the ServiceImport resource as we know the CRD should exist and the credentials
-		// should allow read access.
-		restConfig, _, err = resource.GetAuthorizedRestConfigFromData(ctx, serviceDisc.Spec.BrokerK8sApiServer,
-			serviceDisc.Spec.BrokerK8sApiServerToken,
-			serviceDisc.Spec.BrokerK8sCA,
-			&rest.TLSClientConfig{},
-			gvr.FromMetaGroupVersion(mcsv1b1.GroupVersion, "serviceimports"),
-			serviceDisc.Spec.BrokerK8sRemoteNamespace)
-		namespace = serviceDisc.Spec.BrokerK8sRemoteNamespace
-	}
-
-	return restConfig, namespace, errors.Wrap(err, "error getting auth rest config")
 }
 
 func getRestConfigFromConfig(config clientcmd.ClientConfig, overrides *clientcmd.ConfigOverrides) (RestConfig, error) {

--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -20,6 +20,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"slices"
 	"strings"
@@ -28,16 +29,19 @@ import (
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/image"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+	mcsv1b1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 type Info struct {
@@ -251,4 +255,116 @@ func MergeImageOverrides(imageOverrides map[string]string, localImageOverrides [
 	}
 
 	return imageOverrides, nil
+}
+
+// NewBrokerRestConfig creates a REST config for connecting to the broker cluster.
+// It prefers reading credentials from the broker Secret (more secure) but falls back
+// to CR fields (BrokerK8sApiServerToken, BrokerK8sCA) for backwards compatibility.
+// Returns the broker REST config and the broker namespace.
+func (c *Info) NewBrokerRestConfig(ctx context.Context) (*rest.Config, string, error) {
+	// Determine which CR to use (Submariner takes precedence over ServiceDiscovery)
+	var brokerAPIServer, brokerNamespace, brokerSecretName, tokenField, caField string
+	var gvResource schema.GroupVersionResource
+
+	if c.Submariner != nil {
+		brokerAPIServer = c.Submariner.Spec.BrokerK8sApiServer
+		brokerNamespace = c.Submariner.Spec.BrokerK8sRemoteNamespace
+		brokerSecretName = c.Submariner.Spec.BrokerK8sSecret
+		tokenField = c.Submariner.Spec.BrokerK8sApiServerToken
+		caField = c.Submariner.Spec.BrokerK8sCA
+		gvResource = submarinerv1.SchemeGroupVersion.WithResource("clusters")
+	} else if c.ServiceDiscovery != nil {
+		brokerAPIServer = c.ServiceDiscovery.Spec.BrokerK8sApiServer
+		brokerNamespace = c.ServiceDiscovery.Spec.BrokerK8sRemoteNamespace
+		brokerSecretName = c.ServiceDiscovery.Spec.BrokerK8sSecret
+		tokenField = c.ServiceDiscovery.Spec.BrokerK8sApiServerToken
+		caField = c.ServiceDiscovery.Spec.BrokerK8sCA
+		gvResource = gvr.FromMetaGroupVersion(mcsv1b1.GroupVersion, "serviceimports")
+	} else {
+		// Neither Submariner nor ServiceDiscovery CR found - return nil to allow caller to distinguish
+		return nil, "", nil
+	}
+
+	var token, ca string
+	var err error
+
+	// Try to read broker credentials from Secret first (more secure)
+	if brokerSecretName != "" {
+		token, ca, err = c.readBrokerSecret(ctx, brokerSecretName)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		// No Secret configured - use CR fields for backwards compatibility
+		token = tokenField
+		ca = caField
+	}
+
+	// Create REST config for broker using the credentials
+	brokerRestConfig, _, err := resource.GetAuthorizedRestConfigFromData(ctx,
+		brokerAPIServer,
+		token,
+		ca,
+		&rest.TLSClientConfig{},
+		gvResource,
+		brokerNamespace)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "error getting auth rest config for broker")
+	}
+
+	return brokerRestConfig, brokerNamespace, nil
+}
+
+// NewBrokerProducer creates a client.Producer for connecting to the broker cluster.
+// It prefers reading credentials from the broker Secret (more secure) but falls back
+// to CR fields (BrokerK8sApiServerToken, BrokerK8sCA) for backwards compatibility.
+// Returns the broker client producer, broker REST config, and the broker namespace.
+func (c *Info) NewBrokerProducer(ctx context.Context) (client.Producer, string, error) {
+	brokerRestConfig, brokerNamespace, err := c.NewBrokerRestConfig(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if brokerRestConfig == nil {
+		// Neither Submariner nor ServiceDiscovery CR found
+		return nil, "", nil
+	}
+
+	// Create client producer from the broker REST config
+	brokerProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "error creating broker client producer")
+	}
+
+	return brokerProducer, brokerNamespace, nil
+}
+
+// readBrokerSecret reads the broker token and CA from a Secret using the cluster's ClientProducer.
+func (c *Info) readBrokerSecret(ctx context.Context, secretName string) (string, string, error) {
+	secret := &corev1.Secret{}
+
+	err := c.ClientProducer.ForGeneral().Get(ctx, controllerClient.ObjectKey{
+		Namespace: c.OperatorNamespace(),
+		Name:      secretName,
+	}, secret)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "error reading broker secret %s/%s", c.OperatorNamespace(), secretName)
+	}
+
+	// Extract token data
+	tokenData, ok := secret.Data["token"]
+	if !ok || len(tokenData) == 0 {
+		return "", "", errors.Errorf("broker secret %s/%s missing 'token' data", c.OperatorNamespace(), secretName)
+	}
+
+	// Extract ca.crt data
+	caData, ok := secret.Data["ca.crt"]
+	if !ok || len(caData) == 0 {
+		return "", "", errors.Errorf("broker secret %s/%s missing 'ca.crt' data", c.OperatorNamespace(), secretName)
+	}
+
+	// Secret.Data is already decoded from base64 by Kubernetes API client
+	// But GetAuthorizedRestConfigFromData expects CA to be base64-encoded
+	// Token is used as-is (string)
+	return string(tokenData), base64.StdEncoding.EncodeToString(caData), nil
 }

--- a/pkg/cluster/info_test.go
+++ b/pkg/cluster/info_test.go
@@ -19,18 +19,25 @@ limitations under the License.
 package cluster_test
 
 import (
+	"encoding/base64"
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
 	"github.com/submariner-io/admiral/pkg/names"
+	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -45,6 +52,7 @@ var _ = Describe("Info", func() {
 	Describe("OperatorNamespace", testOperatorNamespace)
 	Describe("GetClusters", testGetClusters)
 	Describe("MergeImageOverrides", testMergeImageOverrides)
+	Describe("NewBrokerRestConfig", testNewBrokerRestConfig)
 })
 
 func testNewInfo() {
@@ -541,5 +549,127 @@ func testMergeImageOverrides() {
 		})
 
 		Expect(err).To(HaveOccurred())
+	})
+}
+
+func testNewBrokerRestConfig() {
+	const (
+		brokerNamespace  = "broker-ns"
+		brokerAPIServer  = "broker-api-server:6443"
+		brokerSecretName = "broker-secret"
+		secretToken      = "secret-token"
+		secretCA         = "secret-ca-cert" //nolint:gosec // For testing
+		clearTextCA      = "clear-text-ca"
+	)
+
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
+			return t.clients.ForDynamic(), nil
+		}
+
+		t.submariner.Spec.BrokerK8sApiServer = brokerAPIServer
+		t.submariner.Spec.BrokerK8sRemoteNamespace = brokerNamespace
+		t.submariner.Spec.BrokerK8sApiServerToken = base64.StdEncoding.EncodeToString([]byte("cr-token"))
+		t.submariner.Spec.BrokerK8sCA = base64.StdEncoding.EncodeToString([]byte(clearTextCA))
+	})
+
+	When("Submariner CR has broker credentials in Secret", func() {
+		BeforeEach(func(ctx SpecContext) {
+			t.submariner.Spec.BrokerK8sSecret = brokerSecretName
+
+			// Create the broker secret
+			Expect(t.clients.ForGeneral().Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      brokerSecretName,
+					Namespace: constants.OperatorNamespace,
+				},
+				Data: map[string][]byte{
+					"token":  []byte(secretToken),
+					"ca.crt": []byte(secretCA),
+				},
+			})).To(Succeed())
+		})
+
+		It("should return broker rest config using Secret credentials", func(ctx SpecContext) {
+			restConfig, ns, err := t.newInfo(ctx).NewBrokerRestConfig(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(restConfig).NotTo(BeNil())
+			Expect(restConfig.Host).To(ContainSubstring(brokerAPIServer))
+			Expect(restConfig.BearerToken).To(Equal(secretToken))
+			Expect(restConfig.TLSClientConfig.CAData).To(Equal([]byte(secretCA)))
+			Expect(ns).To(Equal(brokerNamespace))
+		})
+	})
+
+	When("Submariner CR has broker credentials in CR fields", func() {
+		It("should return broker rest config using CR field credentials", func(ctx SpecContext) {
+			restConfig, ns, err := t.newInfo(ctx).NewBrokerRestConfig(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(restConfig).NotTo(BeNil())
+			Expect(restConfig.Host).To(ContainSubstring(brokerAPIServer))
+			Expect(restConfig.BearerToken).To(Equal(t.submariner.Spec.BrokerK8sApiServerToken))
+			Expect(restConfig.TLSClientConfig.CAData).To(Equal([]byte(clearTextCA)))
+			Expect(ns).To(Equal(brokerNamespace))
+		})
+	})
+
+	When("ServiceDiscovery CR has broker credentials in CR fields", func() {
+		BeforeEach(func() {
+			t.serviceDisc.Spec.BrokerK8sApiServer = brokerAPIServer
+			t.serviceDisc.Spec.BrokerK8sRemoteNamespace = brokerNamespace
+			t.serviceDisc.Spec.BrokerK8sApiServerToken = t.submariner.Spec.BrokerK8sApiServerToken
+			t.serviceDisc.Spec.BrokerK8sCA = t.submariner.Spec.BrokerK8sCA
+
+			t.submariner = nil
+		})
+
+		It("should return broker rest config using ServiceDiscovery credentials", func(ctx SpecContext) {
+			restConfig, ns, err := t.newInfo(ctx).NewBrokerRestConfig(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(restConfig).NotTo(BeNil())
+			Expect(restConfig.Host).To(ContainSubstring(brokerAPIServer))
+			Expect(restConfig.BearerToken).To(Equal(t.serviceDisc.Spec.BrokerK8sApiServerToken))
+			Expect(restConfig.TLSClientConfig.CAData).To(Equal([]byte(clearTextCA)))
+			Expect(ns).To(Equal(brokerNamespace))
+		})
+	})
+
+	When("broker Secret is configured but not found", func() {
+		BeforeEach(func() {
+			t.submariner.Spec.BrokerK8sSecret = brokerSecretName
+		})
+
+		It("should return an error", func(ctx SpecContext) {
+			_, _, err := t.newInfo(ctx).NewBrokerRestConfig(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("neither Submariner nor ServiceDiscovery CR exists", func() {
+		BeforeEach(func() {
+			t.submariner = nil
+			t.serviceDisc = nil
+		})
+
+		It("should succeed with nil rest config", func(ctx SpecContext) {
+			restConfig, _, err := t.newInfo(ctx).NewBrokerRestConfig(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(restConfig).To(BeNil())
+		})
+	})
+
+	When("REST config creation fails", func() {
+		It("should return an error", func(ctx SpecContext) {
+			info := t.newInfo(ctx)
+
+			resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
+				return nil, errors.New("fake error")
+			}
+
+			_, _, err := info.NewBrokerRestConfig(ctx)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 }

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -26,8 +26,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
-	"github.com/submariner-io/subctl/internal/restconfig"
-	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
@@ -65,19 +63,14 @@ func checkOverlappingCIDRs(ctx context.Context, clusterInfo *cluster.Info, statu
 
 	defer status.End()
 
-	brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(ctx, clusterInfo.Submariner, nil)
-	if err != nil {
-		return status.Error(err, "Error getting the Broker's REST config")
-	}
-
-	clientProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	brokerProducer, brokerNamespace, err := clusterInfo.NewBrokerProducer(ctx)
 	if err != nil {
 		return status.Error(err, "Error creating broker client Producer")
 	}
 
 	endpointList := &submarinerv1.EndpointList{}
 
-	err = clientProducer.ForGeneral().List(ctx, endpointList,
+	err = brokerProducer.ForGeneral().List(ctx, endpointList,
 		controllerClient.InNamespace(brokerNamespace))
 	if err != nil {
 		return status.Error(err, "Error listing the Submariner endpoints from the Broker cluster")

--- a/pkg/diagnose/deployments_test.go
+++ b/pkg/diagnose/deployments_test.go
@@ -173,14 +173,14 @@ var _ = Describe("Deployments", func() {
 
 	Context("with a multiple node environment", t.testMultipleNodes)
 
-	When("creation of broker REST config fails", func() {
+	When("creation of broker client Producer fails", func() {
 		BeforeEach(func() {
 			resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
 				return nil, errFake
 			}
 		})
 
-		t.testFailure(t.run, "REST config", errFake.Error())
+		t.testFailure(t.run, "broker client Producer", errFake.Error())
 	})
 
 	When("listing of Endpoint resources fails", func() {

--- a/pkg/diagnose/servicediscovery.go
+++ b/pkg/diagnose/servicediscovery.go
@@ -27,8 +27,6 @@ import (
 	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/gvr"
-	"github.com/submariner-io/subctl/internal/restconfig"
-	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -177,19 +175,13 @@ func verifyStatusCondition(se *mcsv1b1.ServiceExport, condType mcsv1b1.ServiceEx
 }
 
 func checkServiceImports(ctx context.Context, clusterInfo *cluster.Info, status reporter.Interface) {
-	brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(ctx, clusterInfo.Submariner, nil)
-	if err != nil {
-		status.Failure("Error getting the Broker's REST config: %v", err)
-		return
-	}
-
-	clientProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	brokerProducer, brokerNamespace, err := clusterInfo.NewBrokerProducer(ctx)
 	if err != nil {
 		status.Failure("Error creating broker client Producer: %v", err)
 		return
 	}
 
-	serviceImports, err := clientProducer.ForDynamic().Resource(serviceImportGVR()).Namespace(brokerNamespace).List(
+	serviceImports, err := brokerProducer.ForDynamic().Resource(serviceImportGVR()).Namespace(brokerNamespace).List(
 		ctx, metav1.ListOptions{})
 	if err != nil {
 		status.Failure("Error listing ServiceImports on the broker: %v", err)


### PR DESCRIPTION
Move `ForBroker()` logic from `restconfig` package to a new `cluster.Info.NewBrokerProducer()` method. This enables reading broker credentials securely from a Kubernetes Secret via the cluster's ClientProducer, rather than using a standalone kubeconfig client.

Changes:
- Add `cluster.Info.NewBrokerProducer()` method that:
  - Prefers reading credentials from broker Secret (more secure)
  - Falls back to CR fields for backwards compatibility
  - Returns nil when neither Submariner nor ServiceDiscovery CR exists
  - Returns proper errors when Secret is configured but can't be read
- Remove `restconfig.ForBroker()` and helper functions
- Update all callers to use the new method:
  - pkg/diagnose/deployments.go
  - pkg/diagnose/servicediscovery.go
  - internal/gather/gather.go
  - cmd/subctl/recover_broker_info.go
- Add comprehensive unit tests for NewBrokerProducer

Fixes https://github.com/submariner-io/subctl/issues/631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized broker connection handling using available cluster configuration and credentials.
  - Supports broker credentials from configured Secrets, with compatibility for legacy credential fields.
  - Improved broker connectivity across recovery, gathering, and diagnostic workflows, including clusters without a locally available broker.

- **Bug Fixes**
  - Improved error reporting when broker client creation or credential retrieval fails.

- **Tests**
  - Added coverage for broker credential sources, missing resources, TLS and token settings, and connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->