### PR TITLE
Publish subctl-checksums.txt with release assets

### DIFF
--- a/.github/workflows/release_subctl_on_push.yml
+++ b/.github/workflows/release_subctl_on_push.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           gh release delete ${{ env.RELEASE }} -y || true
           git push -d origin ${{ env.RELEASE }} || true
-          gh release create ${{ env.RELEASE }} dist/*.tar.xz --prerelease \
+          gh release create ${{ env.RELEASE }} dist/*.tar.xz dist/subctl-checksums.txt --prerelease \
             --title "Cutting Edge: ${{ env.BRANCH }}" \
             --notes "Cutting edge binaries of \`subctl\` for '${{ env.BRANCH }}' branch, always updated to the latest merged code." \
             --target ${GITHUB_SHA}


### PR DESCRIPTION
The release_subctl_on_push.yml upload glob was dist/*.tar.xz, which excludes
dist/subctl-checksums.txt even though make build-cross already generates it
(Makefile: dist/subctl-checksums.txt target, a build-cross prerequisite).

This adds the checksum file to the gh release create asset list so downstream
consumers (shipyard's get-subctl.sh) can verify the downloaded tarball.
Prerequisite for shipyard's FIND-006 download-and-verify change.