### PR TITLE
Automated backport of #1845: Read IPSec PSK from Secret for recover broker info

### DIFF
--- a/pkg/broker/recover_broker_info.go
+++ b/pkg/broker/recover_broker_info.go
@@ -19,11 +19,14 @@ limitations under the License.
 package broker
 
 import (
+	"context"
 	"encoding/base64"
 
+	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/set"
 )
@@ -36,9 +39,21 @@ func RecoverData(submCluster *cluster.Info, broker *v1alpha1.Broker, brokerNames
 
 	status.Success("Retrieving IPSec PSK secret from Submariner found on cluster %s", submCluster.Name)
 
-	decodedPSKSecret, err := base64.StdEncoding.DecodeString(submCluster.Submariner.Spec.CeIPSecPSK)
-	if err != nil {
-		return status.Error(err, "error decoding the secret")
+	var decodedPSKSecret []byte
+	var err error
+
+	// Read PSK from Secret if configured, otherwise fall back to CR field
+	if submCluster.Submariner.Spec.CeIPSecPSKSecret != "" {
+		decodedPSKSecret, err = readIPSecPSKFromSecret(submCluster, submCluster.Submariner.Spec.CeIPSecPSKSecret)
+		if err != nil {
+			return status.Error(err, "error reading IPSec PSK from secret %q", submCluster.Submariner.Spec.CeIPSecPSKSecret)
+		}
+	} else {
+		// Fall back to reading from CR field for backwards compatibility
+		decodedPSKSecret, err = base64.StdEncoding.DecodeString(submCluster.Submariner.Spec.CeIPSecPSK)
+		if err != nil {
+			return status.Error(err, "error decoding the secret")
+		}
 	}
 
 	status.Success("Successfully retrieved the data. Writing it to broker-info.subm")
@@ -47,4 +62,20 @@ func RecoverData(submCluster *cluster.Info, broker *v1alpha1.Broker, brokerNames
 		set.New(broker.Spec.Components...), broker.Spec.DefaultCustomDomains, status)
 
 	return status.Error(err, "error reconstructing broker-info.subm")
+}
+
+func readIPSecPSKFromSecret(submCluster *cluster.Info, secretName string) ([]byte, error) {
+	secret, err := submCluster.ClientProducer.ForKubernetes().CoreV1().Secrets(submCluster.Submariner.Namespace).Get(
+		context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading IPSec PSK secret %s/%s", submCluster.OperatorNamespace(), secretName)
+	}
+
+	pskData, ok := secret.Data["psk"]
+	if !ok || len(pskData) == 0 {
+		return nil, errors.Errorf("IPSec PSK secret %s/%s missing 'psk' data", submCluster.OperatorNamespace(), secretName)
+	}
+
+	// Secret.Data is already decoded from base64 by Kubernetes API client
+	return pskData, nil
 }


### PR DESCRIPTION
Backport of #1845 on release-0.22.

#1845: Read IPSec PSK from Secret for recover broker info

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IPSec PSKs can now be retrieved securely from a configured Kubernetes Secret.
  * Retains support for existing base64-encoded PSK configuration when no Secret is specified.

* **Bug Fixes**
  * Added validation and clearer errors for unavailable Secrets, missing `psk` data, empty values, and invalid encoded PSKs.

* **Tests**
  * Added coverage for broker data recovery, Secret-based PSKs, fallback behavior, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->