### PR TITLE
Automated backport of #1863: Stop publishing sensitive plain-text information directly in

### DIFF
--- a/pkg/deploy/servicediscovery.go
+++ b/pkg/deploy/servicediscovery.go
@@ -20,7 +20,6 @@ package deploy
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
 	"github.com/submariner-io/subctl/internal/constants"
@@ -76,9 +75,7 @@ func populateServiceDiscoverySpec(options *ServiceDiscoveryOptions, brokerInfo *
 	serviceDiscoverySpec := operatorv1alpha1.ServiceDiscoverySpec{
 		Repository:               options.Repository,
 		Version:                  options.ImageVersion,
-		BrokerK8sCA:              base64.StdEncoding.EncodeToString(brokerSecret.Data["ca.crt"]),
 		BrokerK8sRemoteNamespace: string(brokerSecret.Data["namespace"]),
-		BrokerK8sApiServerToken:  string(brokerSecret.Data["token"]),
 		BrokerK8sApiServer:       brokerURL,
 		BrokerK8sSecret:          brokerSecret.ObjectMeta.Name,
 		BrokerK8sInsecure:        options.BrokerK8sInsecure,

--- a/pkg/deploy/servicediscovery_test.go
+++ b/pkg/deploy/servicediscovery_test.go
@@ -20,7 +20,6 @@ package deploy_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -75,9 +74,9 @@ var _ = Describe("ServiceDiscovery", func() {
 		spec := expectServiceDiscoverySuccess()
 		Expect(spec.Repository).To(Equal(options.Repository))
 		Expect(spec.Version).To(Equal(options.ImageVersion))
-		Expect(spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString(t.brokerSecret.Data["ca.crt"])))
+		Expect(spec.BrokerK8sCA).To(BeEmpty())
 		Expect(spec.BrokerK8sRemoteNamespace).To(Equal(string(t.brokerSecret.Data["namespace"])))
-		Expect(spec.BrokerK8sApiServerToken).To(Equal(string(t.brokerSecret.Data["token"])))
+		Expect(spec.BrokerK8sApiServerToken).To(BeEmpty())
 		Expect(spec.BrokerK8sApiServer).To(Equal("broker.example.com:8443"))
 		Expect(spec.BrokerK8sSecret).To(Equal(t.brokerSecret.ObjectMeta.Name))
 		Expect(spec.BrokerK8sInsecure).To(Equal(options.BrokerK8sInsecure))

--- a/pkg/deploy/submariner.go
+++ b/pkg/deploy/submariner.go
@@ -20,7 +20,6 @@ package deploy
 
 import (
 	"context"
-	"encoding/base64"
 	"strings"
 
 	"github.com/submariner-io/admiral/pkg/reporter"
@@ -99,11 +98,8 @@ func populateSubmarinerSpec(options *SubmarinerOptions, brokerInfo *broker.Info,
 		CeIPSecDebug:                    options.IPSecDebug,
 		CeIPSecForceUDPEncaps:           options.ForceUDPEncaps,
 		CeIPSecPreferredServer:          options.PreferredServer,
-		CeIPSecPSK:                      base64.StdEncoding.EncodeToString(brokerInfo.IPSecPSK.Data["psk"]),
 		CeIPSecPSKSecret:                pskSecret.ObjectMeta.Name,
-		BrokerK8sCA:                     base64.StdEncoding.EncodeToString(brokerSecret.Data["ca.crt"]),
 		BrokerK8sRemoteNamespace:        string(brokerSecret.Data["namespace"]),
-		BrokerK8sApiServerToken:         string(brokerSecret.Data["token"]),
 		BrokerK8sApiServer:              brokerURL,
 		BrokerK8sSecret:                 brokerSecret.ObjectMeta.Name,
 		BrokerK8sInsecure:               options.BrokerK8sInsecure,

--- a/pkg/deploy/submariner_test.go
+++ b/pkg/deploy/submariner_test.go
@@ -20,7 +20,6 @@ package deploy_test
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -111,11 +110,12 @@ func testSubmariner() {
 		Expect(spec.CeIPSecDebug).To(Equal(options.IPSecDebug))
 		Expect(spec.CeIPSecForceUDPEncaps).To(Equal(options.ForceUDPEncaps))
 		Expect(spec.CeIPSecPreferredServer).To(Equal(options.PreferredServer))
-		Expect(spec.CeIPSecPSK).To(Equal(base64.StdEncoding.EncodeToString(t.brokerInfo.IPSecPSK.Data["psk"])))
+		Expect(spec.CeIPSecPSK).To(BeEmpty())
 		Expect(spec.CeIPSecPSKSecret).To(Equal(t.brokerInfo.IPSecPSK.Name))
-		Expect(spec.BrokerK8sCA).To(Equal(base64.StdEncoding.EncodeToString(t.brokerSecret.Data["ca.crt"])))
+		Expect(spec.BrokerK8sCA).To(BeEmpty())
 		Expect(spec.BrokerK8sRemoteNamespace).To(Equal(string(t.brokerSecret.Data["namespace"])))
-		Expect(spec.BrokerK8sApiServerToken).To(Equal(string(t.brokerSecret.Data["token"])))
+		Expect(spec.BrokerK8sApiServerToken).To(BeEmpty())
+		Expect(spec.BrokerK8sCA).To(BeEmpty())
 		Expect(spec.BrokerK8sApiServer).To(Equal("broker.example.com:8443"))
 		Expect(spec.BrokerK8sSecret).To(Equal(t.brokerSecret.ObjectMeta.Name))
 		Expect(spec.BrokerK8sInsecure).To(Equal(options.BrokerK8sInsecure))

--- a/pkg/diagnose/diagnose_suite_test.go
+++ b/pkg/diagnose/diagnose_suite_test.go
@@ -20,7 +20,6 @@ package diagnose_test
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -119,7 +118,6 @@ func newTestDriver() *testDriver {
 			Spec: v1alpha1.SubmarinerSpec{
 				ClusterID:                "east",
 				BrokerK8sApiServer:       "api-server",
-				BrokerK8sApiServerToken:  base64.StdEncoding.EncodeToString([]byte("token")),
 				BrokerK8sRemoteNamespace: constants.DefaultBrokerNamespace,
 			},
 		}

--- a/pkg/join/join_test.go
+++ b/pkg/join/join_test.go
@@ -20,7 +20,6 @@ package join_test
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -95,10 +94,6 @@ func testDeployment() {
 		_, err = serviceaccount.GetTokenSecretFor(context.TODO(), t.fakeProducer.KubeClient, brokerNamespace, saName)
 		Expect(err).NotTo(HaveOccurred())
 
-		secret, err := t.fakeProducer.KubeClient.CoreV1().Secrets(constants.OperatorNamespace).Get(context.TODO(),
-			broker.LocalClientBrokerSecretName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
 		subm := t.assertSubmarinerResource()
 		Expect(subm.Spec.CeIPSecUseOVNCertAuthMode).To(BeTrue())
 		Expect(subm.Spec.Namespace).To(Equal(constants.OperatorNamespace))
@@ -129,7 +124,8 @@ func testDeployment() {
 		Expect(subm.Spec.ImageOverrides).To(BeEmpty())
 
 		Expect(subm.Spec.BrokerK8sRemoteNamespace).To(Equal(brokerNamespace))
-		Expect(subm.Spec.BrokerK8sApiServerToken).To(Equal(string(secret.Data["token"])))
+		Expect(subm.Spec.BrokerK8sApiServerToken).To(BeEmpty())
+		Expect(subm.Spec.BrokerK8sCA).To(BeEmpty())
 		Expect(subm.Spec.BrokerK8sApiServer).To(Equal(brokerApiServer))
 		Expect(subm.Spec.BrokerK8sSecret).To(Equal(broker.LocalClientBrokerSecretName))
 		Expect(subm.Spec.BrokerK8sInsecure).To(BeTrue())
@@ -138,7 +134,7 @@ func testDeployment() {
 		Expect(subm.Spec.CeIPSecDebug).To(Equal(t.options.IPSecDebug))
 		Expect(subm.Spec.CeIPSecForceUDPEncaps).To(Equal(t.options.ForceUDPEncaps))
 		Expect(subm.Spec.CeIPSecPreferredServer).To(Equal(t.options.PreferredServer))
-		Expect(subm.Spec.CeIPSecPSK).To(Equal(base64.StdEncoding.EncodeToString(t.brokerInfo.IPSecPSK.Data["psk"])))
+		Expect(subm.Spec.CeIPSecPSK).To(BeEmpty())
 		Expect(subm.Spec.CeIPSecPSKSecret).To(Equal(t.brokerInfo.IPSecPSK.Name))
 
 		Expect(subm.Spec.CustomDomains).To(Equal(t.options.CustomDomains))
@@ -163,10 +159,6 @@ func testDeployment() {
 		It("should only deploy the ServiceDiscovery resource", func() {
 			Expect(t.runJoinClusterToBroker()).To(Succeed())
 
-			secret, err := t.fakeProducer.KubeClient.CoreV1().Secrets(constants.OperatorNamespace).Get(context.TODO(),
-				broker.LocalClientBrokerSecretName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
 			sd := t.assertServiceDiscoveryResource()
 			Expect(sd.Spec.Namespace).To(Equal(constants.OperatorNamespace))
 			Expect(sd.Spec.ClusterID).To(Equal(t.options.ClusterID))
@@ -174,7 +166,7 @@ func testDeployment() {
 			Expect(sd.Spec.ClustersetIPCIDR).To(HavePrefix("243."))
 
 			Expect(sd.Spec.BrokerK8sRemoteNamespace).To(Equal(brokerNamespace))
-			Expect(sd.Spec.BrokerK8sApiServerToken).To(Equal(string(secret.Data["token"])))
+			Expect(sd.Spec.BrokerK8sApiServerToken).To(BeEmpty())
 			Expect(sd.Spec.BrokerK8sApiServer).To(Equal(brokerApiServer))
 			Expect(sd.Spec.BrokerK8sSecret).To(Equal(broker.LocalClientBrokerSecretName))
 			Expect(sd.Spec.BrokerK8sInsecure).To(BeTrue())

--- a/pkg/servicediscoverycr/ensure_test.go
+++ b/pkg/servicediscoverycr/ensure_test.go
@@ -69,8 +69,7 @@ var _ = Describe("Ensure", func() {
 		serviceDiscoverySpec = &operatorv1alpha1.ServiceDiscoverySpec{
 			ClusterID:                clusterID,
 			BrokerK8sApiServer:       brokerURL,
-			BrokerK8sApiServerToken:  "test-token",
-			BrokerK8sCA:              "test-ca",
+			BrokerK8sSecret:          "test-secret",
 			BrokerK8sRemoteNamespace: "test-broker-namespace",
 			Repository:               operatorv1alpha1.DefaultRepo,
 			Version:                  operatorv1alpha1.DefaultSubmarinerVersion,
@@ -109,7 +108,7 @@ var _ = Describe("Ensure", func() {
 					Namespace: serviceDiscoveryKey.Namespace,
 				},
 				Spec: operatorv1alpha1.ServiceDiscoverySpec{
-					BrokerK8sApiServerToken: "existing-token",
+					BrokerK8sSecret: "existing-secret",
 				},
 			})
 		})

--- a/pkg/submarinercr/ensure_test.go
+++ b/pkg/submarinercr/ensure_test.go
@@ -71,8 +71,7 @@ var _ = Describe("Ensure", func() {
 		submarinerSpec = &operatorv1alpha1.SubmarinerSpec{
 			ClusterID:                clusterID,
 			BrokerK8sApiServer:       brokerURL,
-			BrokerK8sApiServerToken:  "test-token",
-			BrokerK8sCA:              "test-ca",
+			BrokerK8sSecret:          "test-secret",
 			BrokerK8sRemoteNamespace: "test-broker-namespace",
 			Repository:               operatorv1alpha1.DefaultRepo,
 			Version:                  operatorv1alpha1.DefaultSubmarinerVersion,
@@ -118,7 +117,7 @@ var _ = Describe("Ensure", func() {
 					Namespace: constants.OperatorNamespace,
 				},
 				Spec: operatorv1alpha1.SubmarinerSpec{
-					BrokerK8sApiServerToken: "existing-token",
+					BrokerK8sSecret: "existing-secret",
 				},
 			}
 


### PR DESCRIPTION
Backport of #1863 on release-0.22.

#1863: Stop publishing sensitive plain-text information directly in

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.