### PR TITLE
Update version labels to v0.23.2

### DIFF
--- a/package/Dockerfile.subctl.konflux
+++ b/package/Dockerfile.subctl.konflux
@@ -50,7 +50,7 @@ ENTRYPOINT ["/usr/local/bin/subctl"]
 
 LABEL com.redhat.component="subctl-container" \
       name="rhacm2/subctl-rhel9" \
-      version="v0.23.0" \
+      version="v0.23.2" \
       summary="The command-line interface for Submariner (subctl)" \
       description="A command-line utility for installing, configuring, and troubleshooting Submariner cross-cluster connectivity." \
       io.k8s.display-name="Submariner Control Utility (subctl)" \


### PR DESCRIPTION
Enables correct Konflux image tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image metadata version label from v0.23.0 to v0.23.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->