### PR TITLE
Stop publishing sensitive plain-text information directly in the CR

### DIFF
--- a/pkg/deploy/servicediscovery.go
+++ b/pkg/deploy/servicediscovery.go
@@ -20,7 +20,6 @@ package deploy
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
@@ -76,9 +75,7 @@ func populateServiceDiscoverySpec(options *ServiceDiscoveryOptions, brokerInfo *
 	serviceDiscoverySpec := operatorv1alpha1.ServiceDiscoverySpec{
 		Repository:               options.Repository,
 		Version:                  options.ImageVersion,
-		BrokerK8sCA:              base64.StdEncoding.EncodeToString(brokerSecret.Data["ca.crt"]),
 		BrokerK8sRemoteNamespace: string(brokerSecret.Data["namespace"]),
-		BrokerK8sApiServerToken:  string(brokerSecret.Data["token"]),
 		BrokerK8sApiServer:       brokerURL,
 		BrokerK8sSecret:          brokerSecret.ObjectMeta.Name,
 		BrokerK8sInsecure:        options.BrokerK8sInsecure,

--- a/pkg/deploy/servicediscovery_test.go
+++ b/pkg/deploy/servicediscovery_test.go
@@ -20,7 +20,6 @@ package deploy_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -75,9 +74,9 @@ var _ = Describe("ServiceDiscovery", func() {
 		spec := expectServiceDiscoverySuccess(ctx)
 		Expect(spec.Repository).To(Equal(options.Repository))
 		Expect(spec.Version).To(Equal(options.ImageVersion))
-		Expect(spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString(t.brokerSecret.Data["ca.crt"])))
+		Expect(spec.BrokerK8sCA).To(BeEmpty())
 		Expect(spec.BrokerK8sRemoteNamespace).To(Equal(string(t.brokerSecret.Data["namespace"])))
-		Expect(spec.BrokerK8sApiServerToken).To(Equal(string(t.brokerSecret.Data["token"])))
+		Expect(spec.BrokerK8sApiServerToken).To(BeEmpty())
 		Expect(spec.BrokerK8sApiServer).To(Equal("broker.example.com:8443"))
 		Expect(spec.BrokerK8sSecret).To(Equal(t.brokerSecret.ObjectMeta.Name))
 		Expect(spec.BrokerK8sInsecure).To(Equal(options.BrokerK8sInsecure))

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -20,7 +20,6 @@ package deploy
 
 import (
 	"context"
-	"encoding/base64"
 	"strings"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -100,11 +99,8 @@ func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info,
 		CeIPSecDebug:                    options.IPSecDebug,
 		CeIPSecForceUDPEncaps:           options.ForceUDPEncaps,
 		CeIPSecPreferredServer:          options.PreferredServer,
-		CeIPSecPSK:                      base64.StdEncoding.EncodeToString(brokerInfo.IPSecPSK.Data["psk"]),
 		CeIPSecPSKSecret:                pskSecret.ObjectMeta.Name,
-		BrokerK8sCA:                     base64.StdEncoding.EncodeToString(brokerSecret.Data["ca.crt"]),
 		BrokerK8sRemoteNamespace:        string(brokerSecret.Data["namespace"]),
-		BrokerK8sApiServerToken:         string(brokerSecret.Data["token"]),
 		BrokerK8sApiServer:              brokerURL,
 		BrokerK8sSecret:                 brokerSecret.ObjectMeta.Name,
 		BrokerK8sInsecure:               options.BrokerK8sInsecure,

--- a/pkg/deploy/submariner_test.go
+++ b/pkg/deploy/submariner_test.go
@@ -20,7 +20,6 @@ package deploy_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -111,11 +110,12 @@ func testSubmariner() {
 		Expect(spec.CeIPSecDebug).To(Equal(options.IPSecDebug))
 		Expect(spec.CeIPSecForceUDPEncaps).To(Equal(options.ForceUDPEncaps))
 		Expect(spec.CeIPSecPreferredServer).To(Equal(options.PreferredServer))
-		Expect(spec.CeIPSecPSK).To(Equal(base64.StdEncoding.EncodeToString(t.brokerInfo.IPSecPSK.Data["psk"])))
+		Expect(spec.CeIPSecPSK).To(BeEmpty())
 		Expect(spec.CeIPSecPSKSecret).To(Equal(t.brokerInfo.IPSecPSK.Name))
-		Expect(spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString(t.brokerSecret.Data["ca.crt"])))
+		Expect(spec.BrokerK8sCA).To(BeEmpty())
 		Expect(spec.BrokerK8sRemoteNamespace).To(Equal(string(t.brokerSecret.Data["namespace"])))
-		Expect(spec.BrokerK8sApiServerToken).To(Equal(string(t.brokerSecret.Data["token"])))
+		Expect(spec.BrokerK8sApiServerToken).To(BeEmpty())
+		Expect(spec.BrokerK8sCA).To(BeEmpty())
 		Expect(spec.BrokerK8sApiServer).To(Equal("broker.example.com:8443"))
 		Expect(spec.BrokerK8sSecret).To(Equal(t.brokerSecret.ObjectMeta.Name))
 		Expect(spec.BrokerK8sInsecure).To(Equal(options.BrokerK8sInsecure))

--- a/pkg/diagnose/diagnose_suite_test.go
+++ b/pkg/diagnose/diagnose_suite_test.go
@@ -20,7 +20,6 @@ package diagnose_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"maps"
 	"testing"
@@ -227,7 +226,6 @@ func newTestDriver() *testDriver {
 			Spec: v1alpha1.SubmarinerSpec{
 				ClusterID:                localCluster,
 				BrokerK8sApiServer:       "api-server",
-				BrokerK8sApiServerToken:  base64.StdEncoding.EncodeToString([]byte("token")),
 				BrokerK8sRemoteNamespace: constants.DefaultBrokerNamespace,
 				CeIPSecNATTPort:          7319,
 			},

--- a/pkg/join/join_test.go
+++ b/pkg/join/join_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package join_test
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -95,10 +94,6 @@ func testDeployment() {
 		_, err = serviceaccount.GetTokenSecretFor(ctx, t.fakeProducer.KubeClient, brokerNamespace, saName)
 		Expect(err).NotTo(HaveOccurred())
 
-		secret, err := t.fakeProducer.KubeClient.CoreV1().Secrets(constants.OperatorNamespace).Get(ctx,
-			broker.LocalClientBrokerSecretName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
 		subm := t.assertSubmarinerResource(ctx)
 		Expect(subm.Spec.CeIPSecUseOVNCertAuthMode).To(BeTrue())
 		Expect(subm.Spec.Namespace).To(Equal(constants.OperatorNamespace))
@@ -130,7 +125,8 @@ func testDeployment() {
 		Expect(subm.Spec.ImageOverrides).To(BeEmpty())
 
 		Expect(subm.Spec.BrokerK8sRemoteNamespace).To(Equal(brokerNamespace))
-		Expect(subm.Spec.BrokerK8sApiServerToken).To(Equal(string(secret.Data["token"])))
+		Expect(subm.Spec.BrokerK8sApiServerToken).To(BeEmpty())
+		Expect(subm.Spec.BrokerK8sCA).To(BeEmpty())
 		Expect(subm.Spec.BrokerK8sApiServer).To(Equal(brokerApiServer))
 		Expect(subm.Spec.BrokerK8sSecret).To(Equal(broker.LocalClientBrokerSecretName))
 		Expect(subm.Spec.BrokerK8sInsecure).To(BeTrue())
@@ -139,7 +135,7 @@ func testDeployment() {
 		Expect(subm.Spec.CeIPSecDebug).To(Equal(t.options.IPSecDebug))
 		Expect(subm.Spec.CeIPSecForceUDPEncaps).To(Equal(t.options.ForceUDPEncaps))
 		Expect(subm.Spec.CeIPSecPreferredServer).To(Equal(t.options.PreferredServer))
-		Expect(subm.Spec.CeIPSecPSK).To(Equal(base64.StdEncoding.EncodeToString(t.brokerInfo.IPSecPSK.Data["psk"])))
+		Expect(subm.Spec.CeIPSecPSK).To(BeEmpty())
 		Expect(subm.Spec.CeIPSecPSKSecret).To(Equal(t.brokerInfo.IPSecPSK.Name))
 
 		Expect(subm.Spec.CustomDomains).To(Equal(t.options.CustomDomains))
@@ -164,10 +160,6 @@ func testDeployment() {
 		It("should only deploy the ServiceDiscovery resource", func(ctx SpecContext) {
 			Expect(t.runJoinClusterToBroker(ctx)).To(Succeed())
 
-			secret, err := t.fakeProducer.KubeClient.CoreV1().Secrets(constants.OperatorNamespace).Get(ctx,
-				broker.LocalClientBrokerSecretName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
 			sd := t.assertServiceDiscoveryResource(ctx)
 			Expect(sd.Spec.Namespace).To(Equal(constants.OperatorNamespace))
 			Expect(sd.Spec.ClusterID).To(Equal(t.options.ClusterID))
@@ -175,7 +167,7 @@ func testDeployment() {
 			Expect(sd.Spec.ClustersetIPCIDR).To(HavePrefix("243."))
 
 			Expect(sd.Spec.BrokerK8sRemoteNamespace).To(Equal(brokerNamespace))
-			Expect(sd.Spec.BrokerK8sApiServerToken).To(Equal(string(secret.Data["token"])))
+			Expect(sd.Spec.BrokerK8sApiServerToken).To(BeEmpty())
 			Expect(sd.Spec.BrokerK8sApiServer).To(Equal(brokerApiServer))
 			Expect(sd.Spec.BrokerK8sSecret).To(Equal(broker.LocalClientBrokerSecretName))
 			Expect(sd.Spec.BrokerK8sInsecure).To(BeTrue())

--- a/pkg/servicediscoverycr/ensure_test.go
+++ b/pkg/servicediscoverycr/ensure_test.go
@@ -68,8 +68,7 @@ var _ = Describe("Ensure", func() {
 		serviceDiscoverySpec = &operatorv1alpha1.ServiceDiscoverySpec{
 			ClusterID:                clusterID,
 			BrokerK8sApiServer:       brokerURL,
-			BrokerK8sApiServerToken:  "test-token",
-			BrokerK8sCA:              "test-ca",
+			BrokerK8sSecret:          "test-secret",
 			BrokerK8sRemoteNamespace: "test-broker-namespace",
 			Repository:               operatorv1alpha1.DefaultRepo,
 			Version:                  operatorv1alpha1.DefaultSubmarinerVersion,
@@ -108,7 +107,7 @@ var _ = Describe("Ensure", func() {
 					Namespace: serviceDiscoveryKey.Namespace,
 				},
 				Spec: operatorv1alpha1.ServiceDiscoverySpec{
-					BrokerK8sApiServerToken: "existing-token",
+					BrokerK8sSecret: "existing-secret",
 				},
 			})
 		})

--- a/pkg/submarinercr/ensure_test.go
+++ b/pkg/submarinercr/ensure_test.go
@@ -70,8 +70,7 @@ var _ = Describe("Ensure", func() {
 		submarinerSpec = &operatorv1alpha1.SubmarinerSpec{
 			ClusterID:                clusterID,
 			BrokerK8sApiServer:       brokerURL,
-			BrokerK8sApiServerToken:  "test-token",
-			BrokerK8sCA:              "test-ca",
+			BrokerK8sSecret:          "test-secret",
 			BrokerK8sRemoteNamespace: "test-broker-namespace",
 			Repository:               operatorv1alpha1.DefaultRepo,
 			Version:                  operatorv1alpha1.DefaultSubmarinerVersion,
@@ -117,7 +116,7 @@ var _ = Describe("Ensure", func() {
 					Namespace: constants.OperatorNamespace,
 				},
 				Spec: operatorv1alpha1.SubmarinerSpec{
-					BrokerK8sApiServerToken: "existing-token",
+					BrokerK8sSecret: "existing-secret",
 				},
 			}
 


### PR DESCRIPTION
The IPsec PSK and broker token are stored in secrets in the Submariner CR and consumers of the direct plain-text fields prefer the secret fields so join can stop publishing the plain-text fields.

Fixes https://github.com/submariner-io/submariner-operator/issues/1869



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Submariner resources no longer include embedded broker API tokens, certificate authorities, or IPsec pre-shared keys.
  * Broker connection details continue to reference the configured secret and remote namespace.

* **Tests**
  * Updated deployment, join, diagnostic, and resource-management checks to reflect the revised secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->