### PR TITLE
Automated backport of #1857: Refactor broker connection to use Secret-based credentials

### DIFF
--- a/cmd/subctl/recover_broker_info.go
+++ b/cmd/subctl/recover_broker_info.go
@@ -71,9 +71,9 @@ func recoverBrokerInfoFromSubm(submCluster *cluster.Info, _ string, status repor
 	if !found {
 		status.Warning("Broker not found. Trying to connect to the Broker installed on a different cluster")
 
-		brokerRestConfig, brokerNamespace, err = restconfig.ForBroker(submCluster.Submariner, submCluster.ServiceDiscovery)
+		brokerRestConfig, brokerNamespace, err = submCluster.NewBrokerRestConfig(context.TODO())
 		if err != nil {
-			return status.Error(err, "Error getting the Broker's REST config")
+			return status.Error(err, "Error creating broker REST config")
 		}
 
 		brokerObj, found, err = getBroker(context.TODO(), brokerRestConfig, brokerNamespace)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.20.3
 	github.com/submariner-io/shipyard v0.20.3
 	github.com/submariner-io/submariner v0.20.3
-	github.com/submariner-io/submariner-operator v0.20.3
+	github.com/submariner-io/submariner-operator v0.20.4-0.20260812143745-ad262e7afc0f
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -519,8 +519,8 @@ github.com/submariner-io/shipyard v0.20.3 h1:cPOz6O5XQ1DEMkBMUierppLxckxv+otTvc7
 github.com/submariner-io/shipyard v0.20.3/go.mod h1:0PtuW4fvN1P+eHB4RnE3HH7wPivOeqlrpEqjGh6BFxo=
 github.com/submariner-io/submariner v0.20.3 h1:t5oNu3+Ac2Kuw6XVxCd5z9D3a0g7vzFJ/KT5T1o3msY=
 github.com/submariner-io/submariner v0.20.3/go.mod h1:U19Fn8fS5eNv9Vk2UUbrNBWnvnyFUaD7KdTCYpP/QZc=
-github.com/submariner-io/submariner-operator v0.20.3 h1:gz0QEvhodwE+0go2WsbNIhsjkPHgvpCZxR8aYsXxWpM=
-github.com/submariner-io/submariner-operator v0.20.3/go.mod h1:Ggeh3eqwnBjMXh2XbL8pLVbuvGTUA2PUlYmSZ9V1n90=
+github.com/submariner-io/submariner-operator v0.20.4-0.20260812143745-ad262e7afc0f h1:VZbpwkpOUquTMDveqYUzud2Joaa+AjdrC8XKrF4EYiU=
+github.com/submariner-io/submariner-operator v0.20.4-0.20260812143745-ad262e7afc0f/go.mod h1:Ggeh3eqwnBjMXh2XbL8pLVbuvGTUA2PUlYmSZ9V1n90=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -30,9 +30,7 @@ import (
 	"github.com/submariner-io/subctl/internal/component"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/exit"
-	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/brokercr"
-	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -180,21 +178,17 @@ func gatherDiscovery(dataType string, info Info) bool {
 func gatherBroker(dataType string, info Info) bool {
 	switch dataType {
 	case Resources:
-		brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(info.Submariner, info.ServiceDiscovery)
+		brokerProducer, brokerNamespace, err := info.NewBrokerProducer(context.TODO())
 		if err != nil {
-			info.Status.Failure("Error getting the broker's rest config: %s", err)
+			info.Status.Failure("Error creating broker client Producer: %s", err)
 			return true
 		}
 
-		if brokerRestConfig != nil {
-			info.RestConfig = brokerRestConfig
-
-			info.ClientProducer, err = client.NewProducerFromRestConfig(brokerRestConfig)
-			if err != nil {
-				info.Status.Failure("Error creating broker client Producer: %s", err)
-				return true
-			}
+		if brokerProducer != nil {
+			// Successfully got broker producer - this cluster is connected to a remote broker
+			info.ClientProducer = brokerProducer
 		} else {
+			// No Submariner/ServiceDiscovery CR found - check if broker is installed locally
 			err = info.ClientProducer.ForGeneral().Get(context.TODO(), controllerClient.ObjectKey{
 				Namespace: constants.OperatorNamespace,
 				Name:      brokercr.Name,

--- a/internal/restconfig/producer_test.go
+++ b/internal/restconfig/producer_test.go
@@ -20,7 +20,6 @@ package restconfig_test
 
 import (
 	"context"
-	"encoding/base64"
 	"os"
 	"sort"
 	"strings"
@@ -29,7 +28,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 	"github.com/submariner-io/admiral/pkg/reporter"
-	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
 	"github.com/submariner-io/subctl/internal/restconfig"
 	"github.com/submariner-io/subctl/pkg/client"
@@ -40,10 +38,6 @@ import (
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -68,7 +62,6 @@ var (
 	})
 	_ = Describe("IfConnectivityInstalled", testIfConnectivityInstalled)
 	_ = Describe("IfServiceDiscoveryInstalled", testIfServiceDiscoveryInstalled)
-	_ = Describe("ForBroker", testForBroker)
 )
 
 func testSetupFlags() {
@@ -879,71 +872,6 @@ func testIfServiceDiscoveryInstalled() {
 					return nil
 				}), reporter.Stdout())
 
-			Expect(err).To(Succeed())
-		})
-	})
-}
-
-func testForBroker() {
-	const (
-		brokerNS  = "brokerNS"
-		apiServer = "api-server"
-	)
-
-	var (
-		apiServerToken = base64.StdEncoding.EncodeToString([]byte("token"))
-		dynClient      dynamic.Interface
-	)
-
-	BeforeEach(func() {
-		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
-
-		resource.NewDynamicClient = func(_ *rest.Config) (dynamic.Interface, error) {
-			return dynClient, nil
-		}
-	})
-
-	When("a Submariner resource is provided", func() {
-		It("should return a valid REST config", func() {
-			restConfig, ns, err := restconfig.ForBroker(&v1alpha1.Submariner{
-				Spec: v1alpha1.SubmarinerSpec{
-					BrokerK8sApiServer:       apiServer,
-					BrokerK8sApiServerToken:  apiServerToken,
-					BrokerK8sRemoteNamespace: brokerNS,
-				},
-			}, nil)
-
-			Expect(err).To(Succeed())
-			Expect(restConfig).ToNot(BeNil())
-			Expect(restConfig.Host).To(ContainSubstring(apiServer))
-			Expect(restConfig.BearerToken).To(Equal(apiServerToken))
-			Expect(ns).To(Equal(brokerNS))
-			Expect(err).To(Succeed())
-		})
-	})
-
-	When("a ServiceDiscovery resource is provided", func() {
-		It("should return a valid REST config", func() {
-			restConfig, ns, err := restconfig.ForBroker(nil, &v1alpha1.ServiceDiscovery{
-				Spec: v1alpha1.ServiceDiscoverySpec{
-					BrokerK8sApiServer:       apiServer,
-					BrokerK8sApiServerToken:  apiServerToken,
-					BrokerK8sRemoteNamespace: brokerNS,
-				},
-			})
-
-			Expect(err).To(Succeed())
-			Expect(restConfig).ToNot(BeNil())
-			Expect(restConfig.Host).To(ContainSubstring(apiServer))
-			Expect(restConfig.BearerToken).To(Equal(apiServerToken))
-			Expect(ns).To(Equal(brokerNS))
-			Expect(err).To(Succeed())
-		})
-	})
-
-	When("no resource is provided", func() {
-		It("should succeed", func() {
-			_, _, err := restconfig.ForBroker(nil, nil)
 			Expect(err).To(Succeed())
 		})
 	})

--- a/internal/restconfig/restconfig.go
+++ b/internal/restconfig/restconfig.go
@@ -28,16 +28,12 @@ import (
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
-	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	"github.com/submariner-io/subctl/pkg/version"
-	"github.com/submariner-io/submariner-operator/api/v1alpha1"
-	subv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 const InCluster = "in-cluster"
@@ -447,37 +443,6 @@ func (rcp *Producer) overrideContextAndRun(clusterName, contextName string, func
 	rcp.defaultClientConfig.overrides.CurrentContext = contextName
 
 	return rcp.RunOnSelectedContext(function, status)
-}
-
-func ForBroker(submariner *v1alpha1.Submariner, serviceDisc *v1alpha1.ServiceDiscovery) (*rest.Config, string, error) {
-	var restConfig *rest.Config
-	var namespace string
-	var err error
-
-	// This is used in subctl; the broker secret isn't available mounted, so we use the old strings for now
-	if submariner != nil {
-		// Try to authorize against the submariner Cluster resource as we know the CRD should exist and the credentials
-		// should allow read access.
-		restConfig, _, err = resource.GetAuthorizedRestConfigFromData(submariner.Spec.BrokerK8sApiServer,
-			submariner.Spec.BrokerK8sApiServerToken,
-			submariner.Spec.BrokerK8sCA,
-			&rest.TLSClientConfig{},
-			subv1.SchemeGroupVersion.WithResource("clusters"),
-			submariner.Spec.BrokerK8sRemoteNamespace)
-		namespace = submariner.Spec.BrokerK8sRemoteNamespace
-	} else if serviceDisc != nil {
-		// Try to authorize against the ServiceImport resource as we know the CRD should exist and the credentials
-		// should allow read access.
-		restConfig, _, err = resource.GetAuthorizedRestConfigFromData(serviceDisc.Spec.BrokerK8sApiServer,
-			serviceDisc.Spec.BrokerK8sApiServerToken,
-			serviceDisc.Spec.BrokerK8sCA,
-			&rest.TLSClientConfig{},
-			gvr.FromMetaGroupVersion(mcsv1a1.GroupVersion, "serviceimports"),
-			serviceDisc.Spec.BrokerK8sRemoteNamespace)
-		namespace = serviceDisc.Spec.BrokerK8sRemoteNamespace
-	}
-
-	return restConfig, namespace, errors.Wrap(err, "error getting auth rest config")
 }
 
 func getRestConfigFromConfig(config clientcmd.ClientConfig, overrides *clientcmd.ConfigOverrides) (RestConfig, error) {

--- a/pkg/cluster/info.go
+++ b/pkg/cluster/info.go
@@ -20,6 +20,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -27,17 +28,20 @@ import (
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/subctl/internal/constants"
+	"github.com/submariner-io/subctl/internal/gvr"
 	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/image"
 	"github.com/submariner-io/submariner-operator/api/v1alpha1"
 	opnames "github.com/submariner-io/submariner-operator/pkg/names"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/strings/slices"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+	mcsv1b1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 type Info struct {
@@ -251,4 +255,116 @@ func MergeImageOverrides(imageOverrides map[string]string, localImageOverrides [
 	}
 
 	return imageOverrides, nil
+}
+
+// NewBrokerRestConfig creates a REST config for connecting to the broker cluster.
+// It prefers reading credentials from the broker Secret (more secure) but falls back
+// to CR fields (BrokerK8sApiServerToken, BrokerK8sCA) for backwards compatibility.
+// Returns the broker REST config and the broker namespace.
+func (c *Info) NewBrokerRestConfig(ctx context.Context) (*rest.Config, string, error) {
+	// Determine which CR to use (Submariner takes precedence over ServiceDiscovery)
+	var brokerAPIServer, brokerNamespace, brokerSecretName, tokenField, caField string
+	var gvResource schema.GroupVersionResource
+
+	if c.Submariner != nil {
+		brokerAPIServer = c.Submariner.Spec.BrokerK8sApiServer
+		brokerNamespace = c.Submariner.Spec.BrokerK8sRemoteNamespace
+		brokerSecretName = c.Submariner.Spec.BrokerK8sSecret
+		tokenField = c.Submariner.Spec.BrokerK8sApiServerToken
+		caField = c.Submariner.Spec.BrokerK8sCA
+		gvResource = submarinerv1.SchemeGroupVersion.WithResource("clusters")
+	} else if c.ServiceDiscovery != nil {
+		brokerAPIServer = c.ServiceDiscovery.Spec.BrokerK8sApiServer
+		brokerNamespace = c.ServiceDiscovery.Spec.BrokerK8sRemoteNamespace
+		brokerSecretName = c.ServiceDiscovery.Spec.BrokerK8sSecret
+		tokenField = c.ServiceDiscovery.Spec.BrokerK8sApiServerToken
+		caField = c.ServiceDiscovery.Spec.BrokerK8sCA
+		gvResource = gvr.FromMetaGroupVersion(mcsv1b1.GroupVersion, "serviceimports")
+	} else {
+		// Neither Submariner nor ServiceDiscovery CR found - return nil to allow caller to distinguish
+		return nil, "", nil
+	}
+
+	var token, ca string
+	var err error
+
+	// Try to read broker credentials from Secret first (more secure)
+	if brokerSecretName != "" {
+		token, ca, err = c.readBrokerSecret(ctx, brokerSecretName)
+		if err != nil {
+			return nil, "", err
+		}
+	} else {
+		// No Secret configured - use CR fields for backwards compatibility
+		token = tokenField
+		ca = caField
+	}
+
+	// Create REST config for broker using the credentials
+	brokerRestConfig, _, err := resource.GetAuthorizedRestConfigFromData(
+		brokerAPIServer,
+		token,
+		ca,
+		&rest.TLSClientConfig{},
+		gvResource,
+		brokerNamespace)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "error getting auth rest config for broker")
+	}
+
+	return brokerRestConfig, brokerNamespace, nil
+}
+
+// NewBrokerProducer creates a client.Producer for connecting to the broker cluster.
+// It prefers reading credentials from the broker Secret (more secure) but falls back
+// to CR fields (BrokerK8sApiServerToken, BrokerK8sCA) for backwards compatibility.
+// Returns the broker client producer, broker REST config, and the broker namespace.
+func (c *Info) NewBrokerProducer(ctx context.Context) (client.Producer, string, error) {
+	brokerRestConfig, brokerNamespace, err := c.NewBrokerRestConfig(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if brokerRestConfig == nil {
+		// Neither Submariner nor ServiceDiscovery CR found
+		return nil, "", nil
+	}
+
+	// Create client producer from the broker REST config
+	brokerProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "error creating broker client producer")
+	}
+
+	return brokerProducer, brokerNamespace, nil
+}
+
+// readBrokerSecret reads the broker token and CA from a Secret using the cluster's ClientProducer.
+func (c *Info) readBrokerSecret(ctx context.Context, secretName string) (string, string, error) {
+	secret := &corev1.Secret{}
+
+	err := c.ClientProducer.ForGeneral().Get(ctx, controllerClient.ObjectKey{
+		Namespace: c.OperatorNamespace(),
+		Name:      secretName,
+	}, secret)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "error reading broker secret %s/%s", c.OperatorNamespace(), secretName)
+	}
+
+	// Extract token data
+	tokenData, ok := secret.Data["token"]
+	if !ok || len(tokenData) == 0 {
+		return "", "", errors.Errorf("broker secret %s/%s missing 'token' data", c.OperatorNamespace(), secretName)
+	}
+
+	// Extract ca.crt data
+	caData, ok := secret.Data["ca.crt"]
+	if !ok || len(caData) == 0 {
+		return "", "", errors.Errorf("broker secret %s/%s missing 'ca.crt' data", c.OperatorNamespace(), secretName)
+	}
+
+	// Secret.Data is already decoded from base64 by Kubernetes API client
+	// But GetAuthorizedRestConfigFromData expects CA to be base64-encoded
+	// Token is used as-is (string)
+	return string(tokenData), base64.StdEncoding.EncodeToString(caData), nil
 }

--- a/pkg/diagnose/deployments.go
+++ b/pkg/diagnose/deployments.go
@@ -26,8 +26,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
-	"github.com/submariner-io/subctl/internal/restconfig"
-	"github.com/submariner-io/subctl/pkg/client"
 	"github.com/submariner-io/subctl/pkg/cluster"
 	submarinerv1 "github.com/submariner-io/submariner/pkg/apis/submariner.io/v1"
 	"github.com/submariner-io/submariner/pkg/cidr"
@@ -60,19 +58,14 @@ func checkOverlappingCIDRs(clusterInfo *cluster.Info, status reporter.Interface)
 
 	defer status.End()
 
-	brokerRestConfig, brokerNamespace, err := restconfig.ForBroker(clusterInfo.Submariner, nil)
-	if err != nil {
-		return status.Error(err, "Error getting the Broker's REST config")
-	}
-
-	clientProducer, err := client.NewProducerFromRestConfig(brokerRestConfig)
+	brokerProducer, brokerNamespace, err := clusterInfo.NewBrokerProducer(context.TODO())
 	if err != nil {
 		return status.Error(err, "Error creating broker client Producer")
 	}
 
 	endpointList := &submarinerv1.EndpointList{}
 
-	err = clientProducer.ForGeneral().List(context.TODO(), endpointList,
+	err = brokerProducer.ForGeneral().List(context.TODO(), endpointList,
 		controllerClient.InNamespace(brokerNamespace))
 	if err != nil {
 		return status.Error(err, "Error listing the Submariner endpoints from the Broker cluster")


### PR DESCRIPTION
Backport of #1857 on release-0.20.

#1857: Refactor broker connection to use Secret-based credentials

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved broker-cluster connectivity and configuration discovery.
  * Added support for retrieving broker credentials from configured Secrets, with legacy configuration fallback.
  * Improved broker detection and diagnostics when broker resources are unavailable.
* **Bug Fixes**
  * Updated broker recovery and network-overlap checks to use more reliable broker connections.
  * Added validation for required broker credential and certificate data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->